### PR TITLE
Make misha compile again on non-Linux platforms

### DIFF
--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -3,7 +3,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#ifdef __linux__
 #include <sys/sendfile.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -18,6 +20,17 @@ struct FD {
     }
 };
 
+#ifndef __linux__
+struct BUFFER {
+    size_t size;
+    char *buffer;
+    BUFFER(size_t s) : size((s > 16384)? s : 16384), buffer(new char[size]) { }
+    ~BUFFER() {
+        delete [] buffer;
+    }
+};
+#endif
+
 void FileUtils::copy_file(const char *src, const char *tgt)
 {
     FD srcfd;
@@ -30,8 +43,29 @@ void FileUtils::copy_file(const char *src, const char *tgt)
         TGLError(errno, "Error trying to stat file %s: %s", src, strerror(errno));
     if ((tgtfd.fd = creat(tgt, srcstat.st_mode)) == -1)
         TGLError(errno, "Error opeining file %s for writing: %s", tgt, strerror(errno));
+#ifdef __linux__
     if (sendfile(tgtfd.fd, srcfd.fd, NULL, srcstat.st_size) == -1)
         TGLError(errno, "Error copying file %s to %s: %s\n", src, tgt, strerror(errno));
+#else
+    BUFFER buffer(srcstat.st_blksize);
+    if (buffer.buffer == NULL)
+        TGLError(errno, "Error allocating buffer: %s\n", strerror(errno));
+
+    ssize_t nread;
+    while ((nread = read(srcfd.fd, buffer.buffer, buffer.size)) > 0) {
+        const char *p = buffer.buffer;
+        size_t remaining = nread;
+        while (remaining > 0) {
+            ssize_t nwritten = write(tgtfd.fd, p, remaining);
+            if (nwritten <= 0)
+                TGLError(errno, "Error writing file %s while copying from %s: %s\n", tgt, src, strerror(errno));
+            p += nwritten;
+            remaining -= nwritten;
+        }
+    }
+    if (nread < 0)
+        TGLError(errno, "Error reading file %s while copying to %s: %s\n", src, tgt, strerror(errno));
+#endif
 }
 
 void FileUtils::move_file(const char *src, const char *tgt)

--- a/src/strutil.cpp
+++ b/src/strutil.cpp
@@ -273,7 +273,7 @@ int get_one_field(istream &in, string &field, char delim, int num, bool eat_line
 int count_match(const string &targ, const string &mot)
 {
 	int count = 0;
-	uint32_t pos = targ.find(mot, 0);
+	string::size_type pos = targ.find(mot, 0);
 	while(pos != string::npos) {
 		pos = targ.find(mot, pos + 1);
 		count++;


### PR DESCRIPTION
f3ae99ac97a5f37081cff5f26d36cd25195ceb69 added _src/FileUtils.cpp_, which uses the Linux-specific `sendfile` function in  `copy_file()`. (Actually it looks like _src/FileUtils.{h,cpp}_ may have been accidentally committed, as the commit message doesn't mention them and the functions therein are unused.)

This makes compiling on macOS fail, as macOS doesn't have `<sys/sendfile.h>`. This PR adds an alternative based on the usual `read`/`write` loop for non-Linux platforms. (MacOS does have a `sendfile` system function, but it can't write to a regular file as `copy_file()` requires.)

(This code is based on (my own) well-tested code, but has only been compiled within _src/FileUtils.cpp_, not properly tested — as the function is unused.)

Also a small bug fix in `count_match()` (which is currently also unused), identified via a clang warning.