### PR TITLE
fix: remove dead code and disable score filter with indels

### DIFF
--- a/R/sequence.R
+++ b/R/sequence.R
@@ -477,7 +477,6 @@ gseq.pwm_edits <- function(seqs,
         # the standard extension (matching PWMEditDistanceScorer which
         # calls calculate_expanded_interval with motif_len + max_indels).
         w <- nrow(pssm)
-        if (is.data.frame(pssm)) w <- nrow(pssm)
         indel_extra <- if (!is.null(max_indels)) as.integer(max_indels) else 0L
         ext <- if (isTRUE(extend)) w - 1L + indel_extra else if (isFALSE(extend)) 0L else as.integer(extend) + indel_extra
         extended_intervals <- intervals_df

--- a/src/GseqPwmEdits.cpp
+++ b/src/GseqPwmEdits.cpp
@@ -653,16 +653,7 @@ WindowResult compute_window_edits_detailed_with_indels(
                         break;
                     }
                 }
-                if (!reachable) {
-                    // Check total gain
-                    double total_gain = 0.0;
-                    for (auto* ap : optional) total_gain += static_cast<double>(ap->gain);
-                    total_gain += (adjusted - score); // mandatory gains already counted
-                    if (total_gain + (adjusted - score) < static_cast<double>(threshold) - score) {
-                        continue; // unreachable
-                    }
-                    if (!reachable) continue;
-                }
+                if (!reachable) continue;
             }
 
             int total_edits = k + subs_needed;
@@ -830,7 +821,10 @@ WindowResult find_best_window_edits(
     const int L = pssm.length();
     const bool has_score_min = !std::isnan(score_min);
     const bool has_score_max = !std::isnan(score_max);
-    const bool has_score_filter = has_score_min || has_score_max;
+    // Disable score filter when indels are enabled: with indels, the DP alignment
+    // can use L±D bases, so the L-length pre-score is not a valid pre-filter.
+    // This matches PWMEditDistanceScorer::compute_interval behavior.
+    const bool has_score_filter = (has_score_min || has_score_max) && (max_indels == 0);
     const int seqlen = static_cast<int>(seq.length());
 
     WindowResult best;
@@ -844,8 +838,6 @@ WindowResult find_best_window_edits(
         auto try_window = [&](bool reverse, int direction) {
             int seq_avail = seqlen - s0;
             // Score filter: compute L-length window score for filtering
-            // Only apply if we have at least L bases available (indel windows
-            // can be shorter than L, so skip the filter for those)
             if (has_score_filter && seq_avail >= L) {
                 float logp = 0.0f;
                 for (int i = 0; i < L; i++) {


### PR DESCRIPTION
## Summary

- Remove dead unreachability check in `compute_window_edits_detailed_with_indels` — the `total_gain` calculation was unreachable because `if (!reachable) continue` always executed after it. Simplified to a single `if (!reachable) continue`.
- Remove redundant `if (is.data.frame(pssm)) w <- nrow(pssm)` in `gseq.pwm_edits()`.
- Gate `score_min`/`score_max` filter on `max_indels == 0` in `find_best_window_edits`, matching `PWMEditDistanceScorer::compute_interval`. With indels the L-length pre-score is not a valid filter since DP alignment can use L±D bases.

## Test plan

- [x] All 16,986 tests pass (`alutil::tst(parallel=TRUE)`)
- [x] 704 PWM-specific tests pass (edit-distance, adversarial, prefilter, gseq-pwm-edits)
- [x] Indel score filter bug empirically reproduced before fix and confirmed fixed after