### PR TITLE
Add direction parameter to PWM edit distance functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # misha 5.6.7
 
+* Added `direction` parameter to PWM edit distance functions (`pwm.edit_distance`, `pwm.edit_distance.pos`, `pwm.max.edit_distance`, `pwm.edit_distance.lse`, `pwm.edit_distance.lse.pos`, `gseq.pwm_edits`) for computing minimum edits to bring score below a threshold.
 * Added PWM edit distance virtual track functions: `pwm.edit_distance`, `pwm.edit_distance.pos`, `pwm.max.edit_distance`, `pwm.edit_distance.lse`, and `pwm.edit_distance.lse.pos`. Compute minimum edit distance (substitutions and indels) to reach a PWM score threshold, with per-window (max) and aggregate (LSE) scoring modes.
 * Added `gseq.pwm_edits()` for retrieving detailed per-edit information (positions and replacement bases) from PWM edit distance computation.
 * Enabled sub-chromosome range splitting for `gscreen` and `gextract`, improving parallel efficiency on genomes with large chromosomes.

--- a/R/sequence.R
+++ b/R/sequence.R
@@ -459,7 +459,8 @@ gseq.pwm_edits <- function(seqs,
                            score.min = NULL,
                            score.max = NULL,
                            extend = TRUE,
-                           strand = 1L) {
+                           strand = 1L,
+                           direction = "above") {
     # Handle interval input: extract sequences
     is_intervals <- is.data.frame(seqs) &&
         all(c("chrom", "start", "end") %in% colnames(seqs))
@@ -541,6 +542,7 @@ gseq.pwm_edits <- function(seqs,
     if (!is.logical(bidirect)) stop("bidirect must be TRUE or FALSE")
     if (!is.numeric(prior) || prior < 0 || prior > 1) stop("prior must be between 0 and 1")
     if (strand != 1 && strand != -1) stop("strand must be 1 or -1")
+    if (!direction %in% c("above", "below")) stop("direction must be 'above' or 'below'")
 
     strand_mode <- if (bidirect) 0L else as.integer(strand)
 
@@ -564,7 +566,8 @@ gseq.pwm_edits <- function(seqs,
         if (!is.null(roi_end)) as.integer(roi_end) else NULL,
         if (is.logical(c_extend)) as.logical(c_extend) else as.integer(c_extend),
         if (!is.null(score.min)) as.numeric(score.min) else NULL,
-        if (!is.null(score.max)) as.numeric(score.max) else NULL
+        if (!is.null(score.max)) as.numeric(score.max) else NULL,
+        as.character(direction)
     )
 
     # Add interval columns if input was intervals

--- a/R/sequence.R
+++ b/R/sequence.R
@@ -408,6 +408,10 @@ gseq.pwm <- function(seqs,
 #'   Default TRUE.
 #' @param strand integer; which strand to scan when \code{bidirect=FALSE}.
 #'   1=forward, -1=reverse. Default 1.
+#' @param direction character; direction of the edit distance query.
+#'   \code{"above"} (default) finds minimum edits to bring score above
+#'   \code{score.thresh}; \code{"below"} finds minimum edits to bring score
+#'   below \code{score.thresh}.
 #' @return A data frame (long format) with one row per edit, containing columns:
 #' \describe{
 #'   \item{seq_idx}{Index into input sequences/intervals (1-based)}

--- a/R/vtrack.R
+++ b/R/vtrack.R
@@ -273,6 +273,7 @@
     prior <- if (!is.null(dots$prior)) dots$prior else 0.01
     extend <- if (!is.null(dots$extend)) dots$extend else TRUE
     strand <- if (!is.null(dots$strand)) dots$strand else 1
+    direction <- if (!is.null(dots$direction)) dots$direction else "above"
 
     pssm <- .coerce_pssm_matrix(
         pssm,
@@ -295,6 +296,10 @@
 
     if (strand != 1 && strand != -1) {
         stop("strand must be 1 or -1")
+    }
+
+    if (!direction %in% c("above", "below")) {
+        stop("direction must be 'above' or 'below'")
     }
 
     if (!is.numeric(score.thresh) || length(score.thresh) != 1) {
@@ -338,7 +343,8 @@
         bidirect = bidirect,
         prior = prior,
         extend = extend,
-        strand = strand
+        strand = strand,
+        direction = direction
     )
 }
 
@@ -368,6 +374,7 @@
     prior <- if (!is.null(dots$prior)) dots$prior else 0.01
     extend <- if (!is.null(dots$extend)) dots$extend else TRUE
     strand <- if (!is.null(dots$strand)) dots$strand else 1
+    direction <- if (!is.null(dots$direction)) dots$direction else "above"
 
     pssm <- .coerce_pssm_matrix(
         pssm,
@@ -390,6 +397,10 @@
 
     if (strand != 1 && strand != -1) {
         stop("strand must be 1 or -1")
+    }
+
+    if (!direction %in% c("above", "below")) {
+        stop("direction must be 'above' or 'below'")
     }
 
     if (!is.numeric(score.thresh) || length(score.thresh) != 1) {
@@ -425,7 +436,8 @@
         bidirect = bidirect,
         prior = prior,
         extend = extend,
-        strand = strand
+        strand = strand,
+        direction = direction
     )
 }
 

--- a/R/vtrack.R
+++ b/R/vtrack.R
@@ -592,16 +592,16 @@
 #' \strong{Edit distance summarizers}
 #' \tabular{llll}{
 #'   Source \tab func \tab Key params \tab Description \cr
-#'   NULL (sequence) \tab pwm.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, bidirect, prior, extend, strand \tab Minimum number of edits (substitutions + indels) needed to reach \code{score.thresh} across all windows. \cr
-#'   NULL (sequence) \tab pwm.edit_distance.pos \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, bidirect, prior, extend, strand \tab 1-based position of the window achieving minimum edit distance (signed by strand when bidirect). \cr
-#'   NULL (sequence) \tab pwm.max.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, bidirect, prior, extend, strand \tab Edit distance at the best-scoring PWM window (same location as pwm.max/pwm.max.pos). \cr
+#'   NULL (sequence) \tab pwm.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, direction, bidirect, prior, extend, strand \tab Minimum number of edits (substitutions + indels) needed to reach \code{score.thresh} across all windows. \cr
+#'   NULL (sequence) \tab pwm.edit_distance.pos \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, direction, bidirect, prior, extend, strand \tab 1-based position of the window achieving minimum edit distance (signed by strand when bidirect). \cr
+#'   NULL (sequence) \tab pwm.max.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, direction, bidirect, prior, extend, strand \tab Edit distance at the best-scoring PWM window (same location as pwm.max/pwm.max.pos). \cr
 #' }
 #'
 #' \strong{LSE edit distance summarizers}
 #' \tabular{llll}{
 #'   Source \tab func \tab Key params \tab Description \cr
-#'   NULL (sequence) \tab pwm.edit_distance.lse \tab pssm, score.thresh, max_edits, score.min, score.max, bidirect, prior, extend, strand \tab Minimum number of substitution edits needed to raise the LSE score (log-sum-exp of per-window PWM scores) above \code{score.thresh}. Exhaustive for k<=2, greedy heuristic for k>=3. \cr
-#'   NULL (sequence) \tab pwm.edit_distance.lse.pos \tab pssm, score.thresh, max_edits, score.min, score.max, bidirect, prior, extend, strand \tab 1-based position of the most impactful single edit for raising the LSE score. \cr
+#'   NULL (sequence) \tab pwm.edit_distance.lse \tab pssm, score.thresh, max_edits, score.min, score.max, direction, bidirect, prior, extend, strand \tab Minimum number of substitution edits needed to raise the LSE score (log-sum-exp of per-window PWM scores) above \code{score.thresh}. Exhaustive for k<=2, greedy heuristic for k>=3. \cr
+#'   NULL (sequence) \tab pwm.edit_distance.lse.pos \tab pssm, score.thresh, max_edits, score.min, score.max, direction, bidirect, prior, extend, strand \tab 1-based position of the most impactful single edit for raising the LSE score. \cr
 #' }
 #'
 #' \strong{K-mer summarizers}
@@ -636,6 +636,7 @@
 #'   \item \code{max_indels}: For \code{pwm.edit_distance}, \code{pwm.edit_distance.pos}, and \code{pwm.max.edit_distance} only. Not supported by LSE variants. Optional non-negative integer specifying the maximum number of insertions and deletions allowed (default 0, substitutions only). When > 0, a banded Needleman-Wunsch DP is used to find the minimum total edits (substitutions + indels) to reach the score threshold. Typical values are 1-2.
 #'   \item \code{score.min}: For edit distance functions only. Optional numeric filter. Windows whose PWM log-likelihood is below \code{score.min} are skipped (edit distance returns NA). Improves performance by avoiding expensive computation on low-scoring windows. For LSE variants, the filter applies to the aggregate LSE score across all windows rather than individual window scores. Default NULL (no filter).
 #'   \item \code{score.max}: For edit distance functions only. Optional numeric filter. Windows whose PWM log-likelihood is above \code{score.max} are skipped (edit distance returns NA). Combined with \code{score.min}, enables efficient regime-specific queries (e.g., only positions with score in [\code{score.min}, \code{score.max}]). For LSE variants, the filter applies to the aggregate LSE score across all windows rather than individual window scores. Default NULL (no filter).
+#'   \item \code{direction}: For edit distance functions only. Direction of the edit distance query: \code{"above"} (default) finds the minimum edits to bring the score above \code{score.thresh}; \code{"below"} finds the minimum edits to bring the score below \code{score.thresh}.
 #' }
 #'
 #' \strong{Spatial weighting}

--- a/dev/notes/features/2026-03-29_edit-distance-below.md
+++ b/dev/notes/features/2026-03-29_edit-distance-below.md
@@ -1,0 +1,118 @@
+# Edit Distance "Below" Direction
+
+**Date:** 2026-03-29
+**Branch:** `feat/edit-distance-below`
+
+## Motivation
+
+Currently, PWM edit distance functions only answer "how many edits to reach **above** a threshold?" This feature adds the symmetric question: "how many edits to bring the score **below** a threshold?" This is useful for finding minimal perturbations that disrupt a binding site.
+
+## API Design
+
+Add a `direction` parameter (`"above"` / `"below"`, default `"above"`) to:
+
+**Virtual track functions:**
+- `pwm.edit_distance`
+- `pwm.edit_distance.pos`
+- `pwm.max.edit_distance`
+- `pwm.edit_distance.lse`
+- `pwm.edit_distance.lse.pos`
+
+**Sequence function:**
+- `gseq.pwm_edits()`
+
+**Semantics:**
+- `direction="above"` (existing behavior): return 0 if score >= threshold, else minimum edits to reach >= threshold.
+- `direction="below"`: return 0 if score <= threshold, else minimum edits to bring score <= threshold.
+
+## Algorithm: Substitution-Only
+
+### Core idea
+
+Mirror the "above" algorithm. Instead of computing *gain* (how much score increases per edit), compute *loss* (how much score decreases per edit).
+
+### Steps (direction="below")
+
+1. Compute `surplus = current_score - threshold`. If `surplus <= 0`, return 0 (already below).
+2. For each position `i`, compute `loss[i] = PSSM[i][current_base] - col_min[i]` — the maximum score degradation from switching to the worst base at that position.
+3. Greedily pick positions with the highest loss until the accumulated loss covers the surplus.
+4. Return the number of positions picked.
+
+### Precomputation
+
+- `col_min[i]` — per-column minimum PSSM score (analogous to `col_max[i]` used for "above").
+- Loss bins — histogram of loss values, populated identically to gain bins but using loss values.
+- `S_min = sum(col_min)` — minimum achievable score with all worst bases.
+
+### Unreachable case
+
+If `S_min > threshold`, the score cannot be brought below threshold even with all worst bases. Return `NA`.
+
+### Key insight
+
+Reuse the same bin/histogram machinery in `precompute_tables()`. Populate with loss values instead of gain values. The greedy counting logic (scan bins from largest to smallest) is identical.
+
+## Algorithm: Indels
+
+### Banded DP
+
+The banded DP currently maximizes score. For "below" direction, add a "minimize score" variant:
+
+- Fill DP cells with minimum achievable score instead of maximum.
+- `early_abandon_banded_dp`: abandon if the minimum achievable score exceeds the threshold (cannot get below).
+
+### Specialized 1-indel and 2-indel solvers
+
+Each needs a "below" variant that:
+- Considers deletions/insertions that *reduce* score most.
+- Checks feasibility against `S_min` (extended for indel-shifted alignment lengths).
+
+## Algorithm: LSE
+
+### Objective
+
+Find minimum edits to bring `F = log(sum(exp(S_p)))` below threshold, where `S_p` are per-position scores across strands/shifts.
+
+### Approach
+
+- Greedy: pick edits with the largest *negative* delta-Z (most score-reducing).
+- Exhaustive search for `k <= 2`, greedy for `k >= 3` (same structure as "above", with flipped objective).
+- `col_min` replaces `col_max` in precomputation; loss replaces gain.
+
+## Files to Modify
+
+### C++
+
+| File | Changes |
+|------|---------|
+| `src/PWMEditDistanceScorer.h/cpp` | Add `Direction` enum (`ABOVE`, `BELOW`). In `precompute_tables()`, compute `col_min` and loss bins alongside existing gain bins. In scoring path, flip deficit/surplus logic based on direction. |
+| `src/PWMLseEditDistanceScorer.h/cpp` | Direction support for LSE mode: flip objective in greedy/exhaustive search. |
+| `src/GseqPwmEdits.cpp` | Pass direction parameter through to scorer; report edits that reduce score. |
+| `src/TrackExpressionVars.h/cpp` | Parse and store direction parameter from R. |
+| `src/SequenceVarProcessor.cpp` | Wire direction to scorer constructors. |
+
+### R
+
+| File | Changes |
+|------|---------|
+| `R/vtrack.R` | Accept and validate `direction` parameter in PWM edit distance vtrack functions. Pass to C++. |
+| `R/sequence.R` | Accept and validate `direction` parameter in `gseq.pwm_edits()`. Pass to C++. |
+
+### Tests
+
+| File | Purpose |
+|------|---------|
+| `tests/testthat/test-pwm-edit-distance-below.R` | New test file for all "below" direction tests. |
+| `tests/testthat/helper-pwm.R` | R reference implementation `manual_pwm_edit_distance_below()` for validation. |
+
+## Test Strategy
+
+1. **R reference implementation**: `manual_pwm_edit_distance_below()` that brute-force computes minimum edits to bring score below threshold (enumerate edits for small k, verify greedy for larger).
+2. **All modes**: Test `MIN_EDITS`, `MIN_EDITS_POSITION`, `PWM_MAX_EDITS` with `direction="below"`.
+3. **Edge cases**:
+   - Already below threshold -> return 0.
+   - Unreachable (cannot get below even with all worst bases) -> return `NA`.
+   - `max_edits` cap reached -> return `NA`.
+4. **Indels + below**: Test with `D=1` and `D=2` indel budgets.
+5. **LSE + below**: Test LSE mode with direction="below".
+6. **Regression**: All existing "above" tests must continue to pass unchanged (default direction is "above").

--- a/man/gseq.pwm_edits.Rd
+++ b/man/gseq.pwm_edits.Rd
@@ -15,7 +15,8 @@ gseq.pwm_edits(
   score.min = NULL,
   score.max = NULL,
   extend = TRUE,
-  strand = 1L
+  strand = 1L,
+  direction = "above"
 )
 }
 \arguments{
@@ -51,6 +52,11 @@ Default TRUE.}
 
 \item{strand}{integer; which strand to scan when \code{bidirect=FALSE}.
 1=forward, -1=reverse. Default 1.}
+
+\item{direction}{character; direction of the edit distance query.
+\code{"above"} (default) finds minimum edits to bring score above
+\code{score.thresh}; \code{"below"} finds minimum edits to bring score
+below \code{score.thresh}.}
 }
 \value{
 A data frame (long format) with one row per edit, containing columns:

--- a/man/gvtrack.create.Rd
+++ b/man/gvtrack.create.Rd
@@ -143,16 +143,16 @@ interval after all modifier adjustments.
 \strong{Edit distance summarizers}
 \tabular{llll}{
   Source \tab func \tab Key params \tab Description \cr
-  NULL (sequence) \tab pwm.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, bidirect, prior, extend, strand \tab Minimum number of edits (substitutions + indels) needed to reach \code{score.thresh} across all windows. \cr
-  NULL (sequence) \tab pwm.edit_distance.pos \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, bidirect, prior, extend, strand \tab 1-based position of the window achieving minimum edit distance (signed by strand when bidirect). \cr
-  NULL (sequence) \tab pwm.max.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, bidirect, prior, extend, strand \tab Edit distance at the best-scoring PWM window (same location as pwm.max/pwm.max.pos). \cr
+  NULL (sequence) \tab pwm.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, direction, bidirect, prior, extend, strand \tab Minimum number of edits (substitutions + indels) needed to reach \code{score.thresh} across all windows. \cr
+  NULL (sequence) \tab pwm.edit_distance.pos \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, direction, bidirect, prior, extend, strand \tab 1-based position of the window achieving minimum edit distance (signed by strand when bidirect). \cr
+  NULL (sequence) \tab pwm.max.edit_distance \tab pssm, score.thresh, max_edits, max_indels, score.min, score.max, direction, bidirect, prior, extend, strand \tab Edit distance at the best-scoring PWM window (same location as pwm.max/pwm.max.pos). \cr
 }
 
 \strong{LSE edit distance summarizers}
 \tabular{llll}{
   Source \tab func \tab Key params \tab Description \cr
-  NULL (sequence) \tab pwm.edit_distance.lse \tab pssm, score.thresh, max_edits, score.min, score.max, bidirect, prior, extend, strand \tab Minimum number of substitution edits needed to raise the LSE score (log-sum-exp of per-window PWM scores) above \code{score.thresh}. Exhaustive for k<=2, greedy heuristic for k>=3. \cr
-  NULL (sequence) \tab pwm.edit_distance.lse.pos \tab pssm, score.thresh, max_edits, score.min, score.max, bidirect, prior, extend, strand \tab 1-based position of the most impactful single edit for raising the LSE score. \cr
+  NULL (sequence) \tab pwm.edit_distance.lse \tab pssm, score.thresh, max_edits, score.min, score.max, direction, bidirect, prior, extend, strand \tab Minimum number of substitution edits needed to raise the LSE score (log-sum-exp of per-window PWM scores) above \code{score.thresh}. Exhaustive for k<=2, greedy heuristic for k>=3. \cr
+  NULL (sequence) \tab pwm.edit_distance.lse.pos \tab pssm, score.thresh, max_edits, score.min, score.max, direction, bidirect, prior, extend, strand \tab 1-based position of the most impactful single edit for raising the LSE score. \cr
 }
 
 \strong{K-mer summarizers}
@@ -187,6 +187,7 @@ The sections below provide additional notes for motif, interval, k-mer, and mask
   \item \code{max_indels}: For \code{pwm.edit_distance}, \code{pwm.edit_distance.pos}, and \code{pwm.max.edit_distance} only. Not supported by LSE variants. Optional non-negative integer specifying the maximum number of insertions and deletions allowed (default 0, substitutions only). When > 0, a banded Needleman-Wunsch DP is used to find the minimum total edits (substitutions + indels) to reach the score threshold. Typical values are 1-2.
   \item \code{score.min}: For edit distance functions only. Optional numeric filter. Windows whose PWM log-likelihood is below \code{score.min} are skipped (edit distance returns NA). Improves performance by avoiding expensive computation on low-scoring windows. For LSE variants, the filter applies to the aggregate LSE score across all windows rather than individual window scores. Default NULL (no filter).
   \item \code{score.max}: For edit distance functions only. Optional numeric filter. Windows whose PWM log-likelihood is above \code{score.max} are skipped (edit distance returns NA). Combined with \code{score.min}, enables efficient regime-specific queries (e.g., only positions with score in [\code{score.min}, \code{score.max}]). For LSE variants, the filter applies to the aggregate LSE score across all windows rather than individual window scores. Default NULL (no filter).
+  \item \code{direction}: For edit distance functions only. Direction of the edit distance query: \code{"above"} (default) finds the minimum edits to bring the score above \code{score.thresh}; \code{"below"} finds the minimum edits to bring the score below \code{score.thresh}.
 }
 
 \strong{Spatial weighting}

--- a/src/GseqPwmEdits.cpp
+++ b/src/GseqPwmEdits.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <map>
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -98,10 +99,13 @@ WindowResult compute_window_edits_detailed(
     const char* seq_ptr, int L,
     const DnaPSSM& pssm,
     const std::vector<float>& col_max_scores,
+    const std::vector<float>& col_min_scores,
     float S_max,
+    float S_min,
     float threshold,
     int max_edits,    // -1 = no cap
     bool reverse,
+    bool below,       // true = direction "below"
     // Precomputed tables for O(L) algorithm
     const std::vector<float>& gain_values,
     const std::vector<std::vector<uint8_t>>& bin_index)
@@ -113,13 +117,14 @@ WindowResult compute_window_edits_detailed(
 
     // Per-position info for edit tracking
     struct PosInfo {
-        int motif_col;      // 0-based motif column
-        char ref_base;      // current base (after complement if reverse)
-        int ref_idx;        // base index (0-3, or 4 for unknown)
-        float base_score;   // current score contribution
-        float gain;         // gain if switched to best base
-        int best_base_idx;  // index of best base for this column
-        bool mandatory;     // true if base is unknown/zero-prob
+        int motif_col;        // 0-based motif column
+        char ref_base;        // current base (after complement if reverse)
+        int ref_idx;          // base index (0-3, or 4 for unknown)
+        float base_score;     // current score contribution
+        float gain;           // gain if switched to target base (positive = toward goal)
+        float output_gain;    // gain value for output (positive for above, negative for below)
+        int target_base_idx;  // index of target base (best for above, worst for below)
+        bool mandatory;       // true if base is unknown/zero-prob (above only)
     };
 
     std::vector<PosInfo> positions(L);
@@ -140,45 +145,82 @@ WindowResult compute_window_edits_detailed(
         p.ref_base = base;
         p.ref_idx = base_to_index(base);
 
-        // Find best base for this column
-        float best_score = -std::numeric_limits<float>::infinity();
-        p.best_base_idx = 0;
-        for (int b = 0; b < 4; b++) {
-            float s = pssm[i].get_log_prob_from_code(b);
-            if (s > best_score) {
-                best_score = s;
-                p.best_base_idx = b;
+        if (below) {
+            // "below" direction: target is worst base (min score)
+            float worst_score = std::numeric_limits<float>::infinity();
+            p.target_base_idx = 0;
+            for (int b = 0; b < 4; b++) {
+                float s = pssm[i].get_log_prob_from_code(b);
+                if (s < worst_score) {
+                    worst_score = s;
+                    p.target_base_idx = b;
+                }
             }
-        }
 
-        if (p.ref_idx == 4) {
-            // Unknown base: mandatory edit
-            // Use mean log-probability for the true score (consistent with PWMScorer)
-            float mean_logp = 0.0f;
-            for (int b = 0; b < 4; b++) mean_logp += pssm[i].get_log_prob_from_code(b);
-            mean_logp /= 4.0f;
-
-            p.mandatory = true;
-            p.base_score = mean_logp;
-            p.gain = col_max_scores[i] - mean_logp;
-            mandatory_edits++;
-            true_score += static_cast<double>(mean_logp);
-            adjusted_score += static_cast<double>(col_max_scores[i]);
-        } else {
-            float score = pssm[i].get_log_prob_from_code(p.ref_idx);
-            if (score <= kLogZeroThreshold || !std::isfinite(score)) {
-                p.mandatory = true;
-                p.base_score = score;
-                p.gain = col_max_scores[i] - score;  // gain can be +inf, that's fine
-                mandatory_edits++;
-                true_score += static_cast<double>(score);  // keep true -inf in score_before
-                adjusted_score += static_cast<double>(col_max_scores[i]);
+            if (p.ref_idx == 4) {
+                // Unknown base: use mean log-probability
+                float mean_logp = 0.0f;
+                for (int b = 0; b < 4; b++) mean_logp += pssm[i].get_log_prob_from_code(b);
+                mean_logp /= 4.0f;
+                p.mandatory = false;  // no mandatory edits for "below"
+                p.base_score = mean_logp;
+                // loss = current - worst (positive means switching helps)
+                p.gain = mean_logp - col_min_scores[i];
+                p.output_gain = -(p.gain);  // negative in output
+                true_score += static_cast<double>(mean_logp);
+                adjusted_score += static_cast<double>(mean_logp);
             } else {
+                float score = pssm[i].get_log_prob_from_code(p.ref_idx);
                 p.mandatory = false;
                 p.base_score = score;
-                p.gain = col_max_scores[i] - score;
+                p.gain = score - col_min_scores[i];  // loss from switching to worst
+                p.output_gain = -(p.gain);  // negative in output
                 true_score += static_cast<double>(score);
                 adjusted_score += static_cast<double>(score);
+            }
+        } else {
+            // "above" direction: target is best base (max score)
+            float best_score = -std::numeric_limits<float>::infinity();
+            p.target_base_idx = 0;
+            for (int b = 0; b < 4; b++) {
+                float s = pssm[i].get_log_prob_from_code(b);
+                if (s > best_score) {
+                    best_score = s;
+                    p.target_base_idx = b;
+                }
+            }
+
+            if (p.ref_idx == 4) {
+                // Unknown base: mandatory edit
+                float mean_logp = 0.0f;
+                for (int b = 0; b < 4; b++) mean_logp += pssm[i].get_log_prob_from_code(b);
+                mean_logp /= 4.0f;
+
+                p.mandatory = true;
+                p.base_score = mean_logp;
+                p.gain = col_max_scores[i] - mean_logp;
+                p.output_gain = p.gain;
+                mandatory_edits++;
+                true_score += static_cast<double>(mean_logp);
+                adjusted_score += static_cast<double>(col_max_scores[i]);
+            } else {
+                float score = pssm[i].get_log_prob_from_code(p.ref_idx);
+                if (score <= kLogZeroThreshold || !std::isfinite(score)) {
+                    p.mandatory = true;
+                    p.base_score = score;
+                    p.gain = col_max_scores[i] - score;
+                    p.output_gain = p.gain;
+                    mandatory_edits++;
+                    true_score += static_cast<double>(score);
+                    adjusted_score += static_cast<double>(col_max_scores[i]);
+                } else {
+                    p.mandatory = false;
+                    p.base_score = score;
+                    p.gain = col_max_scores[i] - score;
+                    p.output_gain = p.gain;
+                    true_score += static_cast<double>(score);
+                    adjusted_score += static_cast<double>(score);
+                }
             }
         }
     }
@@ -191,10 +233,14 @@ WindowResult compute_window_edits_detailed(
         result.window_seq[i] = positions[i].ref_base;
     }
 
-    double deficit = static_cast<double>(threshold) - adjusted_score;
+    // For "below": surplus = adjusted_score - threshold (need to lose this much)
+    // For "above": deficit = threshold - adjusted_score (need to gain this much)
+    double gap = below
+        ? (adjusted_score - static_cast<double>(threshold))
+        : (static_cast<double>(threshold) - adjusted_score);
 
-    // Already above threshold (after accounting for mandatory edits)?
-    if (deficit <= 0.0) {
+    // Already past threshold (after accounting for mandatory edits)?
+    if (gap <= 0.0) {
         // Still apply max_edits cap: mandatory-only result must respect the budget.
         if (max_edits >= 0 && mandatory_edits > max_edits) {
             result.n_edits = -1;
@@ -204,14 +250,14 @@ WindowResult compute_window_edits_detailed(
         // score_after = adjusted_score (which has mandatory edits applied)
         result.score_after = static_cast<float>(adjusted_score);
         result.mutated_seq = result.window_seq;
-        // Add mandatory edits if any
+        // Add mandatory edits if any (above direction only)
         for (int i = 0; i < L; i++) {
             if (positions[i].mandatory) {
                 EditInfo edit;
                 edit.motif_col = i + 1;  // 1-based
                 edit.ref_base = positions[i].ref_base;
-                edit.alt_base = index_to_base(positions[i].best_base_idx);
-                edit.gain = positions[i].gain;
+                edit.alt_base = index_to_base(positions[i].target_base_idx);
+                edit.gain = positions[i].output_gain;
                 edit.edit_type = "sub";
                 result.edits.push_back(edit);
                 result.mutated_seq[i] = edit.alt_base;
@@ -221,8 +267,12 @@ WindowResult compute_window_edits_detailed(
     }
 
     // Check reachability
-    double max_possible_gain = static_cast<double>(S_max) - adjusted_score;
-    if (max_possible_gain < deficit) {
+    // For "above": max possible improvement = S_max - adjusted_score
+    // For "below": max possible loss = adjusted_score - S_min
+    double max_possible_delta = below
+        ? (adjusted_score - static_cast<double>(S_min))
+        : (static_cast<double>(S_max) - adjusted_score);
+    if (max_possible_delta < gap) {
         result.n_edits = -1;  // unreachable
         return result;
     }
@@ -240,19 +290,19 @@ WindowResult compute_window_edits_detailed(
                   return positions[a].gain > positions[b].gain;
               });
 
-    // Greedy: take largest gains until deficit is covered
+    // Greedy: take largest gains until gap is covered
     double acc = 0.0;
     int edits = mandatory_edits;
     std::vector<EditInfo> edit_list;
 
-    // First add mandatory edits
+    // First add mandatory edits (above direction only)
     for (int i = 0; i < L; i++) {
         if (positions[i].mandatory) {
             EditInfo edit;
             edit.motif_col = i + 1;
             edit.ref_base = positions[i].ref_base;
-            edit.alt_base = index_to_base(positions[i].best_base_idx);
-            edit.gain = positions[i].gain;
+            edit.alt_base = index_to_base(positions[i].target_base_idx);
+            edit.gain = positions[i].output_gain;
             edit.edit_type = "sub";
             edit_list.push_back(edit);
         }
@@ -270,15 +320,16 @@ WindowResult compute_window_edits_detailed(
         EditInfo edit;
         edit.motif_col = idx + 1;  // 1-based
         edit.ref_base = positions[idx].ref_base;
-        edit.alt_base = index_to_base(positions[idx].best_base_idx);
-        edit.gain = positions[idx].gain;
+        edit.alt_base = index_to_base(positions[idx].target_base_idx);
+        edit.gain = positions[idx].output_gain;
         edit.edit_type = "sub";
         edit_list.push_back(edit);
 
-        if (acc >= deficit) {
-            // We've covered the deficit
+        if (acc >= gap) {
+            // We've covered the gap
+            double score_change = below ? -acc : acc;
             result.n_edits = edits;
-            result.score_after = static_cast<float>(adjusted_score + acc);
+            result.score_after = static_cast<float>(adjusted_score + score_change);
             result.edits = edit_list;
             // Build mutated_seq
             result.mutated_seq = result.window_seq;
@@ -311,21 +362,27 @@ WindowResult compute_window_edits_detailed(
  * @param L        motif length
  * @param pssm     the PSSM
  * @param col_max_scores  per-column max scores
+ * @param col_min_scores  per-column min scores
  * @param S_max    sum of col_max_scores
+ * @param S_min    sum of col_min_scores
  * @param threshold target score
  * @param max_edits overall edit cap (-1 = no cap)
  * @param max_indels max indels allowed (D)
  * @param reverse  true if scanning reverse strand
+ * @param below    true if direction is "below"
  */
 WindowResult compute_window_edits_detailed_with_indels(
     const char* seq_ptr, int seq_avail, int L,
     const DnaPSSM& pssm,
     const std::vector<float>& col_max_scores,
+    const std::vector<float>& col_min_scores,
     float S_max,
+    float S_min,
     float threshold,
     int max_edits,
     int max_indels,
-    bool reverse)
+    bool reverse,
+    bool below)
 {
     const int D = max_indels;
 
@@ -343,11 +400,25 @@ WindowResult compute_window_edits_detailed_with_indels(
         const int indel_levels = D + 1;
 
         // Flattened 3D DP table
-        std::vector<double> dp(rows * cols * indel_levels,
-                               -std::numeric_limits<double>::infinity());
+        // For "above" (maximize): init to -inf, pick max
+        // For "below" (minimize): init to +inf, pick min
+        const double dp_sentinel = below
+            ? std::numeric_limits<double>::infinity()
+            : -std::numeric_limits<double>::infinity();
+        std::vector<double> dp(rows * cols * indel_levels, dp_sentinel);
 
         auto idx3 = [cols, indel_levels](int i, int j, int k) -> int {
             return i * cols * indel_levels + j * indel_levels + k;
+        };
+
+        auto is_valid = [below](double v) -> bool {
+            if (below) return v < std::numeric_limits<double>::infinity() * 0.5;
+            else return v > -std::numeric_limits<double>::infinity() * 0.5;
+        };
+
+        auto is_better = [below](double candidate, double current) -> bool {
+            if (below) return candidate < current;
+            else return candidate > current;
         };
 
         // Base case
@@ -391,9 +462,9 @@ WindowResult compute_window_edits_detailed_with_indels(
                     // 1. Match/Substitution (diagonal)
                     if (std::abs((i - 1) - (j - 1)) <= D) {
                         double prev = dp[idx3(i - 1, j - 1, k)];
-                        if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
+                        if (is_valid(prev)) {
                             double new_score = prev + static_cast<double>(base_score);
-                            if (new_score > dp[idx3(i, j, k)]) {
+                            if (is_better(new_score, dp[idx3(i, j, k)])) {
                                 dp[idx3(i, j, k)] = new_score;
                             }
                         }
@@ -403,8 +474,8 @@ WindowResult compute_window_edits_detailed_with_indels(
                         // 2. Insertion: skip motif[i-1], advance motif not sequence
                         if (std::abs((i - 1) - j) <= D) {
                             double prev = dp[idx3(i - 1, j, k)];
-                            if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
-                                if (prev > dp[idx3(i, j, k + 1)]) {
+                            if (is_valid(prev)) {
+                                if (is_better(prev, dp[idx3(i, j, k + 1)])) {
                                     dp[idx3(i, j, k + 1)] = prev;
                                 }
                             }
@@ -413,8 +484,8 @@ WindowResult compute_window_edits_detailed_with_indels(
                         // 3. Deletion: skip seq[j-1], advance sequence not motif
                         if (std::abs(i - (j - 1)) <= D) {
                             double prev = dp[idx3(i, j - 1, k)];
-                            if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
-                                if (prev > dp[idx3(i, j, k + 1)]) {
+                            if (is_valid(prev)) {
+                                if (is_better(prev, dp[idx3(i, j, k + 1)])) {
                                     dp[idx3(i, j, k + 1)] = prev;
                                 }
                             }
@@ -427,7 +498,7 @@ WindowResult compute_window_edits_detailed_with_indels(
         // Extract results for each indel count k
         for (int k = 0; k <= D; ++k) {
             double score = dp[idx3(L, W, k)];
-            if (score <= -std::numeric_limits<double>::infinity() * 0.5) {
+            if (!is_valid(score)) {
                 continue;
             }
 
@@ -508,7 +579,7 @@ WindowResult compute_window_edits_detailed_with_indels(
                     }
 
                     double prev = dp[idx3(ti - 1, tj - 1, tk)];
-                    if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
+                    if (is_valid(prev) &&
                         std::fabs((prev + static_cast<double>(bs)) - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
                         AlignOp op;
                         op.op = 'M';
@@ -526,7 +597,7 @@ WindowResult compute_window_edits_detailed_with_indels(
                 if (!found && ti > 0 && tk > 0 && std::abs((ti - 1) - tj) <= D) {
                     // Try insertion (skip motif position)
                     double prev = dp[idx3(ti - 1, tj, tk - 1)];
-                    if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
+                    if (is_valid(prev) &&
                         std::fabs(prev - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
                         AlignOp op;
                         op.op = 'I';
@@ -544,7 +615,7 @@ WindowResult compute_window_edits_detailed_with_indels(
                 if (!found && tj > 0 && tk > 0 && std::abs(ti - (tj - 1)) <= D) {
                     // Try deletion (skip seq position)
                     double prev = dp[idx3(ti, tj - 1, tk - 1)];
-                    if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
+                    if (is_valid(prev) &&
                         std::fabs(prev - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
                         AlignOp op;
                         op.op = 'D';
@@ -575,10 +646,11 @@ WindowResult compute_window_edits_detailed_with_indels(
 
             // Collect gains from aligned (diagonal/M) positions for greedy sub selection
             struct AlignedPos {
-                int align_idx;      // index into alignment vector
-                float gain;         // col_max - current score
-                int best_base_idx;  // index of best base for this column
-                bool mandatory;     // unknown base or zero-prob
+                int align_idx;        // index into alignment vector
+                float gain;           // improvement toward goal (always positive for sorting)
+                float output_gain;    // gain for output (positive for above, negative for below)
+                int target_base_idx;  // index of target base (best for above, worst for below)
+                bool mandatory;       // unknown base or zero-prob (above only)
             };
 
             std::vector<AlignedPos> aligned_positions;
@@ -588,45 +660,78 @@ WindowResult compute_window_edits_detailed_with_indels(
                 if (alignment[a].op != 'M') continue;
 
                 int mc = alignment[a].motif_pos;
-                float gain = col_max_scores[mc] - alignment[a].base_score;
 
-                // Find best base for this column
-                float best_s = -std::numeric_limits<float>::infinity();
-                int best_b = 0;
-                for (int b = 0; b < 4; b++) {
-                    float s = pssm[mc].get_log_prob_from_code(b);
-                    if (s > best_s) { best_s = s; best_b = b; }
+                if (below) {
+                    // "below": target is worst base, gain = loss from switching
+                    float worst_s = std::numeric_limits<float>::infinity();
+                    int worst_b = 0;
+                    for (int b = 0; b < 4; b++) {
+                        float s = pssm[mc].get_log_prob_from_code(b);
+                        if (s < worst_s) { worst_s = s; worst_b = b; }
+                    }
+                    float loss = alignment[a].base_score - col_min_scores[mc];
+
+                    AlignedPos ap;
+                    ap.align_idx = static_cast<int>(a);
+                    ap.gain = loss;  // positive for sorting
+                    ap.output_gain = -loss;  // negative in output
+                    ap.target_base_idx = worst_b;
+                    ap.mandatory = false;
+                    aligned_positions.push_back(ap);
+                } else {
+                    // "above": target is best base
+                    float best_s = -std::numeric_limits<float>::infinity();
+                    int best_b = 0;
+                    for (int b = 0; b < 4; b++) {
+                        float s = pssm[mc].get_log_prob_from_code(b);
+                        if (s > best_s) { best_s = s; best_b = b; }
+                    }
+                    float gain = col_max_scores[mc] - alignment[a].base_score;
+
+                    bool mandatory_flag = (alignment[a].base_idx == 4) ||
+                        (alignment[a].base_score <= kLogZeroThreshold ||
+                         !std::isfinite(alignment[a].base_score));
+
+                    AlignedPos ap;
+                    ap.align_idx = static_cast<int>(a);
+                    ap.gain = gain;
+                    ap.output_gain = gain;
+                    ap.target_base_idx = best_b;
+                    ap.mandatory = mandatory_flag;
+                    aligned_positions.push_back(ap);
                 }
-
-                bool mandatory = (alignment[a].base_idx == 4) ||
-                    (alignment[a].base_score <= kLogZeroThreshold ||
-                     !std::isfinite(alignment[a].base_score));
-
-                AlignedPos ap;
-                ap.align_idx = static_cast<int>(a);
-                ap.gain = gain;
-                ap.best_base_idx = best_b;
-                ap.mandatory = mandatory;
-                aligned_positions.push_back(ap);
             }
 
             // Determine substitutions needed
-            // Account for mandatory subs at aligned positions (zero-prob / unknown)
+            // For "above": account for mandatory subs (zero-prob / unknown)
+            // For "below": no mandatory subs
             int mandatory_subs = 0;
             double adjusted = score;
-            for (auto& ap : aligned_positions) {
-                if (ap.mandatory) {
-                    adjusted += static_cast<double>(ap.gain);
-                    mandatory_subs++;
+            if (!below) {
+                for (auto& ap : aligned_positions) {
+                    if (ap.mandatory) {
+                        adjusted += static_cast<double>(ap.gain);
+                        mandatory_subs++;
+                    }
                 }
             }
 
+            // Check if already past threshold after mandatory edits
+            // For "above": adjusted >= threshold
+            // For "below": adjusted <= threshold
             int subs_needed;
-            if (adjusted >= static_cast<double>(threshold)) {
+            bool already_past = below
+                ? (adjusted <= static_cast<double>(threshold))
+                : (adjusted >= static_cast<double>(threshold));
+            if (already_past) {
                 subs_needed = mandatory_subs;
             } else {
                 // Need additional greedy subs
-                double remaining_deficit = static_cast<double>(threshold) - adjusted;
+                // For "above": remaining gap = threshold - adjusted
+                // For "below": remaining gap = adjusted - threshold
+                double remaining_gap = below
+                    ? (adjusted - static_cast<double>(threshold))
+                    : (static_cast<double>(threshold) - adjusted);
 
                 // Sort non-mandatory by gain descending
                 std::vector<const AlignedPos*> optional;
@@ -648,7 +753,7 @@ WindowResult compute_window_edits_detailed_with_indels(
                     if (max_edits >= 0 && (k + subs_needed) >= max_edits) break;
                     acc += static_cast<double>(ap->gain);
                     subs_needed++;
-                    if (acc >= remaining_deficit) {
+                    if (acc >= remaining_gap) {
                         reachable = true;
                         break;
                     }
@@ -668,7 +773,7 @@ WindowResult compute_window_edits_detailed_with_indels(
             // Build detailed edit list and result
             // Mark which aligned positions need substitution
             std::set<int> sub_align_indices;
-            // First, mandatory
+            // First, mandatory (above only)
             for (auto& ap : aligned_positions) {
                 if (ap.mandatory) sub_align_indices.insert(ap.align_idx);
             }
@@ -685,15 +790,23 @@ WindowResult compute_window_edits_detailed_with_indels(
                               return a->gain > b->gain;
                           });
                 double acc = 0.0;
-                double remaining_deficit = static_cast<double>(threshold) - adjusted;
+                double remaining_gap = below
+                    ? (adjusted - static_cast<double>(threshold))
+                    : (static_cast<double>(threshold) - adjusted);
                 int extra = 0;
                 for (auto* ap : optional) {
                     if (extra >= (subs_needed - mandatory_subs)) break;
                     acc += static_cast<double>(ap->gain);
                     sub_align_indices.insert(ap->align_idx);
                     extra++;
-                    if (acc >= remaining_deficit) break;
+                    if (acc >= remaining_gap) break;
                 }
+            }
+
+            // Build a lookup from align_idx to AlignedPos for target base info
+            std::map<int, const AlignedPos*> ap_lookup;
+            for (auto& ap : aligned_positions) {
+                ap_lookup[ap.align_idx] = &ap;
             }
 
             // Build window_seq and mutated_seq as an alignment view:
@@ -711,12 +824,14 @@ WindowResult compute_window_edits_detailed_with_indels(
 
                 if (aop.op == 'M') {
                     bool do_sub = (sub_align_indices.count(static_cast<int>(a)) > 0);
-                    // Find best base for this column
-                    float best_s = -std::numeric_limits<float>::infinity();
-                    int best_b = 0;
-                    for (int b = 0; b < 4; b++) {
-                        float s = pssm[aop.motif_pos].get_log_prob_from_code(b);
-                        if (s > best_s) { best_s = s; best_b = b; }
+
+                    // Get target base from AlignedPos lookup
+                    auto it = ap_lookup.find(static_cast<int>(a));
+                    int target_b = 0;
+                    float output_gain_val = 0.0f;
+                    if (it != ap_lookup.end()) {
+                        target_b = it->second->target_base_idx;
+                        output_gain_val = it->second->output_gain;
                     }
 
                     window_seq += aop.base_char;
@@ -724,34 +839,50 @@ WindowResult compute_window_edits_detailed_with_indels(
                         EditInfo ei;
                         ei.motif_col = aop.motif_pos + 1; // 1-based
                         ei.ref_base = aop.base_char;
-                        ei.alt_base = index_to_base(best_b);
-                        ei.gain = col_max_scores[aop.motif_pos] - aop.base_score;
+                        ei.alt_base = index_to_base(target_b);
+                        ei.gain = output_gain_val;
                         ei.edit_type = "sub";
                         edit_list.push_back(ei);
-                        mutated_seq += index_to_base(best_b);
-                        score_after += static_cast<double>(ei.gain);
+                        mutated_seq += index_to_base(target_b);
+                        // For "above": score goes up by gain
+                        // For "below": score goes down by |gain| (output_gain is negative)
+                        score_after += static_cast<double>(output_gain_val);
                     } else {
                         mutated_seq += aop.base_char;
                     }
                 } else if (aop.op == 'I') {
                     // Insertion: motif position has no aligned seq base
-                    float best_s = -std::numeric_limits<float>::infinity();
-                    int best_b = 0;
-                    for (int b = 0; b < 4; b++) {
-                        float s = pssm[aop.motif_pos].get_log_prob_from_code(b);
-                        if (s > best_s) { best_s = s; best_b = b; }
+                    // For "above": insert best base; for "below": insert worst base
+                    int target_b;
+                    float ins_gain;
+                    if (below) {
+                        float worst_s = std::numeric_limits<float>::infinity();
+                        target_b = 0;
+                        for (int b = 0; b < 4; b++) {
+                            float s = pssm[aop.motif_pos].get_log_prob_from_code(b);
+                            if (s < worst_s) { worst_s = s; target_b = b; }
+                        }
+                        ins_gain = col_min_scores[aop.motif_pos];  // negative contribution
+                    } else {
+                        float best_s = -std::numeric_limits<float>::infinity();
+                        target_b = 0;
+                        for (int b = 0; b < 4; b++) {
+                            float s = pssm[aop.motif_pos].get_log_prob_from_code(b);
+                            if (s > best_s) { best_s = s; target_b = b; }
+                        }
+                        ins_gain = col_max_scores[aop.motif_pos];
                     }
 
                     EditInfo ei;
                     ei.motif_col = aop.motif_pos + 1; // 1-based
                     ei.ref_base = '\0';
-                    ei.alt_base = index_to_base(best_b);
-                    ei.gain = col_max_scores[aop.motif_pos];
+                    ei.alt_base = index_to_base(target_b);
+                    ei.gain = ins_gain;
                     ei.edit_type = "ins";
                     edit_list.push_back(ei);
                     window_seq += '-';  // gap in original sequence
-                    mutated_seq += index_to_base(best_b);
-                    score_after += static_cast<double>(col_max_scores[aop.motif_pos]);
+                    mutated_seq += index_to_base(target_b);
+                    score_after += static_cast<double>(ins_gain);
                 } else if (aop.op == 'D') {
                     // Deletion: seq base skipped (not aligned to any motif pos)
                     EditInfo ei;
@@ -809,12 +940,15 @@ WindowResult find_best_window_edits(
     int roi_start_0, int roi_end_0,  // 0-based range of allowed window starts
     const DnaPSSM& pssm,
     const std::vector<float>& col_max_scores,
+    const std::vector<float>& col_min_scores,
     float S_max,
+    float S_min,
     float threshold,
     int max_edits,
     int max_indels,
     bool scan_forward, bool scan_reverse,
     float score_min, float score_max,
+    bool below,
     const std::vector<float>& gain_values,
     const std::vector<std::vector<uint8_t>>& bin_index)
 {
@@ -860,12 +994,13 @@ WindowResult find_best_window_edits(
             WindowResult wr;
             if (max_indels > 0) {
                 wr = compute_window_edits_detailed_with_indels(
-                    window_start, seq_avail, L, pssm, col_max_scores, S_max,
-                    threshold, max_edits, max_indels, reverse);
+                    window_start, seq_avail, L, pssm, col_max_scores, col_min_scores,
+                    S_max, S_min, threshold, max_edits, max_indels, reverse, below);
             } else {
                 wr = compute_window_edits_detailed(
-                    window_start, L, pssm, col_max_scores, S_max,
-                    threshold, max_edits, reverse, gain_values, bin_index);
+                    window_start, L, pssm, col_max_scores, col_min_scores,
+                    S_max, S_min, threshold, max_edits, reverse, below,
+                    gain_values, bin_index);
             }
 
             if (wr.n_edits < 0) return;  // unreachable
@@ -916,7 +1051,8 @@ SEXP C_gseq_pwm_edits(SEXP r_seqs, SEXP r_pssm, SEXP r_score_thresh,
                        SEXP r_max_edits, SEXP r_max_indels,
                        SEXP r_bidirect, SEXP r_strand_mode,
                        SEXP r_prior, SEXP r_roi_start, SEXP r_roi_end,
-                       SEXP r_extend, SEXP r_score_min, SEXP r_score_max)
+                       SEXP r_extend, SEXP r_score_min, SEXP r_score_max,
+                       SEXP r_direction)
 {
     try {
         if (!Rf_isString(r_seqs)) Rf_error("seqs must be a character vector");
@@ -994,34 +1130,50 @@ SEXP C_gseq_pwm_edits(SEXP r_seqs, SEXP r_pssm, SEXP r_score_thresh,
             score_max_val = static_cast<float>(Rf_asReal(r_score_max));
         }
 
+        // Parse direction
+        bool below = false;
+        if (!Rf_isNull(r_direction) && Rf_isString(r_direction) && Rf_length(r_direction) > 0) {
+            std::string dir_str = CHAR(STRING_ELT(r_direction, 0));
+            below = (dir_str == "below");
+        }
+
         // Precompute tables (same as PWMEditDistanceScorer::precompute_tables)
         std::vector<float> col_max_scores(w);
+        std::vector<float> col_min_scores(w);
         float S_max = 0.0f;
+        float S_min = 0.0f;
         for (int i = 0; i < w; i++) {
             float max_score = -std::numeric_limits<float>::infinity();
+            float min_score = std::numeric_limits<float>::infinity();
             for (int b = 0; b < 4; b++) {
                 float s = core.pssm[i].get_log_prob_from_code(b);
                 if (s > max_score) max_score = s;
+                if (s < min_score && std::isfinite(s)) min_score = s;
             }
             col_max_scores[i] = max_score;
+            col_min_scores[i] = min_score;
             S_max += max_score;
+            S_min += min_score;
         }
 
-        // Gain values sorted descending
+        // Gain/loss values sorted descending (direction-dependent)
+        // ABOVE: delta[i][b] = col_max[i] - score[i][b]  (gain from switching to best)
+        // BELOW: delta[i][b] = score[i][b] - col_min[i]   (loss from switching to worst)
         std::set<float, std::greater<float>> unique_gains;
         std::vector<std::vector<uint8_t>> bin_idx(w);
         for (int i = 0; i < w; i++) {
             bin_idx[i].resize(5);
             for (int b = 0; b < 4; b++) {
-                float g = col_max_scores[i] - core.pssm[i].get_log_prob_from_code(b);
+                float s = core.pssm[i].get_log_prob_from_code(b);
+                float g = below ? (s - col_min_scores[i]) : (col_max_scores[i] - s);
+                if (!std::isfinite(g) || g < 0.0f) g = 0.0f;
                 unique_gains.insert(g);
             }
-            float min_score = std::numeric_limits<float>::infinity();
-            for (int b = 0; b < 4; b++) {
-                float s = core.pssm[i].get_log_prob_from_code(b);
-                if (s < min_score) min_score = s;
-            }
-            unique_gains.insert(col_max_scores[i] - min_score);
+            // Unknown base (index 4): use max delta
+            float max_delta = below ? (col_max_scores[i] - col_min_scores[i])
+                                    : (col_max_scores[i] - col_min_scores[i]);
+            if (!std::isfinite(max_delta) || max_delta < 0.0f) max_delta = 0.0f;
+            unique_gains.insert(max_delta);
         }
         std::vector<float> gain_values(unique_gains.begin(), unique_gains.end());
         for (int i = 0; i < w; i++) {
@@ -1030,13 +1182,23 @@ SEXP C_gseq_pwm_edits(SEXP r_seqs, SEXP r_pssm, SEXP r_score_thresh,
                 if (b < 4) {
                     score = core.pssm[i].get_log_prob_from_code(b);
                 } else {
-                    score = std::numeric_limits<float>::infinity();
-                    for (int bb = 0; bb < 4; bb++) {
-                        float s = core.pssm[i].get_log_prob_from_code(bb);
-                        if (s < score) score = s;
+                    // Unknown base: use the worst-case score for this direction
+                    if (below) {
+                        score = -std::numeric_limits<float>::infinity();
+                        for (int bb = 0; bb < 4; bb++) {
+                            float s = core.pssm[i].get_log_prob_from_code(bb);
+                            if (s > score) score = s;
+                        }
+                    } else {
+                        score = std::numeric_limits<float>::infinity();
+                        for (int bb = 0; bb < 4; bb++) {
+                            float s = core.pssm[i].get_log_prob_from_code(bb);
+                            if (s < score) score = s;
+                        }
                     }
                 }
-                float g = col_max_scores[i] - score;
+                float g = below ? (score - col_min_scores[i]) : (col_max_scores[i] - score);
+                if (!std::isfinite(g) || g < 0.0f) g = 0.0f;
                 auto it = std::lower_bound(gain_values.begin(), gain_values.end(),
                                            g, std::greater<float>());
                 bin_idx[i][b] = static_cast<uint8_t>(std::distance(gain_values.begin(), it));
@@ -1099,10 +1261,10 @@ SEXP C_gseq_pwm_edits(SEXP r_seqs, SEXP r_pssm, SEXP r_score_thresh,
 
             WindowResult wr = find_best_window_edits(
                 seq, start_min0, start_max0,
-                core.pssm, col_max_scores, S_max,
+                core.pssm, col_max_scores, col_min_scores, S_max, S_min,
                 threshold, max_edits, max_indels,
                 scan_forward, scan_reverse,
-                score_min, score_max_val,
+                score_min, score_max_val, below,
                 gain_values, bin_idx);
 
             if (wr.n_edits == 0) {

--- a/src/PWMEditDistanceScorer.cpp
+++ b/src/PWMEditDistanceScorer.cpp
@@ -63,12 +63,10 @@ void PWMEditDistanceScorer::precompute_tables()
     }
 
     // Precompute suffix sums for early-abandon pruning.
-    // ABOVE: suffix sums of col_max (max possible contribution from remaining columns)
-    // BELOW: suffix sums of col_min (min possible contribution from remaining columns)
+    // Uses target_score() which returns col_max for ABOVE, col_min for BELOW.
     m_max_suffix_score.resize(L + 1, 0.0f);
     for (int i = L - 1; i >= 0; i--) {
-        m_max_suffix_score[i] = m_max_suffix_score[i + 1] +
-            (below ? m_col_min_scores[i] : m_col_max_scores[i]);
+        m_max_suffix_score[i] = m_max_suffix_score[i + 1] + target_score(i);
     }
 
     // Precompute maximum possible delta (gain for ABOVE, loss for BELOW) from k substitutions.
@@ -99,24 +97,11 @@ void PWMEditDistanceScorer::precompute_tables()
 
         for (int b = 0; b < 4; b++) {
             float score = m_pssm[i].get_log_prob_from_code(b);
-            float delta;
-            if (below) {
-                // For log-zero scores: -Inf - (-Inf) = NaN → treat as 0 (no reduction possible)
-                bool is_logzero = (score <= kLogZeroThreshold || !std::isfinite(score));
-                delta = is_logzero ? 0.0f : (score - m_col_min_scores[i]);
-            } else {
-                delta = m_col_max_scores[i] - score;
-            }
-            unique_deltas.insert(delta);
+            unique_deltas.insert(compute_position_delta(score, i));
         }
 
-        // Handle unknown bases (N, etc.)
-        // ABOVE: worst case = minimum score → largest gain = col_max - min_score
-        // BELOW: worst case = maximum score → largest loss = max_score - col_min
-        float unknown_delta = below
-            ? (m_col_max_scores[i] - m_col_min_scores[i])
-            : (m_col_max_scores[i] - m_col_min_scores[i]);
-        unique_deltas.insert(unknown_delta);
+        // Unknown bases (N): worst case for the direction → max possible delta
+        unique_deltas.insert(m_col_max_scores[i] - m_col_min_scores[i]);
     }
 
     // Copy to vector (already sorted descending)
@@ -129,29 +114,11 @@ void PWMEditDistanceScorer::precompute_tables()
     // Build bin lookup table
     for (int i = 0; i < L; i++) {
         for (int b = 0; b < 5; b++) {  // Include unknown base index 4
-            float score;
-            if (b < 4) {
-                score = m_pssm[i].get_log_prob_from_code(b);
-            } else {
-                // Unknown base: worst case for the direction
-                // ABOVE: use minimum score (worst case, largest gain)
-                // BELOW: use maximum score (worst case, largest loss)
-                if (below) {
-                    score = m_col_max_scores[i];
-                } else {
-                    score = m_col_min_scores[i];
-                }
-            }
+            float score = (b < 4)
+                ? m_pssm[i].get_log_prob_from_code(b)
+                : (below ? m_col_max_scores[i] : m_col_min_scores[i]);  // worst case for direction
 
-            float delta;
-            if (below) {
-                bool is_logzero_score = (score <= kLogZeroThreshold || !std::isfinite(score));
-                delta = is_logzero_score ? 0.0f : (score - m_col_min_scores[i]);
-            } else {
-                delta = m_col_max_scores[i] - score;
-            }
-
-            // Find bin index (m_gain_values is sorted descending)
+            float delta = compute_position_delta(score, i);
             auto it = std::lower_bound(m_gain_values.begin(), m_gain_values.end(),
                                       delta, std::greater<float>());
             m_bin_index[i][b] = static_cast<uint8_t>(std::distance(m_gain_values.begin(), it));
@@ -159,59 +126,28 @@ void PWMEditDistanceScorer::precompute_tables()
     }
 
     // Populate flat PSSM lookup tables for cache-friendly access.
-    // For ABOVE (existing):
-    //   mandatory = log-zero or non-finite score → assume col_max, gain = 0
-    //   normal: score = raw, gain = col_max - raw
-    // For BELOW:
-    //   mandatory = log-zero or non-finite score → score is -Inf, total is -Inf < threshold → 0 edits
-    //   We handle this by storing the raw score and loss = raw - col_min.
-    //   In compute_exact/compute_heuristic, if any mandatory position exists, the total
-    //   adjusted_score becomes -Inf, deficit <= 0, and we return mandatory_edits (0).
-    //   For BELOW, mandatory_table marks log-zero entries: these make the score -Inf
-    //   (already below any threshold), so they contribute col_min and loss = 0.
+    // For ABOVE: mandatory = log-zero → assume col_max score, gain = 0
+    // For BELOW: log-zero makes score -Inf → already below any threshold → not mandatory
     for (int i = 0; i < L && i < MAX_MOTIF_LEN_OPT; i++) {
         for (int b = 0; b < 4; b++) {
             float raw = m_pssm[i].get_log_prob_from_code(b);
             bool is_logzero = (raw <= kLogZeroThreshold || !std::isfinite(raw));
             if (below) {
-                // BELOW: log-zero positions are NOT mandatory edits.
-                // A -Inf score makes the window score -Inf (already below any finite
-                // threshold), so zero edits are needed.  We store the raw -Inf score
-                // so that adjusted_score becomes -Inf, deficit <= 0, and compute_exact
-                // returns mandatory_edits == 0.  Loss is 0 (can't decrease below -Inf).
+                // BELOW: log-zero → raw -Inf stored, adjusted_score becomes -Inf,
+                // deficit ≤ 0, returns 0 edits. Loss = 0 (can't decrease below -Inf).
                 m_mandatory_table[i][b] = false;
-                if (is_logzero) {
-                    m_score_table[i][b] = raw;  // -Inf
-                    m_gain_table[i][b] = 0.0f;
-                } else {
-                    m_score_table[i][b] = raw;
-                    m_gain_table[i][b] = raw - m_col_min_scores[i];
-                }
+                m_score_table[i][b] = raw;
+                m_gain_table[i][b] = is_logzero ? 0.0f : (raw - m_col_min_scores[i]);
             } else {
-                // ABOVE (existing logic)
                 m_mandatory_table[i][b] = is_logzero;
-                if (is_logzero) {
-                    m_score_table[i][b] = m_col_max_scores[i];
-                    m_gain_table[i][b] = 0.0f;
-                } else {
-                    m_score_table[i][b] = raw;
-                    m_gain_table[i][b] = m_col_max_scores[i] - raw;
-                }
+                m_score_table[i][b] = is_logzero ? m_col_max_scores[i] : raw;
+                m_gain_table[i][b] = is_logzero ? 0.0f : (m_col_max_scores[i] - raw);
             }
         }
-        // N-base (index 4):
-        // ABOVE: mandatory (unknown base → worst case = col_min, must substitute)
-        // BELOW: not mandatory; assume worst case = col_max (hardest to get below
-        //        threshold), with full loss = col_max - col_min available.
-        if (below) {
-            m_mandatory_table[i][4] = false;
-            m_score_table[i][4] = m_col_max_scores[i];
-            m_gain_table[i][4] = m_col_max_scores[i] - m_col_min_scores[i];
-        } else {
-            m_mandatory_table[i][4] = true;
-            m_score_table[i][4] = m_col_max_scores[i];
-            m_gain_table[i][4] = 0.0f;
-        }
+        // N-base (index 4): ABOVE = mandatory (worst case), BELOW = not mandatory (worst case opposite)
+        m_mandatory_table[i][4] = !below;
+        m_score_table[i][4] = m_col_max_scores[i];
+        m_gain_table[i][4] = below ? (m_col_max_scores[i] - m_col_min_scores[i]) : 0.0f;
     }
 
     // Build pigeonhole pre-filter blocks (must come after m_mandatory_table is populated).
@@ -348,33 +284,20 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    const bool below = (m_direction == Direction::BELOW);
-
-    // Quick reachability check:
-    // ABOVE: if S_max < threshold, even the best possible score can't reach it.
-    // BELOW: if S_min > threshold, even the worst possible score can't go below it.
-    if (below) {
-        if (static_cast<double>(m_S_min) > static_cast<double>(m_threshold)) {
-            return std::numeric_limits<float>::quiet_NaN();
-        }
-    } else {
-        if (static_cast<double>(m_S_max) < static_cast<double>(m_threshold)) {
-            return std::numeric_limits<float>::quiet_NaN();
-        }
+    if (!is_globally_reachable()) {
+        return std::numeric_limits<float>::quiet_NaN();
     }
 
     int mandatory_edits = 0;
     double adjusted_score = 0.0;
 
     // PERF-1: Use class-member count vector with touched-list cleanup
-    // (m_exact_count is already zeroed from previous cleanup)
     m_exact_touched.clear();
 
     for (int i = 0; i < L; i++) {
         int seq_idx = reverse ? (L - 1 - i) : i;
         int base_idx = bidx[seq_idx];
 
-        // Use precomputed lookup tables (complement already applied in bidx)
         if (m_mandatory_table[i][base_idx]) {
             mandatory_edits++;
             adjusted_score += static_cast<double>(m_score_table[i][base_idx]);
@@ -390,14 +313,8 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
         m_exact_count[bin]++;
     }
 
-    // Compute deficit: how much score change we need.
-    // ABOVE: deficit = threshold - adjusted_score (need to increase score)
-    // BELOW: deficit = adjusted_score - threshold (need to decrease score)
-    double deficit = below
-        ? (adjusted_score - static_cast<double>(m_threshold))
-        : (static_cast<double>(m_threshold) - adjusted_score);
+    double deficit = compute_deficit(adjusted_score);
 
-    // Clean up count vector using touched list before any early return
     auto cleanup = [this]() {
         for (size_t idx : m_exact_touched) {
             m_exact_count[idx] = 0;
@@ -409,13 +326,7 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
         return static_cast<float>(mandatory_edits);
     }
 
-    // Check if the maximum possible delta can cover the deficit.
-    // ABOVE: max delta = S_max - adjusted_score
-    // BELOW: max delta = adjusted_score - S_min
-    double max_possible_delta = below
-        ? (adjusted_score - static_cast<double>(m_S_min))
-        : (static_cast<double>(m_S_max) - adjusted_score);
-    if (max_possible_delta < deficit) {
+    if (max_possible_delta(adjusted_score) < deficit) {
         cleanup();
         return std::numeric_limits<float>::quiet_NaN();
     }
@@ -471,20 +382,11 @@ float PWMEditDistanceScorer::compute_heuristic(const int* bidx, bool reverse, in
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    const bool below = (m_direction == Direction::BELOW);
-
-    // Quick reachability check:
-    // ABOVE: if S_max < threshold, no substitution strategy can reach it.
-    // BELOW: if S_min > threshold, no substitution strategy can go below it.
-    if (below) {
-        if (static_cast<double>(m_S_min) > static_cast<double>(m_threshold)) {
-            return std::numeric_limits<float>::quiet_NaN();
-        }
-    } else {
-        if (static_cast<double>(m_S_max) < static_cast<double>(m_threshold)) {
-            return std::numeric_limits<float>::quiet_NaN();
-        }
+    if (!is_globally_reachable()) {
+        return std::numeric_limits<float>::quiet_NaN();
     }
+
+    const bool below = is_below();
 
     int mandatory_edits = 0;
     double adjusted_score = 0.0;
@@ -552,18 +454,12 @@ float PWMEditDistanceScorer::compute_heuristic(const int* bidx, bool reverse, in
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    // Compute deficit
-    double deficit = below
-        ? (adjusted_score - static_cast<double>(m_threshold))
-        : (static_cast<double>(m_threshold) - adjusted_score);
+    double deficit = compute_deficit(adjusted_score);
     if (deficit <= 0.0) {
         return static_cast<float>(mandatory_edits);
     }
 
-    double max_possible_delta = below
-        ? (adjusted_score - static_cast<double>(m_S_min))
-        : (static_cast<double>(m_S_max) - adjusted_score);
-    if (max_possible_delta < deficit) {
+    if (max_possible_delta(adjusted_score) < deficit) {
         return std::numeric_limits<float>::quiet_NaN();
     }
 
@@ -1039,11 +935,7 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
             }
 
             // If score already satisfies threshold, no substitutions needed
-            // ABOVE: score >= threshold; BELOW: score <= threshold
-            bool already_satisfied = (m_direction == Direction::BELOW)
-                ? (score <= static_cast<double>(m_threshold))
-                : (score >= static_cast<double>(m_threshold));
-            if (already_satisfied) {
+            if (threshold_satisfied(score)) {
                 float total_edits = static_cast<float>(k);
                 if (std::isnan(best_edits) || total_edits < best_edits) {
                     best_edits = total_edits;
@@ -1145,10 +1037,7 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                 if (!found) break;  // DP inconsistency (shouldn't happen)
             }
 
-            // Compute minimum substitutions needed (direction-aware deficit)
-            double deficit = (m_direction == Direction::BELOW)
-                ? (score - static_cast<double>(m_threshold))
-                : (static_cast<double>(m_threshold) - score);
+            double deficit = compute_deficit(score);
             if (deficit <= 0.0) {
                 float total_edits = static_cast<float>(k);
                 if (std::isnan(best_edits) || total_edits < best_edits) {
@@ -1405,12 +1294,7 @@ bool PWMEditDistanceScorer::quick_deficit_check(double aligned_score, int indels
         return false;
     }
 
-    // Direction-aware deficit:
-    // ABOVE: deficit = threshold - score (need score to increase)
-    // BELOW: deficit = score - threshold (need score to decrease)
-    double deficit = (m_direction == Direction::BELOW)
-        ? (aligned_score - static_cast<double>(m_threshold))
-        : (static_cast<double>(m_threshold) - aligned_score);
+    double deficit = compute_deficit(aligned_score);
     if (deficit <= 0.0) {
         return true;  // Already at or past threshold
     }
@@ -1452,10 +1336,7 @@ float PWMEditDistanceScorer::compute_min_edits_from_gains(double aligned_score,
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    // Direction-aware deficit
-    double deficit = (m_direction == Direction::BELOW)
-        ? (aligned_score - static_cast<double>(m_threshold))
-        : (static_cast<double>(m_threshold) - aligned_score);
+    double deficit = compute_deficit(aligned_score);
     if (deficit <= 0.0) {
         return static_cast<float>(indels);
     }

--- a/src/PWMEditDistanceScorer.cpp
+++ b/src/PWMEditDistanceScorer.cpp
@@ -99,9 +99,14 @@ void PWMEditDistanceScorer::precompute_tables()
 
         for (int b = 0; b < 4; b++) {
             float score = m_pssm[i].get_log_prob_from_code(b);
-            float delta = below
-                ? (score - m_col_min_scores[i])
-                : (m_col_max_scores[i] - score);
+            float delta;
+            if (below) {
+                // For log-zero scores: -Inf - (-Inf) = NaN → treat as 0 (no reduction possible)
+                bool is_logzero = (score <= kLogZeroThreshold || !std::isfinite(score));
+                delta = is_logzero ? 0.0f : (score - m_col_min_scores[i]);
+            } else {
+                delta = m_col_max_scores[i] - score;
+            }
             unique_deltas.insert(delta);
         }
 
@@ -138,9 +143,13 @@ void PWMEditDistanceScorer::precompute_tables()
                 }
             }
 
-            float delta = below
-                ? (score - m_col_min_scores[i])
-                : (m_col_max_scores[i] - score);
+            float delta;
+            if (below) {
+                bool is_logzero_score = (score <= kLogZeroThreshold || !std::isfinite(score));
+                delta = is_logzero_score ? 0.0f : (score - m_col_min_scores[i]);
+            } else {
+                delta = m_col_max_scores[i] - score;
+            }
 
             // Find bin index (m_gain_values is sorted descending)
             auto it = std::lower_bound(m_gain_values.begin(), m_gain_values.end(),
@@ -165,13 +174,14 @@ void PWMEditDistanceScorer::precompute_tables()
             float raw = m_pssm[i].get_log_prob_from_code(b);
             bool is_logzero = (raw <= kLogZeroThreshold || !std::isfinite(raw));
             if (below) {
-                // BELOW: mandatory means the score is already -Inf at this position.
-                // If the current base has -Inf score, the window score is -Inf (< threshold),
-                // so no edits are needed (handled by deficit check). Treat it as col_min with
-                // loss = 0 (no further reduction possible from this already-minimal position).
-                m_mandatory_table[i][b] = is_logzero;
+                // BELOW: log-zero positions are NOT mandatory edits.
+                // A -Inf score makes the window score -Inf (already below any finite
+                // threshold), so zero edits are needed.  We store the raw -Inf score
+                // so that adjusted_score becomes -Inf, deficit <= 0, and compute_exact
+                // returns mandatory_edits == 0.  Loss is 0 (can't decrease below -Inf).
+                m_mandatory_table[i][b] = false;
                 if (is_logzero) {
-                    m_score_table[i][b] = m_col_min_scores[i];
+                    m_score_table[i][b] = raw;  // -Inf
                     m_gain_table[i][b] = 0.0f;
                 } else {
                     m_score_table[i][b] = raw;
@@ -189,14 +199,19 @@ void PWMEditDistanceScorer::precompute_tables()
                 }
             }
         }
-        // N-base (index 4): always mandatory
+        // N-base (index 4):
+        // ABOVE: mandatory (unknown base → worst case = col_min, must substitute)
+        // BELOW: not mandatory; assume worst case = col_max (hardest to get below
+        //        threshold), with full loss = col_max - col_min available.
         if (below) {
-            m_score_table[i][4] = m_col_min_scores[i];
-        } else {
+            m_mandatory_table[i][4] = false;
             m_score_table[i][4] = m_col_max_scores[i];
+            m_gain_table[i][4] = m_col_max_scores[i] - m_col_min_scores[i];
+        } else {
+            m_mandatory_table[i][4] = true;
+            m_score_table[i][4] = m_col_max_scores[i];
+            m_gain_table[i][4] = 0.0f;
         }
-        m_gain_table[i][4] = 0.0f;
-        m_mandatory_table[i][4] = true;
     }
 
     // Build pigeonhole pre-filter blocks (must come after m_mandatory_table is populated).

--- a/src/PWMEditDistanceScorer.cpp
+++ b/src/PWMEditDistanceScorer.cpp
@@ -18,16 +18,19 @@ PWMEditDistanceScorer::PWMEditDistanceScorer(const DnaPSSM& pssm,
                                              Mode mode,
                                              float score_min,
                                              int max_indels,
-                                             float score_max)
+                                             float score_max,
+                                             Direction direction)
     : GenomeSeqScorer(shared_seqfetch, extend, strand),
       m_pssm(pssm),
       m_threshold(threshold),
       m_max_edits(max_edits),
       m_max_indels(max_indels),
       m_mode(mode),
+      m_direction(direction),
       m_score_min(score_min),
       m_score_max(score_max),
-      m_S_max(0.0f)
+      m_S_max(0.0f),
+      m_S_min(0.0f)
 {
     precompute_tables();
 }
@@ -35,53 +38,60 @@ PWMEditDistanceScorer::PWMEditDistanceScorer(const DnaPSSM& pssm,
 void PWMEditDistanceScorer::precompute_tables()
 {
     int L = m_pssm.length();
-    m_col_max_scores.resize(L);
+    const bool below = (m_direction == Direction::BELOW);
 
-    // Compute column maxima and S_max
+    m_col_max_scores.resize(L);
+    m_col_min_scores.resize(L);
+
+    // Compute column maxima, minima, S_max, and S_min
     m_S_max = 0.0f;
+    m_S_min = 0.0f;
     for (int i = 0; i < L; i++) {
         float max_score = -std::numeric_limits<float>::infinity();
+        float min_score = std::numeric_limits<float>::infinity();
 
-        // Find max score across all bases for this column
         for (int b = 0; b < 4; b++) {
             float score = m_pssm[i].get_log_prob_from_code(b);
-            if (score > max_score) {
-                max_score = score;
-            }
+            if (score > max_score) max_score = score;
+            if (score < min_score) min_score = score;
         }
 
         m_col_max_scores[i] = max_score;
+        m_col_min_scores[i] = min_score;
         m_S_max += max_score;
+        m_S_min += min_score;
     }
 
-    // Precompute suffix sums of column maxima for early-abandon pruning
+    // Precompute suffix sums for early-abandon pruning.
+    // ABOVE: suffix sums of col_max (max possible contribution from remaining columns)
+    // BELOW: suffix sums of col_min (min possible contribution from remaining columns)
     m_max_suffix_score.resize(L + 1, 0.0f);
     for (int i = L - 1; i >= 0; i--) {
-        m_max_suffix_score[i] = m_max_suffix_score[i + 1] + m_col_max_scores[i];
+        m_max_suffix_score[i] = m_max_suffix_score[i + 1] +
+            (below ? m_col_min_scores[i] : m_col_max_scores[i]);
     }
 
-    // Precompute maximum possible gains from k substitutions (for quick deficit checks).
-    // m_max_gain_budget[k] = sum of top k column max-gains (col_max - col_min).
-    // This is a per-PSSM upper bound on the total gain from k edits, regardless of sequence.
+    // Precompute maximum possible delta (gain for ABOVE, loss for BELOW) from k substitutions.
+    // ABOVE: max_gain_budget[k] = sum of top k (col_max - col_min)
+    // BELOW: max_gain_budget[k] = sum of top k (col_max - col_min)
+    // Both directions use the same per-column spread; the interpretation changes but the
+    // values are identical: col_max - col_min is the maximum delta achievable at column i.
     {
-        std::vector<float> col_max_gains(L);
+        std::vector<float> col_max_deltas(L);
         for (int i = 0; i < L; i++) {
-            float min_score = std::numeric_limits<float>::infinity();
-            for (int b = 0; b < 4; b++) {
-                float s = m_pssm[i].get_log_prob_from_code(b);
-                if (s < min_score) min_score = s;
-            }
-            col_max_gains[i] = m_col_max_scores[i] - min_score;
+            col_max_deltas[i] = m_col_max_scores[i] - m_col_min_scores[i];
         }
-        std::sort(col_max_gains.begin(), col_max_gains.end(), std::greater<float>());
+        std::sort(col_max_deltas.begin(), col_max_deltas.end(), std::greater<float>());
         m_max_gain_budget.resize(L + 1, 0.0f);
         for (int k = 0; k < L; k++) {
-            m_max_gain_budget[k + 1] = m_max_gain_budget[k] + col_max_gains[k];
+            m_max_gain_budget[k + 1] = m_max_gain_budget[k] + col_max_deltas[k];
         }
     }
 
-    // Collect all gain values
-    std::set<float, std::greater<float>> unique_gains;  // Sorted descending
+    // Collect all delta values (gain for ABOVE, loss for BELOW).
+    // ABOVE: delta[i][b] = col_max[i] - PSSM[i][b]  (score improvement from editing position i)
+    // BELOW: delta[i][b] = PSSM[i][b] - col_min[i]  (score reduction from editing position i)
+    std::set<float, std::greater<float>> unique_deltas;  // Sorted descending
     m_bin_index.resize(L);
 
     for (int i = 0; i < L; i++) {
@@ -89,25 +99,23 @@ void PWMEditDistanceScorer::precompute_tables()
 
         for (int b = 0; b < 4; b++) {
             float score = m_pssm[i].get_log_prob_from_code(b);
-            float gain = m_col_max_scores[i] - score;
-            unique_gains.insert(gain);
+            float delta = below
+                ? (score - m_col_min_scores[i])
+                : (m_col_max_scores[i] - score);
+            unique_deltas.insert(delta);
         }
 
-        // BUG-1b FIX: Handle unknown bases (N, etc.) - find minimum score
-        // (not maximum) to compute worst-case (largest) gain
-        float min_score = std::numeric_limits<float>::infinity();
-        for (int b = 0; b < 4; b++) {
-            float score = m_pssm[i].get_log_prob_from_code(b);
-            if (score < min_score) {
-                min_score = score;
-            }
-        }
-        float gain_unknown = m_col_max_scores[i] - min_score;
-        unique_gains.insert(gain_unknown);
+        // Handle unknown bases (N, etc.)
+        // ABOVE: worst case = minimum score → largest gain = col_max - min_score
+        // BELOW: worst case = maximum score → largest loss = max_score - col_min
+        float unknown_delta = below
+            ? (m_col_max_scores[i] - m_col_min_scores[i])
+            : (m_col_max_scores[i] - m_col_min_scores[i]);
+        unique_deltas.insert(unknown_delta);
     }
 
     // Copy to vector (already sorted descending)
-    m_gain_values.assign(unique_gains.begin(), unique_gains.end());
+    m_gain_values.assign(unique_deltas.begin(), unique_deltas.end());
 
     // PERF-1: Initialize reusable count vector
     m_exact_count.resize(m_gain_values.size(), 0);
@@ -120,55 +128,84 @@ void PWMEditDistanceScorer::precompute_tables()
             if (b < 4) {
                 score = m_pssm[i].get_log_prob_from_code(b);
             } else {
-                // BUG-1b FIX: Unknown base - use minimum score (worst case)
-                score = std::numeric_limits<float>::infinity();
-                for (int bb = 0; bb < 4; bb++) {
-                    float s = m_pssm[i].get_log_prob_from_code(bb);
-                    if (s < score) {
-                        score = s;
-                    }
+                // Unknown base: worst case for the direction
+                // ABOVE: use minimum score (worst case, largest gain)
+                // BELOW: use maximum score (worst case, largest loss)
+                if (below) {
+                    score = m_col_max_scores[i];
+                } else {
+                    score = m_col_min_scores[i];
                 }
             }
 
-            float gain = m_col_max_scores[i] - score;
+            float delta = below
+                ? (score - m_col_min_scores[i])
+                : (m_col_max_scores[i] - score);
 
             // Find bin index (m_gain_values is sorted descending)
             auto it = std::lower_bound(m_gain_values.begin(), m_gain_values.end(),
-                                      gain, std::greater<float>());
+                                      delta, std::greater<float>());
             m_bin_index[i][b] = static_cast<uint8_t>(std::distance(m_gain_values.begin(), it));
         }
     }
 
-    // Populate flat PSSM lookup tables for cache-friendly access in get_aligned_base_score()
+    // Populate flat PSSM lookup tables for cache-friendly access.
+    // For ABOVE (existing):
+    //   mandatory = log-zero or non-finite score → assume col_max, gain = 0
+    //   normal: score = raw, gain = col_max - raw
+    // For BELOW:
+    //   mandatory = log-zero or non-finite score → score is -Inf, total is -Inf < threshold → 0 edits
+    //   We handle this by storing the raw score and loss = raw - col_min.
+    //   In compute_exact/compute_heuristic, if any mandatory position exists, the total
+    //   adjusted_score becomes -Inf, deficit <= 0, and we return mandatory_edits (0).
+    //   For BELOW, mandatory_table marks log-zero entries: these make the score -Inf
+    //   (already below any threshold), so they contribute col_min and loss = 0.
     for (int i = 0; i < L && i < MAX_MOTIF_LEN_OPT; i++) {
         for (int b = 0; b < 4; b++) {
             float raw = m_pssm[i].get_log_prob_from_code(b);
-            bool is_mandatory = (raw <= kLogZeroThreshold || !std::isfinite(raw));
-            m_mandatory_table[i][b] = is_mandatory;
-            if (is_mandatory) {
-                m_score_table[i][b] = m_col_max_scores[i];
-                m_gain_table[i][b] = 0.0f;
+            bool is_logzero = (raw <= kLogZeroThreshold || !std::isfinite(raw));
+            if (below) {
+                // BELOW: mandatory means the score is already -Inf at this position.
+                // If the current base has -Inf score, the window score is -Inf (< threshold),
+                // so no edits are needed (handled by deficit check). Treat it as col_min with
+                // loss = 0 (no further reduction possible from this already-minimal position).
+                m_mandatory_table[i][b] = is_logzero;
+                if (is_logzero) {
+                    m_score_table[i][b] = m_col_min_scores[i];
+                    m_gain_table[i][b] = 0.0f;
+                } else {
+                    m_score_table[i][b] = raw;
+                    m_gain_table[i][b] = raw - m_col_min_scores[i];
+                }
             } else {
-                m_score_table[i][b] = raw;
-                m_gain_table[i][b] = m_col_max_scores[i] - raw;
+                // ABOVE (existing logic)
+                m_mandatory_table[i][b] = is_logzero;
+                if (is_logzero) {
+                    m_score_table[i][b] = m_col_max_scores[i];
+                    m_gain_table[i][b] = 0.0f;
+                } else {
+                    m_score_table[i][b] = raw;
+                    m_gain_table[i][b] = m_col_max_scores[i] - raw;
+                }
             }
         }
         // N-base (index 4): always mandatory
-        m_score_table[i][4] = m_col_max_scores[i];
+        if (below) {
+            m_score_table[i][4] = m_col_min_scores[i];
+        } else {
+            m_score_table[i][4] = m_col_max_scores[i];
+        }
         m_gain_table[i][4] = 0.0f;
         m_mandatory_table[i][4] = true;
     }
 
     // Build pigeonhole pre-filter blocks (must come after m_mandatory_table is populated).
-    // By the pigeonhole principle: if a sequence matches a motif with at most K total
-    // edits and we divide the motif into (K+1) non-overlapping blocks, at least one
-    // block must match exactly (0 edits). With D indels, check shifts {-D, ..., +D}.
-    //
-    // Enable when: K >= 1 (have an edit budget to pigeonhole) AND L is long enough
-    // that each block has >= 3 columns (enough selectivity to reject random sequence).
+    // Pigeonhole only applies to ABOVE direction; for BELOW, the invariant
+    // ("at least one block must match exactly") doesn't hold in the same way
+    // since we're trying to disrupt matches, not find them.
     m_use_prefilter = false;
     m_prefilter_blocks.clear();
-    {
+    if (!below) {
         int K = m_max_edits;
         // For exact mode (K < 0), K is unbounded — can't form finite block count.
         // For K == 0, we already check exact match only, no pre-filter needed.
@@ -296,10 +333,19 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    // Quick reachability check: if S_max < threshold, no substitution strategy can
-    // reach it. This is O(1) since m_S_max is precomputed.
-    if (static_cast<double>(m_S_max) < static_cast<double>(m_threshold)) {
-        return std::numeric_limits<float>::quiet_NaN();
+    const bool below = (m_direction == Direction::BELOW);
+
+    // Quick reachability check:
+    // ABOVE: if S_max < threshold, even the best possible score can't reach it.
+    // BELOW: if S_min > threshold, even the worst possible score can't go below it.
+    if (below) {
+        if (static_cast<double>(m_S_min) > static_cast<double>(m_threshold)) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
+    } else {
+        if (static_cast<double>(m_S_max) < static_cast<double>(m_threshold)) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
     }
 
     int mandatory_edits = 0;
@@ -329,7 +375,12 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
         m_exact_count[bin]++;
     }
 
-    double deficit = static_cast<double>(m_threshold) - adjusted_score;
+    // Compute deficit: how much score change we need.
+    // ABOVE: deficit = threshold - adjusted_score (need to increase score)
+    // BELOW: deficit = adjusted_score - threshold (need to decrease score)
+    double deficit = below
+        ? (adjusted_score - static_cast<double>(m_threshold))
+        : (static_cast<double>(m_threshold) - adjusted_score);
 
     // Clean up count vector using touched list before any early return
     auto cleanup = [this]() {
@@ -343,8 +394,13 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
         return static_cast<float>(mandatory_edits);
     }
 
-    double max_possible_gain = static_cast<double>(m_S_max) - adjusted_score;
-    if (max_possible_gain < deficit) {
+    // Check if the maximum possible delta can cover the deficit.
+    // ABOVE: max delta = S_max - adjusted_score
+    // BELOW: max delta = adjusted_score - S_min
+    double max_possible_delta = below
+        ? (adjusted_score - static_cast<double>(m_S_min))
+        : (static_cast<double>(m_S_max) - adjusted_score);
+    if (max_possible_delta < deficit) {
         cleanup();
         return std::numeric_limits<float>::quiet_NaN();
     }
@@ -358,12 +414,12 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
             continue;
         }
 
-        double gain = static_cast<double>(m_gain_values[j]);
-        if (gain <= 0.0) {
+        double delta_val = static_cast<double>(m_gain_values[j]);
+        if (delta_val <= 0.0) {
             continue;
         }
 
-        double cap = gain * static_cast<double>(bin_count);
+        double cap = delta_val * static_cast<double>(bin_count);
 
         if (acc + cap < deficit) {
             acc += cap;
@@ -375,7 +431,7 @@ float PWMEditDistanceScorer::compute_exact(const int* bidx, bool reverse)
                 return static_cast<float>(edits);
             }
 
-            double need_raw = remaining / gain;
+            double need_raw = remaining / delta_val;
             if (!std::isfinite(need_raw)) {
                 need_raw = static_cast<double>(bin_count);
             }
@@ -400,23 +456,30 @@ float PWMEditDistanceScorer::compute_heuristic(const int* bidx, bool reverse, in
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    // Quick reachability check: if S_max < threshold, no substitution strategy can
-    // reach it. This is O(1) since m_S_max is precomputed.
-    if (static_cast<double>(m_S_max) < static_cast<double>(m_threshold)) {
-        return std::numeric_limits<float>::quiet_NaN();
+    const bool below = (m_direction == Direction::BELOW);
+
+    // Quick reachability check:
+    // ABOVE: if S_max < threshold, no substitution strategy can reach it.
+    // BELOW: if S_min > threshold, no substitution strategy can go below it.
+    if (below) {
+        if (static_cast<double>(m_S_min) > static_cast<double>(m_threshold)) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
+    } else {
+        if (static_cast<double>(m_S_max) < static_cast<double>(m_threshold)) {
+            return std::numeric_limits<float>::quiet_NaN();
+        }
     }
 
     int mandatory_edits = 0;
     double adjusted_score = 0.0;
-    std::vector<float> gains;
-    gains.reserve(L);
+    std::vector<float> deltas;
+    deltas.reserve(L);
 
-    // Track sum of top max_k gains seen so far for suffix-bound early-abandon.
-    // This accounts for substitutions in already-scanned prefix positions.
-    // We maintain a min-heap of the top max_k gains for O(log k) updates.
-    double top_gains_sum = 0.0;
-    std::vector<float> top_gains_heap;  // min-heap of top max_k gains
-    top_gains_heap.reserve(max_k + 1);
+    // Track sum of top max_k deltas seen so far for suffix-bound early-abandon.
+    double top_deltas_sum = 0.0;
+    std::vector<float> top_deltas_heap;  // min-heap of top max_k deltas
+    top_deltas_heap.reserve(max_k + 1);
 
     for (int i = 0; i < L; i++) {
         int seq_idx = reverse ? (L - 1 - i) : i;
@@ -429,35 +492,44 @@ float PWMEditDistanceScorer::compute_heuristic(const int* bidx, bool reverse, in
         } else {
             float base_score = m_score_table[i][base_idx];
             adjusted_score += static_cast<double>(base_score);
-            float gain = m_gain_table[i][base_idx];
-            gains.push_back(gain);
+            float delta = m_gain_table[i][base_idx];
+            deltas.push_back(delta);
 
-            // Update top-k gains tracker
-            if (gain > 0.0f) {
-                if (static_cast<int>(top_gains_heap.size()) < max_k) {
-                    top_gains_heap.push_back(gain);
-                    std::push_heap(top_gains_heap.begin(), top_gains_heap.end(), std::greater<float>());
-                    top_gains_sum += static_cast<double>(gain);
-                } else if (!top_gains_heap.empty() && gain > top_gains_heap.front()) {
-                    top_gains_sum -= static_cast<double>(top_gains_heap.front());
-                    std::pop_heap(top_gains_heap.begin(), top_gains_heap.end(), std::greater<float>());
-                    top_gains_heap.back() = gain;
-                    std::push_heap(top_gains_heap.begin(), top_gains_heap.end(), std::greater<float>());
-                    top_gains_sum += static_cast<double>(gain);
+            // Update top-k deltas tracker
+            if (delta > 0.0f) {
+                if (static_cast<int>(top_deltas_heap.size()) < max_k) {
+                    top_deltas_heap.push_back(delta);
+                    std::push_heap(top_deltas_heap.begin(), top_deltas_heap.end(), std::greater<float>());
+                    top_deltas_sum += static_cast<double>(delta);
+                } else if (!top_deltas_heap.empty() && delta > top_deltas_heap.front()) {
+                    top_deltas_sum -= static_cast<double>(top_deltas_heap.front());
+                    std::pop_heap(top_deltas_heap.begin(), top_deltas_heap.end(), std::greater<float>());
+                    top_deltas_heap.back() = delta;
+                    std::push_heap(top_deltas_heap.begin(), top_deltas_heap.end(), std::greater<float>());
+                    top_deltas_sum += static_cast<double>(delta);
                 }
             }
         }
 
-        // Column-by-column suffix-bound early-abandon (sound for limited edits):
-        // adjusted_score uses actual bases (plus col_max for mandatory edits).
-        // top_gains_sum accounts for up to max_k substitutions in already-scanned prefix.
-        // m_max_suffix_score[i+1] assumes all remaining columns at their optimum.
-        // This bound is provably safe: it can never reject a reachable window because
-        // any reachable window needs actual_score + at_most_max_k_subs + suffix >= threshold,
-        // and we upper-bound all three components.
-        if (adjusted_score + top_gains_sum + static_cast<double>(m_max_suffix_score[i + 1])
-            < static_cast<double>(m_threshold)) {
-            return std::numeric_limits<float>::quiet_NaN();
+        // Column-by-column suffix-bound early-abandon:
+        // ABOVE: adjusted_score + top_k_gains + suffix_max < threshold → unreachable
+        //   (best possible: current score + best k edits from prefix + all remaining at col_max)
+        // BELOW: adjusted_score - top_k_losses + suffix_min > threshold → unreachable
+        //   (best possible: current score - best k edits from prefix + all remaining at col_min)
+        if (below) {
+            if (adjusted_score - top_deltas_sum + static_cast<double>(m_max_suffix_score[i + 1])
+                > static_cast<double>(m_threshold)) {
+                // Even with the best k losses applied + remaining columns at minimum,
+                // score stays above threshold → unreachable
+                // But only abandon if we've processed enough columns to be meaningful
+                // (early columns don't provide much pruning power)
+                return std::numeric_limits<float>::quiet_NaN();
+            }
+        } else {
+            if (adjusted_score + top_deltas_sum + static_cast<double>(m_max_suffix_score[i + 1])
+                < static_cast<double>(m_threshold)) {
+                return std::numeric_limits<float>::quiet_NaN();
+            }
         }
     }
 
@@ -465,13 +537,18 @@ float PWMEditDistanceScorer::compute_heuristic(const int* bidx, bool reverse, in
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    double deficit = static_cast<double>(m_threshold) - adjusted_score;
+    // Compute deficit
+    double deficit = below
+        ? (adjusted_score - static_cast<double>(m_threshold))
+        : (static_cast<double>(m_threshold) - adjusted_score);
     if (deficit <= 0.0) {
         return static_cast<float>(mandatory_edits);
     }
 
-    double max_possible_gain = static_cast<double>(m_S_max) - adjusted_score;
-    if (max_possible_gain < deficit) {
+    double max_possible_delta = below
+        ? (adjusted_score - static_cast<double>(m_S_min))
+        : (static_cast<double>(m_S_max) - adjusted_score);
+    if (max_possible_delta < deficit) {
         return std::numeric_limits<float>::quiet_NaN();
     }
 
@@ -480,23 +557,23 @@ float PWMEditDistanceScorer::compute_heuristic(const int* bidx, bool reverse, in
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    if (remaining_budget > static_cast<int>(gains.size())) {
-        remaining_budget = static_cast<int>(gains.size());
+    if (remaining_budget > static_cast<int>(deltas.size())) {
+        remaining_budget = static_cast<int>(deltas.size());
     }
 
     if (remaining_budget <= 0) {
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    if (remaining_budget < static_cast<int>(gains.size())) {
-        std::nth_element(gains.begin(), gains.begin() + remaining_budget, gains.end(),
+    if (remaining_budget < static_cast<int>(deltas.size())) {
+        std::nth_element(deltas.begin(), deltas.begin() + remaining_budget, deltas.end(),
                          std::greater<float>());
     }
-    std::sort(gains.begin(), gains.begin() + remaining_budget, std::greater<float>());
+    std::sort(deltas.begin(), deltas.begin() + remaining_budget, std::greater<float>());
 
     double acc = 0.0;
     for (int i = 0; i < remaining_budget; i++) {
-        acc += static_cast<double>(gains[i]);
+        acc += static_cast<double>(deltas[i]);
         if (acc >= deficit) {
             return static_cast<float>(mandatory_edits + i + 1);
         }
@@ -895,8 +972,12 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                 continue;
             }
 
-            // If score already reaches threshold, no substitutions needed
-            if (score >= static_cast<double>(m_threshold)) {
+            // If score already satisfies threshold, no substitutions needed
+            // ABOVE: score >= threshold; BELOW: score <= threshold
+            bool already_satisfied = (m_direction == Direction::BELOW)
+                ? (score <= static_cast<double>(m_threshold))
+                : (score >= static_cast<double>(m_threshold));
+            if (already_satisfied) {
                 float total_edits = static_cast<float>(k);
                 if (std::isnan(best_edits) || total_edits < best_edits) {
                     best_edits = total_edits;
@@ -945,7 +1026,11 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                     double prev = dp[idx3(ti - 1, tj - 1, tk)];
                     if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
                         std::fabs((prev + static_cast<double>(bs)) - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
-                        float gain = m_col_max_scores[ti - 1] - bs;
+                        // ABOVE: gain = col_max - bs (how much we can raise the score)
+                        // BELOW: gain = bs - col_min (how much we can lower the score)
+                        float gain = (m_direction == Direction::BELOW)
+                            ? (bs - m_col_min_scores[ti - 1])
+                            : (m_col_max_scores[ti - 1] - bs);
                         if (gain > 1e-12f) {
                             aligned_gains.push_back(gain);
                         }
@@ -977,8 +1062,10 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                 if (!found) break;  // DP inconsistency (shouldn't happen)
             }
 
-            // Compute minimum substitutions needed
-            double deficit = static_cast<double>(m_threshold) - score;
+            // Compute minimum substitutions needed (direction-aware deficit)
+            double deficit = (m_direction == Direction::BELOW)
+                ? (score - static_cast<double>(m_threshold))
+                : (static_cast<double>(m_threshold) - score);
             if (deficit <= 0.0) {
                 float total_edits = static_cast<float>(k);
                 if (std::isnan(best_edits) || total_edits < best_edits) {
@@ -1208,9 +1295,14 @@ bool PWMEditDistanceScorer::quick_deficit_check(double aligned_score, int indels
         return false;
     }
 
-    double deficit = static_cast<double>(m_threshold) - aligned_score;
+    // Direction-aware deficit:
+    // ABOVE: deficit = threshold - score (need score to increase)
+    // BELOW: deficit = score - threshold (need score to decrease)
+    double deficit = (m_direction == Direction::BELOW)
+        ? (aligned_score - static_cast<double>(m_threshold))
+        : (static_cast<double>(m_threshold) - aligned_score);
     if (deficit <= 0.0) {
-        return true;  // Already at or above threshold
+        return true;  // Already at or past threshold
     }
 
     // Compute max substitution budget
@@ -1250,7 +1342,10 @@ float PWMEditDistanceScorer::compute_min_edits_from_gains(double aligned_score,
         return std::numeric_limits<float>::quiet_NaN();
     }
 
-    double deficit = static_cast<double>(m_threshold) - aligned_score;
+    // Direction-aware deficit
+    double deficit = (m_direction == Direction::BELOW)
+        ? (aligned_score - static_cast<double>(m_threshold))
+        : (static_cast<double>(m_threshold) - aligned_score);
     if (deficit <= 0.0) {
         return static_cast<float>(indels);
     }

--- a/src/PWMEditDistanceScorer.cpp
+++ b/src/PWMEditDistanceScorer.cpp
@@ -870,11 +870,13 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
     }
 
     const int D = m_max_indels;
+    const bool below = (m_direction == Direction::BELOW);
     float best_edits = std::numeric_limits<float>::quiet_NaN();
 
     // For each sequence window length W in [L-D, L+D], align the motif (length L)
     // against W sequence bases using a 3D DP:
-    //   dp[i][j][k] = max PWM score aligning motif[0..i-1] with seq[0..j-1]
+    //   ABOVE: dp[i][j][k] = max PWM score aligning motif[0..i-1] with seq[0..j-1]
+    //   BELOW: dp[i][j][k] = min PWM score aligning motif[0..i-1] with seq[0..j-1]
     //                 using exactly k indels (insertions + deletions)
     //
     // Band constraint: |i - j| <= D (prevents needing > D indels)
@@ -882,11 +884,18 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
     // For each final state dp[L][W][k], the score tells us the PWM log-likelihood
     // of the aligned positions with their actual sequence bases. To reach the
     // threshold, we may need additional substitutions: each substitution replaces
-    // a mismatched base with the column-optimal base, gaining (col_max - current).
+    // a base with the column-optimal base for the given direction.
+    // ABOVE: gain = col_max - current (raise score toward threshold)
+    // BELOW: gain = current - col_min (lower score toward threshold)
     // We traceback to find aligned positions and greedily pick the largest gains.
     //
     // Total edits = k (indels) + subs_needed.
     // We minimize this across all W and k.
+
+    // DP initialization sentinel: -inf for ABOVE (maximize), +inf for BELOW (minimize)
+    const double dp_sentinel = below
+        ? std::numeric_limits<double>::infinity()
+        : -std::numeric_limits<double>::infinity();
 
     for (int W = std::max(1, L - D); W <= L + D; ++W) {
         if (W > seq_len) {
@@ -898,7 +907,7 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
         const int indel_levels = D + 1;  // k = 0, 1, ..., D
 
         // Flattened 3D DP table
-        std::vector<double> dp(rows * cols * indel_levels, -std::numeric_limits<double>::infinity());
+        std::vector<double> dp(rows * cols * indel_levels, dp_sentinel);
 
         auto idx3 = [cols, indel_levels](int i, int j, int k) -> int {
             return i * cols * indel_levels + j * indel_levels + k;
@@ -932,13 +941,24 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                 // because the DP traceback handles gains separately.
                 float base_score;
                 if (bi == 4) {
-                    // Unknown base: use minimum score (worst case)
-                    float min_s = std::numeric_limits<float>::infinity();
-                    for (int b = 0; b < 4; b++) {
-                        float s = m_pssm[i - 1].get_log_prob_from_code(b);
-                        if (s < min_s) min_s = s;
+                    // Unknown base: worst case for the direction
+                    // ABOVE: minimum score (hardest to reach threshold from above)
+                    // BELOW: maximum score (hardest to get below threshold)
+                    if (below) {
+                        float max_s = -std::numeric_limits<float>::infinity();
+                        for (int b = 0; b < 4; b++) {
+                            float s = m_pssm[i - 1].get_log_prob_from_code(b);
+                            if (s > max_s) max_s = s;
+                        }
+                        base_score = max_s;
+                    } else {
+                        float min_s = std::numeric_limits<float>::infinity();
+                        for (int b = 0; b < 4; b++) {
+                            float s = m_pssm[i - 1].get_log_prob_from_code(b);
+                            if (s < min_s) min_s = s;
+                        }
+                        base_score = min_s;
                     }
-                    base_score = min_s;
                 } else {
                     base_score = m_pssm[i - 1].get_log_prob_from_code(bi);
                 }
@@ -947,10 +967,21 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                     // 1. Match/Substitution (diagonal): align motif[i-1] with seq[j-1]
                     if (std::abs((i - 1) - (j - 1)) <= D) {
                         double prev = dp[idx3(i - 1, j - 1, k)];
-                        if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
-                            double new_score = prev + static_cast<double>(base_score);
-                            if (new_score > dp[idx3(i, j, k)]) {
-                                dp[idx3(i, j, k)] = new_score;
+                        if (below) {
+                            // BELOW: minimize score
+                            if (prev < std::numeric_limits<double>::infinity() * 0.5) {
+                                double new_score = prev + static_cast<double>(base_score);
+                                if (new_score < dp[idx3(i, j, k)]) {
+                                    dp[idx3(i, j, k)] = new_score;
+                                }
+                            }
+                        } else {
+                            // ABOVE: maximize score
+                            if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
+                                double new_score = prev + static_cast<double>(base_score);
+                                if (new_score > dp[idx3(i, j, k)]) {
+                                    dp[idx3(i, j, k)] = new_score;
+                                }
                             }
                         }
                     }
@@ -959,9 +990,17 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                         // 2. Insertion: skip motif[i-1], advance motif not sequence
                         if (std::abs((i - 1) - j) <= D) {
                             double prev = dp[idx3(i - 1, j, k)];
-                            if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
-                                if (prev > dp[idx3(i, j, k + 1)]) {
-                                    dp[idx3(i, j, k + 1)] = prev;
+                            if (below) {
+                                if (prev < std::numeric_limits<double>::infinity() * 0.5) {
+                                    if (prev < dp[idx3(i, j, k + 1)]) {
+                                        dp[idx3(i, j, k + 1)] = prev;
+                                    }
+                                }
+                            } else {
+                                if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
+                                    if (prev > dp[idx3(i, j, k + 1)]) {
+                                        dp[idx3(i, j, k + 1)] = prev;
+                                    }
                                 }
                             }
                         }
@@ -969,9 +1008,17 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                         // 3. Deletion: skip seq[j-1], advance sequence not motif
                         if (std::abs(i - (j - 1)) <= D) {
                             double prev = dp[idx3(i, j - 1, k)];
-                            if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
-                                if (prev > dp[idx3(i, j, k + 1)]) {
-                                    dp[idx3(i, j, k + 1)] = prev;
+                            if (below) {
+                                if (prev < std::numeric_limits<double>::infinity() * 0.5) {
+                                    if (prev < dp[idx3(i, j, k + 1)]) {
+                                        dp[idx3(i, j, k + 1)] = prev;
+                                    }
+                                }
+                            } else {
+                                if (prev > -std::numeric_limits<double>::infinity() * 0.5) {
+                                    if (prev > dp[idx3(i, j, k + 1)]) {
+                                        dp[idx3(i, j, k + 1)] = prev;
+                                    }
                                 }
                             }
                         }
@@ -983,7 +1030,11 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
         // Extract results for each indel count k
         for (int k = 0; k <= D; ++k) {
             double score = dp[idx3(L, W, k)];
-            if (score <= -std::numeric_limits<double>::infinity() * 0.5) {
+            // Check for sentinel (unreachable state)
+            bool is_sentinel = below
+                ? (score >= std::numeric_limits<double>::infinity() * 0.5)
+                : (score <= -std::numeric_limits<double>::infinity() * 0.5);
+            if (is_sentinel) {
                 continue;
             }
 
@@ -1020,6 +1071,13 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
 
                 double cur = dp[idx3(ti, tj, tk)];
 
+                // Helper: check if a DP value is a valid (non-sentinel) state
+                auto is_valid = [&](double val) -> bool {
+                    return below
+                        ? (val < std::numeric_limits<double>::infinity() * 0.5)
+                        : (val > -std::numeric_limits<double>::infinity() * 0.5);
+                };
+
                 // Try diagonal (match/substitution) first
                 bool found = false;
                 if (std::abs((ti - 1) - (tj - 1)) <= D) {
@@ -1028,22 +1086,32 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
 
                     float bs;
                     if (bi == 4) {
-                        float min_s = std::numeric_limits<float>::infinity();
-                        for (int bb = 0; bb < 4; bb++) {
-                            float s = m_pssm[ti - 1].get_log_prob_from_code(bb);
-                            if (s < min_s) min_s = s;
+                        // Unknown base: use same logic as DP fill
+                        if (below) {
+                            float max_s = -std::numeric_limits<float>::infinity();
+                            for (int bb = 0; bb < 4; bb++) {
+                                float s = m_pssm[ti - 1].get_log_prob_from_code(bb);
+                                if (s > max_s) max_s = s;
+                            }
+                            bs = max_s;
+                        } else {
+                            float min_s = std::numeric_limits<float>::infinity();
+                            for (int bb = 0; bb < 4; bb++) {
+                                float s = m_pssm[ti - 1].get_log_prob_from_code(bb);
+                                if (s < min_s) min_s = s;
+                            }
+                            bs = min_s;
                         }
-                        bs = min_s;
                     } else {
                         bs = m_pssm[ti - 1].get_log_prob_from_code(bi);
                     }
 
                     double prev = dp[idx3(ti - 1, tj - 1, tk)];
-                    if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
+                    if (is_valid(prev) &&
                         std::fabs((prev + static_cast<double>(bs)) - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
                         // ABOVE: gain = col_max - bs (how much we can raise the score)
                         // BELOW: gain = bs - col_min (how much we can lower the score)
-                        float gain = (m_direction == Direction::BELOW)
+                        float gain = below
                             ? (bs - m_col_min_scores[ti - 1])
                             : (m_col_max_scores[ti - 1] - bs);
                         if (gain > 1e-12f) {
@@ -1057,7 +1125,7 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                 if (!found && ti > 0 && tk > 0 && std::abs((ti - 1) - tj) <= D) {
                     // Try insertion
                     double prev = dp[idx3(ti - 1, tj, tk - 1)];
-                    if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
+                    if (is_valid(prev) &&
                         std::fabs(prev - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
                         ti--; tk--;
                         found = true;
@@ -1067,7 +1135,7 @@ float PWMEditDistanceScorer::compute_with_indels(const int* bidx_arr, int seq_le
                 if (!found && tj > 0 && tk > 0 && std::abs(ti - (tj - 1)) <= D) {
                     // Try deletion
                     double prev = dp[idx3(ti, tj - 1, tk - 1)];
-                    if (prev > -std::numeric_limits<double>::infinity() * 0.5 &&
+                    if (is_valid(prev) &&
                         std::fabs(prev - cur) < 1e-9 * std::max(1.0, std::fabs(cur))) {
                         tj--; tk--;
                         found = true;
@@ -1129,27 +1197,23 @@ bool PWMEditDistanceScorer::early_abandon_banded_dp(const char* seq_ptr, int seq
     // Banded DP early-abandon filter for indel-enabled windows.
     //
     // Key insight: the edit distance metric allows substitutions at any matched
-    // position. Each substitution brings a column's score to col_max. Therefore,
-    // the DP must use col_max for every matched column (diagonal transition) to
-    // correctly upper-bound the achievable score. This makes the filter
-    // sequence-independent — it only depends on the motif structure and available
-    // sequence length.
+    // position. Each substitution brings a column's score to its optimal value
+    // for the given direction.
     //
-    // dp[i][j][k] = best achievable PWM score aligning motif[0..i-1] with
-    //   j sequence positions using k indels, where each matched column
-    //   contributes col_max[motif_col] (assuming optimal substitution).
+    // ABOVE: each matched column achieves col_max (upper-bound on score).
+    //   dp computes max achievable score. Abandon if row_max + suffix_max < threshold.
+    // BELOW: each matched column achieves col_min (lower-bound on score).
+    //   dp computes min achievable score. Abandon if row_min + suffix_min > threshold.
     //
     // Band constraint: |i - j| <= D.
     //
-    // After each row i, checks: row_max + suffix_score[i] < threshold?
-    // If so, no alignment family can reach the threshold => skip.
-    //
     // For insertion-heavy families (many motif columns skipped), the achievable
-    // score drops because fewer columns contribute col_max. This is where the
-    // filter provides value.
+    // score changes because fewer columns contribute. This is where the filter
+    // provides value.
 
     const int L = m_pssm.length();
     const int D = m_max_indels;
+    const bool below = (m_direction == Direction::BELOW);
 
     if (L == 0 || D < 0) return false;
 
@@ -1167,13 +1231,14 @@ bool PWMEditDistanceScorer::early_abandon_banded_dp(const char* seq_ptr, int seq
     double dp_prev[MAX_J][KD];
     double dp_cur[MAX_J][KD];
 
-    constexpr double NEG_INF = -1e300;
+    // ABOVE: sentinel = -inf (maximizing), BELOW: sentinel = +inf (minimizing)
+    const double SENTINEL = below ? 1e300 : -1e300;
     const double threshold_d = static_cast<double>(m_threshold);
 
-    // Initialize dp_prev (row 0) to -inf
+    // Initialize dp_prev (row 0) to sentinel
     for (int j = 0; j <= max_j; j++) {
         for (int k = 0; k <= D; k++) {
-            dp_prev[j][k] = NEG_INF;
+            dp_prev[j][k] = SENTINEL;
         }
     }
 
@@ -1185,8 +1250,16 @@ bool PWMEditDistanceScorer::early_abandon_banded_dp(const char* seq_ptr, int seq
     }
 
     // Early abandon check for row 0
-    if (0.0 + static_cast<double>(m_max_suffix_score[0]) < threshold_d) {
-        return true;
+    // ABOVE: 0 + suffix_max < threshold => skip
+    // BELOW: 0 + suffix_min > threshold => skip
+    if (below) {
+        if (0.0 + static_cast<double>(m_max_suffix_score[0]) > threshold_d) {
+            return true;
+        }
+    } else {
+        if (0.0 + static_cast<double>(m_max_suffix_score[0]) < threshold_d) {
+            return true;
+        }
     }
 
     // Row-by-row fill
@@ -1197,7 +1270,7 @@ bool PWMEditDistanceScorer::early_abandon_banded_dp(const char* seq_ptr, int seq
         // Initialize dp_cur for this row's range
         for (int j = j_lo; j <= j_hi; j++) {
             for (int k = 0; k <= D; k++) {
-                dp_cur[j][k] = NEG_INF;
+                dp_cur[j][k] = SENTINEL;
             }
         }
 
@@ -1205,34 +1278,42 @@ bool PWMEditDistanceScorer::early_abandon_banded_dp(const char* seq_ptr, int seq
         if (j_lo == 0) {
             for (int k = 1; k <= D; k++) {
                 double prev = dp_prev[0][k - 1];
-                if (prev > NEG_INF && prev > dp_cur[0][k]) {
+                bool is_valid = below ? (prev < SENTINEL) : (prev > SENTINEL);
+                bool is_better = below ? (prev < dp_cur[0][k]) : (prev > dp_cur[0][k]);
+                if (is_valid && is_better) {
                     dp_cur[0][k] = prev;
                 }
             }
         }
 
-        // Use col_max for match score: since substitutions are allowed,
-        // every matched column can achieve its maximum PSSM score.
-        const double col_max_score = static_cast<double>(m_col_max_scores[i - 1]);
+        // ABOVE: use col_max (substitutions can raise score to maximum)
+        // BELOW: use col_min (substitutions can lower score to minimum)
+        const double col_score = below
+            ? static_cast<double>(m_col_min_scores[i - 1])
+            : static_cast<double>(m_col_max_scores[i - 1]);
 
         for (int j = std::max(1, j_lo); j <= j_hi; j++) {
             for (int k = 0; k <= D; k++) {
-                double val = NEG_INF;
+                double val = SENTINEL;
 
-                // 1. Match (diagonal): dp_prev[j-1][k] + col_max
+                // 1. Match (diagonal): dp_prev[j-1][k] + col_score
                 //    Substitution is free in edit-distance terms (counted separately).
                 if (std::abs((i - 1) - (j - 1)) <= D) {
                     double prev = dp_prev[j - 1][k];
-                    if (prev > NEG_INF) {
-                        double cand = prev + col_max_score;
-                        if (cand > val) val = cand;
+                    bool is_valid = below ? (prev < SENTINEL) : (prev > SENTINEL);
+                    if (is_valid) {
+                        double cand = prev + col_score;
+                        bool is_better = below ? (cand < val) : (cand > val);
+                        if (is_better) val = cand;
                     }
                 }
 
                 // 2. Insertion (skip motif[i-1]): dp_prev[j][k-1]
                 if (k >= 1 && std::abs((i - 1) - j) <= D) {
                     double prev = dp_prev[j][k - 1];
-                    if (prev > NEG_INF && prev > val) {
+                    bool is_valid = below ? (prev < SENTINEL) : (prev > SENTINEL);
+                    bool is_better = below ? (prev < val) : (prev > val);
+                    if (is_valid && is_better) {
                         val = prev;
                     }
                 }
@@ -1240,35 +1321,49 @@ bool PWMEditDistanceScorer::early_abandon_banded_dp(const char* seq_ptr, int seq
                 // 3. Deletion (skip seq[j-1]): dp_cur[j-1][k-1]
                 if (k >= 1) {
                     double prev = dp_cur[j - 1][k - 1];
-                    if (prev > NEG_INF && prev > val) {
+                    bool is_valid = below ? (prev < SENTINEL) : (prev > SENTINEL);
+                    bool is_better = below ? (prev < val) : (prev > val);
+                    if (is_valid && is_better) {
                         val = prev;
                     }
                 }
 
-                if (val > dp_cur[j][k]) {
+                bool val_better = below ? (val < dp_cur[j][k]) : (val > dp_cur[j][k]);
+                if (val_better) {
                     dp_cur[j][k] = val;
                 }
             }
         }
 
-        // Early abandon: find row maximum across all valid (j, k)
-        double row_max = NEG_INF;
+        // Early abandon: find row optimum across all valid (j, k)
+        // ABOVE: row_max + suffix_max < threshold => skip
+        // BELOW: row_min + suffix_min > threshold => skip
+        double row_opt = SENTINEL;
         for (int j = j_lo; j <= j_hi; j++) {
             for (int k = 0; k <= D; k++) {
-                if (dp_cur[j][k] > row_max) {
-                    row_max = dp_cur[j][k];
+                bool is_better = below
+                    ? (dp_cur[j][k] < row_opt)
+                    : (dp_cur[j][k] > row_opt);
+                if (is_better) {
+                    row_opt = dp_cur[j][k];
                 }
             }
         }
 
-        if (row_max + static_cast<double>(m_max_suffix_score[i]) < threshold_d) {
-            return true;
+        if (below) {
+            if (row_opt + static_cast<double>(m_max_suffix_score[i]) > threshold_d) {
+                return true;
+            }
+        } else {
+            if (row_opt + static_cast<double>(m_max_suffix_score[i]) < threshold_d) {
+                return true;
+            }
         }
 
         // Swap rows
         for (int j = 0; j <= max_j; j++) {
             for (int k = 0; k <= D; k++) {
-                dp_prev[j][k] = NEG_INF;
+                dp_prev[j][k] = SENTINEL;
             }
         }
         for (int j = j_lo; j <= j_hi; j++) {

--- a/src/PWMEditDistanceScorer.h
+++ b/src/PWMEditDistanceScorer.h
@@ -140,6 +140,48 @@ private:
     std::vector<PrefilterBlock> m_prefilter_blocks;
     bool m_use_prefilter;
 
+    // Direction-aware helper methods — avoid scattered if/else throughout the code
+    inline bool is_below() const { return m_direction == Direction::BELOW; }
+
+    /** Compute the deficit: how much score must change to satisfy the threshold. */
+    inline double compute_deficit(double score) const {
+        return is_below() ? (score - static_cast<double>(m_threshold))
+                          : (static_cast<double>(m_threshold) - score);
+    }
+
+    /** Check whether the score already satisfies the threshold. */
+    inline bool threshold_satisfied(double score) const {
+        return is_below() ? (score <= static_cast<double>(m_threshold))
+                          : (score >= static_cast<double>(m_threshold));
+    }
+
+    /** Max possible delta achievable from the given score (using all optimal edits). */
+    inline double max_possible_delta(double score) const {
+        return is_below() ? (score - static_cast<double>(m_S_min))
+                          : (static_cast<double>(m_S_max) - score);
+    }
+
+    /** Global reachability: can the threshold ever be reached from any sequence? */
+    inline bool is_globally_reachable() const {
+        return is_below() ? (static_cast<double>(m_S_min) <= static_cast<double>(m_threshold))
+                          : (static_cast<double>(m_S_max) >= static_cast<double>(m_threshold));
+    }
+
+    /** Compute per-position delta value (gain for ABOVE, loss for BELOW). */
+    inline float compute_position_delta(float score, int col_idx) const {
+        if (is_below()) {
+            bool is_logzero = (score <= -1e30f || !std::isfinite(score));
+            return is_logzero ? 0.0f : (score - m_col_min_scores[col_idx]);
+        } else {
+            return m_col_max_scores[col_idx] - score;
+        }
+    }
+
+    /** Target score for a position after editing (col_max for ABOVE, col_min for BELOW). */
+    inline float target_score(int col_idx) const {
+        return is_below() ? m_col_min_scores[col_idx] : m_col_max_scores[col_idx];
+    }
+
     /**
      * Precompute gain value bins and lookup tables (called once in constructor)
      */

--- a/src/PWMEditDistanceScorer.h
+++ b/src/PWMEditDistanceScorer.h
@@ -39,6 +39,11 @@ public:
         PWM_MAX_EDITS
     };
 
+    enum class Direction {
+        ABOVE,  // minimum edits to bring score >= threshold (default)
+        BELOW   // minimum edits to bring score <= threshold
+    };
+
     /**
      * Constructor
      * @param pssm The Position-Specific Scoring Matrix
@@ -51,6 +56,8 @@ public:
      * @param score_min Minimum PWM score filter (NaN = no filter)
      * @param max_indels Maximum number of insertions+deletions allowed (0 = substitutions only)
      * @param score_max Maximum PWM score filter (NaN = no filter)
+     * @param direction ABOVE = min edits to reach score >= threshold;
+     *                  BELOW = min edits to bring score <= threshold
      */
     PWMEditDistanceScorer(const DnaPSSM& pssm,
                           GenomeSeqFetch* shared_seqfetch,
@@ -61,7 +68,8 @@ public:
                           Mode mode = Mode::MIN_EDITS,
                           float score_min = std::numeric_limits<float>::quiet_NaN(),
                           int max_indels = 0,
-                          float score_max = std::numeric_limits<float>::quiet_NaN());
+                          float score_max = std::numeric_limits<float>::quiet_NaN(),
+                          Direction direction = Direction::ABOVE);
 
     /**
      * Score a genomic interval - returns minimum edits needed
@@ -95,17 +103,20 @@ private:
     int m_max_edits;  // -1 = exact computation, >=1 = fast heuristic
     int m_max_indels; // 0 = substitutions only, >=1 = allow insertions/deletions via banded NW DP
     Mode m_mode;
+    Direction m_direction;  // ABOVE = edits to raise score >= threshold; BELOW = edits to lower score <= threshold
     float m_score_min; // NaN = no filter; otherwise skip windows with PWM score < this
     float m_score_max; // NaN = no filter; otherwise skip windows with PWM score > this
     ScanMetrics m_last_metrics;
 
     // Precomputed tables for exact mode
     std::vector<float> m_col_max_scores;     // s_max[i] - max score per column
-    std::vector<float> m_gain_values;        // V[1..M] - sorted descending
+    std::vector<float> m_col_min_scores;     // s_min[i] - min score per column (for BELOW direction)
+    std::vector<float> m_gain_values;        // V[1..M] - sorted descending (gains for ABOVE, losses for BELOW)
     std::vector<std::vector<uint8_t>> m_bin_index;  // bin[i][b] - lookup table
     float m_S_max;                           // sum of column maxima
+    float m_S_min;                           // sum of column minima (for BELOW direction)
     std::vector<float> m_max_suffix_score;   // m_max_suffix_score[i] = sum of col maxima from i to L-1
-    std::vector<float> m_max_gain_budget;    // m_max_gain_budget[k] = max total gain from k substitutions (per-PSSM)
+    std::vector<float> m_max_gain_budget;    // m_max_gain_budget[k] = max total gain/loss from k substitutions (per-PSSM)
 
     // Flat precomputed PSSM lookup tables for cache-friendly access
     static constexpr int MAX_MOTIF_LEN_OPT = 64;

--- a/src/PWMLseEditDistanceScorer.cpp
+++ b/src/PWMLseEditDistanceScorer.cpp
@@ -14,16 +14,19 @@ PWMLseEditDistanceScorer::PWMLseEditDistanceScorer(const DnaPSSM& pssm,
                                                      char strand,
                                                      Mode mode,
                                                      float score_min,
-                                                     float score_max)
+                                                     float score_max,
+                                                     Direction direction)
     : GenomeSeqScorer(shared_seqfetch, extend, strand),
       m_pssm(pssm),
       m_threshold(threshold),
       m_max_edits(max_edits),
       m_mode(mode),
+      m_direction(direction),
       m_score_min(score_min),
       m_score_max(score_max),
       m_last_min_edits(std::numeric_limits<float>::quiet_NaN()),
-      m_S_max(0.0f)
+      m_S_max(0.0f),
+      m_S_min(0.0f)
 {
     precompute_tables();
 }
@@ -32,18 +35,26 @@ void PWMLseEditDistanceScorer::precompute_tables()
 {
     int L = m_pssm.length();
     m_col_max_scores.resize(L);
+    m_col_min_scores.resize(L);
     m_S_max = 0.0f;
+    m_S_min = 0.0f;
 
     for (int i = 0; i < L; i++) {
         float max_score = -std::numeric_limits<float>::infinity();
+        float min_score = std::numeric_limits<float>::infinity();
         for (int b = 0; b < 4; b++) {
             float score = m_pssm[i].get_log_prob_from_code(b);
             if (score > max_score) {
                 max_score = score;
             }
+            if (score < min_score) {
+                min_score = score;
+            }
         }
         m_col_max_scores[i] = max_score;
+        m_col_min_scores[i] = min_score;
         m_S_max += max_score;
+        m_S_min += min_score;
     }
 }
 
@@ -305,8 +316,12 @@ PWMLseEditDistanceScorer::try_k1_exhaustive(const std::vector<int>& seq_bases,
     LseResult result;
     double T = static_cast<double>(m_threshold);
     int R = static_cast<int>(seq_bases.size());
+    const bool is_below = (m_direction == Direction::BELOW);
 
-    double best_F_after = -std::numeric_limits<double>::infinity();
+    // For ABOVE: track best (highest) F after edit
+    // For BELOW: track best (lowest) F after edit
+    double best_F_after = is_below ? std::numeric_limits<double>::infinity()
+                                   : -std::numeric_limits<double>::infinity();
     int best_q = -1;
 
     for (int q = 0; q < R; q++) {
@@ -319,9 +334,11 @@ PWMLseEditDistanceScorer::try_k1_exhaustive(const std::vector<int>& seq_bases,
             if (new_Z <= 0.0) continue;
 
             double new_F = std::log(new_Z) + m;
-            if (new_F >= T) {
+            bool meets_threshold = is_below ? (new_F <= T) : (new_F >= T);
+            if (meets_threshold) {
                 // Found a valid 1-edit solution
-                if (new_F > best_F_after) {
+                bool is_better = is_below ? (new_F < best_F_after) : (new_F > best_F_after);
+                if (is_better) {
                     best_F_after = new_F;
                     best_q = q;
                 }
@@ -351,8 +368,10 @@ PWMLseEditDistanceScorer::try_k2_exhaustive(const std::vector<int>& seq_bases,
 {
     LseResult result;
     double T = static_cast<double>(m_threshold);
+    const bool is_below = (m_direction == Direction::BELOW);
 
-    double best_F_after = -std::numeric_limits<double>::infinity();
+    double best_F_after = is_below ? std::numeric_limits<double>::infinity()
+                                   : -std::numeric_limits<double>::infinity();
     int best_q1 = -1;
 
     // For each first edit (q1, y1)
@@ -426,8 +445,10 @@ PWMLseEditDistanceScorer::try_k2_exhaustive(const std::vector<int>& seq_bases,
                     if (new_Z <= 0.0) continue;
 
                     double new_F = std::log(new_Z) + m;
-                    if (new_F >= T) {
-                        if (new_F > best_F_after) {
+                    bool meets_threshold = is_below ? (new_F <= T) : (new_F >= T);
+                    if (meets_threshold) {
+                        bool is_better = is_below ? (new_F < best_F_after) : (new_F > best_F_after);
+                        if (is_better) {
                             best_F_after = new_F;
                             best_q1 = q1;
                         }
@@ -462,6 +483,7 @@ PWMLseEditDistanceScorer::greedy_search(std::vector<int>& seq_bases,
 {
     LseResult result;
     double T = static_cast<double>(m_threshold);
+    const bool is_below = (m_direction == Direction::BELOW);
 
     // Apply prior edits (from exhaustive k=2 that failed)
     if (first_edit_pos >= 0) {
@@ -473,7 +495,8 @@ PWMLseEditDistanceScorer::greedy_search(std::vector<int>& seq_bases,
         F = std::log(Z) + m;
     }
 
-    if (F >= T) {
+    bool threshold_met = is_below ? (F <= T) : (F >= T);
+    if (threshold_met) {
         result.min_edits = static_cast<float>(edits_so_far);
         if (first_edit_pos >= 0) {
             result.best_edit_index = first_edit_pos;
@@ -488,114 +511,223 @@ PWMLseEditDistanceScorer::greedy_search(std::vector<int>& seq_bases,
     int k = edits_so_far;
     int max_k = (m_max_edits > 0) ? m_max_edits : R;  // Practical limit
 
-    // Greedy: use a max-heap with stale-key checking
-    // Heap entry: (delta_z, position, best_base)
-    struct HeapEntry {
-        double delta_z;
-        int pos;
-        int best_base;
-        bool operator<(const HeapEntry& o) const { return delta_z < o.delta_z; }
-    };
+    if (is_below) {
+        // BELOW direction: use a min-heap (most negative delta_z first)
+        // We want to DECREASE F, so pick edits with most negative delta_z
+        struct MinHeapEntry {
+            double delta_z;  // negative values are better
+            int pos;
+            int best_base;
+            // Min-heap: smallest delta_z has highest priority
+            bool operator<(const MinHeapEntry& o) const { return delta_z > o.delta_z; }
+        };
 
-    // Initialize heap with DeltaZ for all positions
-    std::priority_queue<HeapEntry> heap;
-    std::vector<double> stored_dz(R, 0.0);
+        std::priority_queue<MinHeapEntry> heap;
+        std::vector<double> stored_dz(R, 0.0);
 
-    for (int q = 0; q < R; q++) {
-        int cur = seq_bases[q];
-        double best_dz = -std::numeric_limits<double>::infinity();
-        int best_y = -1;
-
-        for (int y = 0; y < 4; y++) {
-            if (y == cur) continue;
-            double dz = compute_delta_z(q, y, seq_bases, A_p, N, L);
-            if (dz > best_dz) {
-                best_dz = dz;
-                best_y = y;
-            }
-        }
-
-        if (best_y >= 0 && best_dz > 0.0) {
-            stored_dz[q] = best_dz;
-            heap.push({best_dz, q, best_y});
-        }
-    }
-
-    while (F < T && !heap.empty() && k < max_k) {
-        HeapEntry top = heap.top();
-        heap.pop();
-
-        int q = top.pos;
-
-        // Stale-key check: recompute DeltaZ
-        int cur = seq_bases[q];
-        double best_dz = -std::numeric_limits<double>::infinity();
-        int best_y = -1;
-
-        for (int y = 0; y < 4; y++) {
-            if (y == cur) continue;
-            double dz = compute_delta_z(q, y, seq_bases, A_p, N, L);
-            if (dz > best_dz) {
-                best_dz = dz;
-                best_y = y;
-            }
-        }
-
-        if (best_dz <= 0.0) {
-            continue;  // No improvement possible at this position
-        }
-
-        // Check if key is stale (recomputed value significantly different)
-        if (best_dz < top.delta_z - 1e-10 && !heap.empty() && best_dz < heap.top().delta_z) {
-            // Push back with updated key
-            stored_dz[q] = best_dz;
-            heap.push({best_dz, q, best_y});
-            continue;
-        }
-
-        // Apply edit
-        apply_edit(q, best_y, seq_bases, S_p, A_p, Z, m, N, L);
-        F = std::log(Z) + m;
-        k++;
-
-        if (first_greedy_edit_pos < 0) {
-            first_greedy_edit_pos = q;
-        }
-
-        // Recompute DeltaZ in the (2L-1)-wide diamond around q
-        int q_lo = std::max(0, q - L + 1);
-        int q_hi = std::min(R - 1, q + L - 1);
-
-        for (int qp = q_lo; qp <= q_hi; qp++) {
-            int curp = seq_bases[qp];
-            double best_dzp = -std::numeric_limits<double>::infinity();
-            int best_yp = -1;
+        for (int q = 0; q < R; q++) {
+            int cur = seq_bases[q];
+            double best_dz = std::numeric_limits<double>::infinity();  // want most negative
+            int best_y = -1;
 
             for (int y = 0; y < 4; y++) {
-                if (y == curp) continue;
-                double dz = compute_delta_z(qp, y, seq_bases, A_p, N, L);
-                if (dz > best_dzp) {
-                    best_dzp = dz;
-                    best_yp = y;
+                if (y == cur) continue;
+                double dz = compute_delta_z(q, y, seq_bases, A_p, N, L);
+                if (dz < best_dz) {
+                    best_dz = dz;
+                    best_y = y;
                 }
             }
 
-            if (best_yp >= 0 && best_dzp > 0.0) {
-                stored_dz[qp] = best_dzp;
-                heap.push({best_dzp, qp, best_yp});
+            if (best_y >= 0 && best_dz < 0.0) {
+                stored_dz[q] = best_dz;
+                heap.push({best_dz, q, best_y});
             }
         }
-    }
 
-    if (F >= T) {
-        result.min_edits = static_cast<float>(k);
-        // Position: report the first edit position
-        int report_pos = (first_edit_pos >= 0) ? first_edit_pos : first_greedy_edit_pos;
-        if (report_pos >= 0) {
-            result.best_edit_index = report_pos;
-            result.best_edit_direction = direction;
-            result.best_pos = encode_position(static_cast<size_t>(report_pos),
-                                              target_length, motif_length, direction);
+        while (F > T && !heap.empty() && k < max_k) {
+            MinHeapEntry top = heap.top();
+            heap.pop();
+
+            int q = top.pos;
+
+            // Stale-key check: recompute DeltaZ
+            int cur = seq_bases[q];
+            double best_dz = std::numeric_limits<double>::infinity();
+            int best_y = -1;
+
+            for (int y = 0; y < 4; y++) {
+                if (y == cur) continue;
+                double dz = compute_delta_z(q, y, seq_bases, A_p, N, L);
+                if (dz < best_dz) {
+                    best_dz = dz;
+                    best_y = y;
+                }
+            }
+
+            if (best_dz >= 0.0) {
+                continue;  // No score decrease possible at this position
+            }
+
+            // Check if key is stale (recomputed value significantly different)
+            if (best_dz > top.delta_z + 1e-10 && !heap.empty() && best_dz > heap.top().delta_z) {
+                stored_dz[q] = best_dz;
+                heap.push({best_dz, q, best_y});
+                continue;
+            }
+
+            // Apply edit
+            apply_edit(q, best_y, seq_bases, S_p, A_p, Z, m, N, L);
+            F = std::log(Z) + m;
+            k++;
+
+            if (first_greedy_edit_pos < 0) {
+                first_greedy_edit_pos = q;
+            }
+
+            // Recompute DeltaZ in the (2L-1)-wide diamond around q
+            int q_lo = std::max(0, q - L + 1);
+            int q_hi = std::min(R - 1, q + L - 1);
+
+            for (int qp = q_lo; qp <= q_hi; qp++) {
+                int curp = seq_bases[qp];
+                double best_dzp = std::numeric_limits<double>::infinity();
+                int best_yp = -1;
+
+                for (int y = 0; y < 4; y++) {
+                    if (y == curp) continue;
+                    double dz = compute_delta_z(qp, y, seq_bases, A_p, N, L);
+                    if (dz < best_dzp) {
+                        best_dzp = dz;
+                        best_yp = y;
+                    }
+                }
+
+                if (best_yp >= 0 && best_dzp < 0.0) {
+                    stored_dz[qp] = best_dzp;
+                    heap.push({best_dzp, qp, best_yp});
+                }
+            }
+        }
+
+        if (F <= T) {
+            result.min_edits = static_cast<float>(k);
+            int report_pos = (first_edit_pos >= 0) ? first_edit_pos : first_greedy_edit_pos;
+            if (report_pos >= 0) {
+                result.best_edit_index = report_pos;
+                result.best_edit_direction = direction;
+                result.best_pos = encode_position(static_cast<size_t>(report_pos),
+                                                  target_length, motif_length, direction);
+            }
+        }
+    } else {
+        // ABOVE direction: use a max-heap (original logic)
+        struct HeapEntry {
+            double delta_z;
+            int pos;
+            int best_base;
+            bool operator<(const HeapEntry& o) const { return delta_z < o.delta_z; }
+        };
+
+        std::priority_queue<HeapEntry> heap;
+        std::vector<double> stored_dz(R, 0.0);
+
+        for (int q = 0; q < R; q++) {
+            int cur = seq_bases[q];
+            double best_dz = -std::numeric_limits<double>::infinity();
+            int best_y = -1;
+
+            for (int y = 0; y < 4; y++) {
+                if (y == cur) continue;
+                double dz = compute_delta_z(q, y, seq_bases, A_p, N, L);
+                if (dz > best_dz) {
+                    best_dz = dz;
+                    best_y = y;
+                }
+            }
+
+            if (best_y >= 0 && best_dz > 0.0) {
+                stored_dz[q] = best_dz;
+                heap.push({best_dz, q, best_y});
+            }
+        }
+
+        while (F < T && !heap.empty() && k < max_k) {
+            HeapEntry top = heap.top();
+            heap.pop();
+
+            int q = top.pos;
+
+            // Stale-key check: recompute DeltaZ
+            int cur = seq_bases[q];
+            double best_dz = -std::numeric_limits<double>::infinity();
+            int best_y = -1;
+
+            for (int y = 0; y < 4; y++) {
+                if (y == cur) continue;
+                double dz = compute_delta_z(q, y, seq_bases, A_p, N, L);
+                if (dz > best_dz) {
+                    best_dz = dz;
+                    best_y = y;
+                }
+            }
+
+            if (best_dz <= 0.0) {
+                continue;  // No improvement possible at this position
+            }
+
+            // Check if key is stale (recomputed value significantly different)
+            if (best_dz < top.delta_z - 1e-10 && !heap.empty() && best_dz < heap.top().delta_z) {
+                // Push back with updated key
+                stored_dz[q] = best_dz;
+                heap.push({best_dz, q, best_y});
+                continue;
+            }
+
+            // Apply edit
+            apply_edit(q, best_y, seq_bases, S_p, A_p, Z, m, N, L);
+            F = std::log(Z) + m;
+            k++;
+
+            if (first_greedy_edit_pos < 0) {
+                first_greedy_edit_pos = q;
+            }
+
+            // Recompute DeltaZ in the (2L-1)-wide diamond around q
+            int q_lo = std::max(0, q - L + 1);
+            int q_hi = std::min(R - 1, q + L - 1);
+
+            for (int qp = q_lo; qp <= q_hi; qp++) {
+                int curp = seq_bases[qp];
+                double best_dzp = -std::numeric_limits<double>::infinity();
+                int best_yp = -1;
+
+                for (int y = 0; y < 4; y++) {
+                    if (y == curp) continue;
+                    double dz = compute_delta_z(qp, y, seq_bases, A_p, N, L);
+                    if (dz > best_dzp) {
+                        best_dzp = dz;
+                        best_yp = y;
+                    }
+                }
+
+                if (best_yp >= 0 && best_dzp > 0.0) {
+                    stored_dz[qp] = best_dzp;
+                    heap.push({best_dzp, qp, best_yp});
+                }
+            }
+        }
+
+        if (F >= T) {
+            result.min_edits = static_cast<float>(k);
+            // Position: report the first edit position
+            int report_pos = (first_edit_pos >= 0) ? first_edit_pos : first_greedy_edit_pos;
+            if (report_pos >= 0) {
+                result.best_edit_index = report_pos;
+                result.best_edit_direction = direction;
+                result.best_pos = encode_position(static_cast<size_t>(report_pos),
+                                                  target_length, motif_length, direction);
+            }
         }
     }
 
@@ -647,18 +779,37 @@ PWMLseEditDistanceScorer::compute_lse_edit_distance(const std::string& seq,
     }
 
     double T = static_cast<double>(m_threshold);
+    const bool is_below = (m_direction == Direction::BELOW);
 
-    // Already above threshold? 0 edits needed
-    if (F >= T) {
+    // Already at target? 0 edits needed
+    if (is_below ? (F <= T) : (F >= T)) {
         result.min_edits = 0.0f;
         result.best_pos = std::numeric_limits<float>::quiet_NaN();  // No edit needed
         return result;
     }
 
-    // Quick unreachability check: S_max + log(N) is the maximum possible F
-    double max_possible_F = static_cast<double>(m_S_max) + std::log(static_cast<double>(N));
-    if (T > max_possible_F + 1e-9) {
-        return result;  // Unreachable even with all bases optimal
+    // Quick unreachability check
+    if (is_below) {
+        // For BELOW: minimum possible F uses worst base at every position
+        // F_min = log(sum(exp(S_p_min))) where S_p_min uses col_min at each column
+        // Lower bound: F_min >= S_min + log(N) is NOT correct (that's for max).
+        // Actually: F_min = log(N) + S_min only if all starts have same score S_min,
+        // but starts overlap so S_p_min varies. Conservative lower bound:
+        // The minimum F is at least S_min_single (the min single-window score)
+        // since log(sum(exp(S_p))) >= max(S_p) >= min(S_p) >= S_min.
+        // Actually log(sum(exp(S_p))) >= max(S_p), so even with all worst bases,
+        // the min of max(S_p) across all possible sequences is S_min (sum of col minima).
+        // So F >= S_min. If T < S_min, it's unreachable.
+        double min_possible_F = static_cast<double>(m_S_min);
+        if (T < min_possible_F - 1e-9) {
+            return result;  // Unreachable: F can never go below S_min
+        }
+    } else {
+        // For ABOVE: S_max + log(N) is the maximum possible F
+        double max_possible_F = static_cast<double>(m_S_max) + std::log(static_cast<double>(N));
+        if (T > max_possible_F + 1e-9) {
+            return result;  // Unreachable even with all bases optimal
+        }
     }
 
     // Check max_edits cap

--- a/src/PWMLseEditDistanceScorer.h
+++ b/src/PWMLseEditDistanceScorer.h
@@ -8,13 +8,15 @@
 #include <queue>
 #include "GenomeSeqScorer.h"
 #include "DnaPSSM.h"
+#include "PWMEditDistanceScorer.h"
 
 /**
  * PWMLseEditDistanceScorer: Computes LSE-mode edit distance for PWM.
  *
  * Given an interval with sequence, the LSE score is F = log(sum(exp(S_p)))
  * where S_p is the PWM score at start position p. This scorer finds the
- * minimum number of base edits (substitutions) to raise F above score.thresh.
+ * minimum number of base edits (substitutions) to bring F above or below
+ * score.thresh, depending on the direction parameter.
  *
  * Algorithm:
  *  - Exhaustive search for k <= 2 (O(RL^2), provably optimal)
@@ -32,6 +34,8 @@ public:
         LSE_EDIT_DISTANCE_POS
     };
 
+    using Direction = PWMEditDistanceScorer::Direction;
+
     /**
      * Constructor
      * @param pssm The Position-Specific Scoring Matrix
@@ -43,6 +47,8 @@ public:
      * @param mode Return mode
      * @param score_min Minimum LSE score filter (NaN = no filter)
      * @param score_max Maximum LSE score filter (NaN = no filter)
+     * @param direction ABOVE = min edits to bring F >= threshold;
+     *                  BELOW = min edits to bring F <= threshold
      */
     PWMLseEditDistanceScorer(const DnaPSSM& pssm,
                              GenomeSeqFetch* shared_seqfetch,
@@ -52,7 +58,8 @@ public:
                              char strand = 0,
                              Mode mode = Mode::LSE_EDIT_DISTANCE,
                              float score_min = std::numeric_limits<float>::quiet_NaN(),
-                             float score_max = std::numeric_limits<float>::quiet_NaN());
+                             float score_max = std::numeric_limits<float>::quiet_NaN(),
+                             Direction direction = Direction::ABOVE);
 
     /**
      * Score a genomic interval - returns minimum edits or position
@@ -66,13 +73,16 @@ private:
     float m_threshold;
     int m_max_edits;
     Mode m_mode;
+    Direction m_direction;
     float m_score_min;
     float m_score_max;
     float m_last_min_edits;
 
     // Precomputed tables
     std::vector<float> m_col_max_scores;  // max score per column
+    std::vector<float> m_col_min_scores;  // min score per column (for BELOW direction)
     float m_S_max;                        // sum of column maxima
+    float m_S_min;                        // sum of column minima (for BELOW direction)
 
     /**
      * Precompute column maxima (called once in constructor)

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -758,6 +758,29 @@ void TrackExpressionVars::add_vtrack_var(const string &vtrack, SEXP rvtrack)
                 lse_mode = PWMLseEditDistanceScorer::Mode::LSE_EDIT_DISTANCE_POS;
             }
 
+            // Extract direction parameter (optional, default "above")
+            PWMLseEditDistanceScorer::Direction lse_direction = PWMLseEditDistanceScorer::Direction::ABOVE;
+            if (Rf_isNewList(rparams)) {
+                int dir_idx = findListElementIndex(rparams, "direction");
+                if (dir_idx >= 0) {
+                    SEXP rdir = VECTOR_ELT(rparams, dir_idx);
+                    if (!Rf_isNull(rdir)) {
+                        if (Rf_isString(rdir) && Rf_length(rdir) == 1) {
+                            std::string dir_str = CHAR(STRING_ELT(rdir, 0));
+                            if (dir_str == "above") {
+                                lse_direction = PWMLseEditDistanceScorer::Direction::ABOVE;
+                            } else if (dir_str == "below") {
+                                lse_direction = PWMLseEditDistanceScorer::Direction::BELOW;
+                            } else {
+                                verror("direction parameter must be \"above\" or \"below\" for vtrack %s", vtrack.c_str());
+                            }
+                        } else {
+                            verror("direction parameter must be a single string (\"above\" or \"below\") for vtrack %s", vtrack.c_str());
+                        }
+                    }
+                }
+            }
+
             // Construct LSE scorer with shared sequence fetcher
             var.pwm_lse_edit_distance_scorer = std::make_unique<PWMLseEditDistanceScorer>(
                 pwm_params.core.pssm,
@@ -768,7 +791,8 @@ void TrackExpressionVars::add_vtrack_var(const string &vtrack, SEXP rvtrack)
                 static_cast<char>(pwm_params.core.strand_mode),
                 lse_mode,
                 score_min,
-                score_max
+                score_max,
+                lse_direction
             );
 
             // Parse optional iterator modifier

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -621,6 +621,29 @@ void TrackExpressionVars::add_vtrack_var(const string &vtrack, SEXP rvtrack)
                 }
             }
 
+            // Extract direction parameter (optional, default "above")
+            PWMEditDistanceScorer::Direction direction = PWMEditDistanceScorer::Direction::ABOVE;
+            if (Rf_isNewList(rparams)) {
+                int dir_idx = findListElementIndex(rparams, "direction");
+                if (dir_idx >= 0) {
+                    SEXP rdir = VECTOR_ELT(rparams, dir_idx);
+                    if (!Rf_isNull(rdir)) {
+                        if (Rf_isString(rdir) && Rf_length(rdir) == 1) {
+                            std::string dir_str = CHAR(STRING_ELT(rdir, 0));
+                            if (dir_str == "above") {
+                                direction = PWMEditDistanceScorer::Direction::ABOVE;
+                            } else if (dir_str == "below") {
+                                direction = PWMEditDistanceScorer::Direction::BELOW;
+                            } else {
+                                verror("direction parameter must be \"above\" or \"below\" for vtrack %s", vtrack.c_str());
+                            }
+                        } else {
+                            verror("direction parameter must be a single string (\"above\" or \"below\") for vtrack %s", vtrack.c_str());
+                        }
+                    }
+                }
+            }
+
             PWMEditDistanceScorer::Mode mode = PWMEditDistanceScorer::Mode::MIN_EDITS;
             if (var.val_func == Track_var::PWM_EDIT_DISTANCE_POS) {
                 mode = PWMEditDistanceScorer::Mode::MIN_EDITS_POSITION;
@@ -639,7 +662,8 @@ void TrackExpressionVars::add_vtrack_var(const string &vtrack, SEXP rvtrack)
                 mode,
                 score_min,
                 max_indels,
-                score_max
+                score_max,
+                direction
             );
 
             // Parse optional iterator modifier (sshift/eshift) for sequence-based vtracks

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -25,6 +25,35 @@
 #include "ValueVarProcessor.h"
 #include "SequenceVarProcessor.h"
 
+namespace {
+// Parse direction parameter from R params list. Returns ABOVE or BELOW.
+PWMEditDistanceScorer::Direction parse_direction_param(SEXP rparams, const std::string& vtrack) {
+    using rdb::verror;
+    PWMEditDistanceScorer::Direction direction = PWMEditDistanceScorer::Direction::ABOVE;
+    if (Rf_isNewList(rparams)) {
+        int dir_idx = TrackExprParams::findListElementIndex(rparams, "direction");
+        if (dir_idx >= 0) {
+            SEXP rdir = VECTOR_ELT(rparams, dir_idx);
+            if (!Rf_isNull(rdir)) {
+                if (Rf_isString(rdir) && Rf_length(rdir) == 1) {
+                    std::string dir_str = CHAR(STRING_ELT(rdir, 0));
+                    if (dir_str == "above") {
+                        direction = PWMEditDistanceScorer::Direction::ABOVE;
+                    } else if (dir_str == "below") {
+                        direction = PWMEditDistanceScorer::Direction::BELOW;
+                    } else {
+                        verror("direction parameter must be \"above\" or \"below\" for vtrack %s", vtrack.c_str());
+                    }
+                } else {
+                    verror("direction parameter must be a single string (\"above\" or \"below\") for vtrack %s", vtrack.c_str());
+                }
+            }
+        }
+    }
+    return direction;
+}
+} // anonymous namespace
+
 const char *TrackExpressionVars::Track_var::FUNC_NAMES[TrackExpressionVars::Track_var::NUM_FUNCS] = {
 	"avg", "min", "max", "nearest", "stddev", "sum", "lse", "quantile",
 	"global.percentile", "global.percentile.min", "global.percentile.max",
@@ -621,28 +650,7 @@ void TrackExpressionVars::add_vtrack_var(const string &vtrack, SEXP rvtrack)
                 }
             }
 
-            // Extract direction parameter (optional, default "above")
-            PWMEditDistanceScorer::Direction direction = PWMEditDistanceScorer::Direction::ABOVE;
-            if (Rf_isNewList(rparams)) {
-                int dir_idx = findListElementIndex(rparams, "direction");
-                if (dir_idx >= 0) {
-                    SEXP rdir = VECTOR_ELT(rparams, dir_idx);
-                    if (!Rf_isNull(rdir)) {
-                        if (Rf_isString(rdir) && Rf_length(rdir) == 1) {
-                            std::string dir_str = CHAR(STRING_ELT(rdir, 0));
-                            if (dir_str == "above") {
-                                direction = PWMEditDistanceScorer::Direction::ABOVE;
-                            } else if (dir_str == "below") {
-                                direction = PWMEditDistanceScorer::Direction::BELOW;
-                            } else {
-                                verror("direction parameter must be \"above\" or \"below\" for vtrack %s", vtrack.c_str());
-                            }
-                        } else {
-                            verror("direction parameter must be a single string (\"above\" or \"below\") for vtrack %s", vtrack.c_str());
-                        }
-                    }
-                }
-            }
+            auto direction = parse_direction_param(rparams, vtrack);
 
             PWMEditDistanceScorer::Mode mode = PWMEditDistanceScorer::Mode::MIN_EDITS;
             if (var.val_func == Track_var::PWM_EDIT_DISTANCE_POS) {
@@ -758,28 +766,7 @@ void TrackExpressionVars::add_vtrack_var(const string &vtrack, SEXP rvtrack)
                 lse_mode = PWMLseEditDistanceScorer::Mode::LSE_EDIT_DISTANCE_POS;
             }
 
-            // Extract direction parameter (optional, default "above")
-            PWMLseEditDistanceScorer::Direction lse_direction = PWMLseEditDistanceScorer::Direction::ABOVE;
-            if (Rf_isNewList(rparams)) {
-                int dir_idx = findListElementIndex(rparams, "direction");
-                if (dir_idx >= 0) {
-                    SEXP rdir = VECTOR_ELT(rparams, dir_idx);
-                    if (!Rf_isNull(rdir)) {
-                        if (Rf_isString(rdir) && Rf_length(rdir) == 1) {
-                            std::string dir_str = CHAR(STRING_ELT(rdir, 0));
-                            if (dir_str == "above") {
-                                lse_direction = PWMLseEditDistanceScorer::Direction::ABOVE;
-                            } else if (dir_str == "below") {
-                                lse_direction = PWMLseEditDistanceScorer::Direction::BELOW;
-                            } else {
-                                verror("direction parameter must be \"above\" or \"below\" for vtrack %s", vtrack.c_str());
-                            }
-                        } else {
-                            verror("direction parameter must be a single string (\"above\" or \"below\") for vtrack %s", vtrack.c_str());
-                        }
-                    }
-                }
-            }
+            auto lse_direction = parse_direction_param(rparams, vtrack);
 
             // Construct LSE scorer with shared sequence fetcher
             var.pwm_lse_edit_distance_scorer = std::make_unique<PWMLseEditDistanceScorer>(

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -102,7 +102,7 @@ extern "C" {
     extern SEXP C_grandom_genome(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_pwm(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_pwm_multitask(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-    extern SEXP C_gseq_pwm_edits(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+    extern SEXP C_gseq_pwm_edits(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_train(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -206,7 +206,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_grandom_genome", (DL_FUNC)&C_grandom_genome, 5},
     {"C_gseq_pwm", (DL_FUNC)&C_gseq_pwm, 16},
     {"C_gseq_pwm_multitask", (DL_FUNC)&C_gseq_pwm_multitask, 17},
-    {"C_gseq_pwm_edits", (DL_FUNC)&C_gseq_pwm_edits, 13},
+    {"C_gseq_pwm_edits", (DL_FUNC)&C_gseq_pwm_edits, 14},
     {"C_gseq_kmer", (DL_FUNC)&C_gseq_kmer, 9},
     {"C_gsynth_train", (DL_FUNC)&C_gsynth_train, 11},
     {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 11},

--- a/tests/testthat/helper-pwm.R
+++ b/tests/testthat/helper-pwm.R
@@ -190,3 +190,106 @@ manual_pwm_edit_distance <- function(seq, pssm, threshold, max_edits = NULL, sca
     }
     best
 }
+
+# Helper function to compute PWM edit distance in "below" direction manually.
+# Returns the minimum number of substitutions to bring the best window's score
+# BELOW the threshold (i.e., score <= threshold).
+# When scan_all = TRUE, returns the minimum edits across every start position.
+# When scan_all = FALSE, seq is treated as a single motif-length window.
+manual_pwm_edit_distance_below <- function(seq, pssm, threshold, max_edits = NULL, scan_all = TRUE) {
+    motif_len <- nrow(pssm)
+
+    if (nchar(seq) < motif_len) {
+        return(NA_real_)
+    }
+
+    log_pssm <- log(pssm)
+    col_min <- apply(log_pssm, 1, min)
+
+    score_window <- function(window_seq) {
+        current_score <- 0
+        has_neg_inf <- FALSE
+        losses <- numeric(0)
+
+        for (i in seq_len(motif_len)) {
+            base <- substr(window_seq, i, i)
+            base_idx <- switch(base,
+                "A" = 1,
+                "C" = 2,
+                "G" = 3,
+                "T" = 4,
+                NA
+            )
+
+            if (is.na(base_idx)) {
+                base_score <- min(log_pssm[i, ])
+            } else {
+                base_score <- log_pssm[i, base_idx]
+            }
+
+            if (!is.finite(base_score)) {
+                # Score is -Inf: total score is -Inf, already below any threshold
+                has_neg_inf <- TRUE
+                break
+            }
+
+            current_score <- current_score + base_score
+            loss <- base_score - col_min[i]
+            losses <- c(losses, loss)
+        }
+
+        if (has_neg_inf) {
+            # Score is -Inf, which is <= any finite threshold
+            return(0)
+        }
+
+        # surplus = how much the current score exceeds the threshold
+        surplus <- current_score - threshold
+        if (surplus <= 0) {
+            # Already at or below threshold
+            return(0)
+        }
+
+        # Check if even switching all positions to worst can cover the surplus
+        total_possible_loss <- sum(losses)
+        if (total_possible_loss < surplus - 1e-12) {
+            return(NA_real_)
+        }
+
+        # Sort losses descending and greedily accumulate
+        losses_sorted <- sort(losses, decreasing = TRUE)
+
+        if (!is.null(max_edits)) {
+            if (max_edits < length(losses_sorted)) {
+                losses_sorted <- losses_sorted[seq_len(max_edits)]
+            }
+        }
+
+        acc <- 0
+        edits <- 0
+        for (loss in losses_sorted) {
+            edits <- edits + 1
+            acc <- acc + loss
+            if (acc >= surplus) {
+                return(edits)
+            }
+        }
+
+        return(NA_real_)
+    }
+
+    if (!scan_all) {
+        return(score_window(seq))
+    }
+
+    seq_len_total <- nchar(seq)
+    best <- NA_real_
+    for (start_idx in seq_len(seq_len_total - motif_len + 1)) {
+        window_seq <- substr(seq, start_idx, start_idx + motif_len - 1)
+        cand <- score_window(window_seq)
+        if (is.na(best) || (!is.na(cand) && cand < best)) {
+            best <- cand
+        }
+    }
+    best
+}

--- a/tests/testthat/test-gseq-pwm-edits-below.R
+++ b/tests/testthat/test-gseq-pwm-edits-below.R
@@ -1,0 +1,486 @@
+# ============================================================================
+# Tests for gseq.pwm_edits() with direction="below"
+# ============================================================================
+
+test_that("gseq.pwm_edits direction=below returns correct structure", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "ACGT" is a perfect match — its score is well above any negative threshold
+    result <- gseq.pwm_edits("ACGT", pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    expect_true(is.data.frame(result))
+    expect_true(all(c(
+        "seq_idx", "strand", "window_start", "score_before",
+        "score_after", "n_edits", "edit_num", "motif_col",
+        "ref", "alt", "gain", "window_seq", "mutated_seq"
+    ) %in% colnames(result)))
+    expect_true(nrow(result) > 0)
+    # Edits should be needed since score_before >> threshold
+    expect_true(any(result$n_edits > 0))
+})
+
+test_that("gseq.pwm_edits direction=below returns 0 edits when already below threshold", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01
+        ),
+        nrow = 2, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "TT" scores very low against this PSSM (prefers AC)
+    # With a threshold high enough that score is already below
+    result <- gseq.pwm_edits("TT", pssm,
+        score.thresh = -0.5,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    expect_equal(result$n_edits[1], 0L)
+    expect_equal(result$edit_num[1], 0L)
+    expect_true(is.na(result$motif_col[1]))
+})
+
+test_that("gseq.pwm_edits direction=below: score_before > threshold and score_after <= threshold", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "ACGT" is a perfect match — score is near 4*log(0.97) ~ -0.12
+    result <- gseq.pwm_edits("ACGT", pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    rows_with_edits <- result[result$n_edits > 0, ]
+    expect_true(nrow(rows_with_edits) > 0, info = "Should need edits to bring score below threshold")
+
+    # score_before should be above the threshold (that is why edits are needed)
+    expect_true(all(rows_with_edits$score_before > -1.0),
+        info = "score_before should be above threshold for below direction"
+    )
+
+    # score_after should be at or below the threshold
+    expect_true(all(rows_with_edits$score_after <= -1.0 + 1e-9),
+        info = "score_after should be at or below threshold for below direction"
+    )
+})
+
+test_that("gseq.pwm_edits direction=below: edits reference bases match window_seq", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01
+        ),
+        nrow = 3, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "ACG" is a perfect match
+    result <- gseq.pwm_edits("ACG", pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    edit_rows <- result[result$edit_num > 0, ]
+    expect_true(nrow(edit_rows) > 0)
+
+    for (i in seq_len(nrow(edit_rows))) {
+        if (!is.na(edit_rows$edit_type[i]) && edit_rows$edit_type[i] == "sub") {
+            mc <- edit_rows$motif_col[i]
+            # ref should match the base at motif_col in window_seq
+            expect_equal(
+                substr(edit_rows$window_seq[i], mc, mc),
+                edit_rows$ref[i],
+                info = paste0("Edit ", i, ": ref should match window_seq at motif_col ", mc)
+            )
+        }
+    }
+
+    # Applying all edits to window_seq should produce mutated_seq
+    # For substitution-only edits, build mutated manually
+    ws <- result$window_seq[1]
+    ms <- result$mutated_seq[1]
+    ws_chars <- strsplit(ws, "")[[1]]
+    for (i in seq_len(nrow(edit_rows))) {
+        if (!is.na(edit_rows$edit_type[i]) && edit_rows$edit_type[i] == "sub") {
+            mc <- edit_rows$motif_col[i]
+            ws_chars[mc] <- edit_rows$alt[i]
+        }
+    }
+    expect_equal(paste0(ws_chars, collapse = ""), ms,
+        info = "Applying all edits to window_seq should produce mutated_seq"
+    )
+})
+
+test_that("gseq.pwm_edits direction=below: gain values are negative for real edits", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "ACGT" is a perfect match — edits needed to destroy it
+    result <- gseq.pwm_edits("ACGT", pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    real_edits <- result[result$edit_num > 0, ]
+    expect_true(nrow(real_edits) > 0)
+
+    sub_edits <- real_edits[!is.na(real_edits$edit_type) & real_edits$edit_type == "sub", ]
+    if (nrow(sub_edits) > 0) {
+        # In "below" direction, gain should be negative (score is being reduced)
+        expect_true(all(sub_edits$gain < 0),
+            info = "gain should be negative for below direction (score is being reduced)"
+        )
+    }
+})
+
+test_that("gseq.pwm_edits direction=below: score_after = score_before + sum(gains)", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    result <- gseq.pwm_edits("ACGT", pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    sub_rows <- result[!is.na(result$edit_type) & result$edit_type == "sub", ]
+    if (nrow(sub_rows) > 0) {
+        total_gain <- sum(sub_rows$gain)
+        expect_equal(result$score_after[1], result$score_before[1] + total_gain,
+            tolerance = 1e-3,
+            info = "score_after must equal score_before + sum(gains) for substitutions"
+        )
+    }
+})
+
+test_that("gseq.pwm_edits direction=below with multiple sequences", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01
+        ),
+        nrow = 2, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "AC" is perfect match (above threshold), "TT" is poor match (likely below)
+    result <- gseq.pwm_edits(c("AC", "TT"), pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    # "AC" should need edits (score is above threshold)
+    ac_rows <- result[result$seq_idx == 1, ]
+    expect_true(any(ac_rows$n_edits > 0),
+        info = "AC should need edits to bring score below threshold"
+    )
+
+    # "TT" should need 0 edits (score is already below threshold)
+    tt_rows <- result[result$seq_idx == 2, ]
+    expect_true(any(tt_rows$n_edits == 0),
+        info = "TT should already be below threshold"
+    )
+})
+
+test_that("gseq.pwm_edits direction=below matches manual_pwm_edit_distance_below", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    seqs <- c("ACGT", "TCGT", "TTTT", "ACGA")
+    threshold <- -5.0
+
+    for (i in seq_along(seqs)) {
+        result <- gseq.pwm_edits(seqs[i], pssm,
+            score.thresh = threshold,
+            prior = 0, bidirect = FALSE, direction = "below"
+        )
+
+        expected_edits <- manual_pwm_edit_distance_below(seqs[i], pssm, threshold, scan_all = TRUE)
+
+        if (nrow(result) > 0) {
+            actual_edits <- result$n_edits[1]
+            if (is.na(expected_edits)) {
+                # Unreachable — should not appear in output
+                # (or seq was already below threshold -> 0 edits)
+            } else {
+                expect_equal(actual_edits, expected_edits,
+                    info = paste0("Seq '", seqs[i], "': n_edits should match manual calculation")
+                )
+            }
+        }
+    }
+})
+
+test_that("gseq.pwm_edits direction=below with bidirectional scanning", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01
+        ),
+        nrow = 2, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "GT" forward strand scores ~-9.21 (already below -1.0 -> 0 edits)
+    # "GT" revcomp "AC" scores ~-0.06 (above -1.0 -> needs edits)
+    # With bidirect=TRUE, the code picks the strand needing fewest edits,
+    # which is the forward strand with 0 edits.
+    result <- gseq.pwm_edits("GT", pssm,
+        score.thresh = -1.0,
+        prior = 0, bidirect = TRUE, direction = "below"
+    )
+
+    expect_true(nrow(result) > 0)
+    # Forward strand is already below threshold, so 0 edits on forward strand
+    expect_equal(result$n_edits[1], 0L)
+    expect_equal(result$strand[1], 1L)
+
+    # Use a sequence where BOTH strands score above threshold
+    # "AC" forward is ~-0.06 (above threshold), revcomp "GT" is ~-9.21 (below)
+    # So again the best is 0 edits on the reverse strand.
+    # Use a higher threshold to force both strands above it.
+    result2 <- gseq.pwm_edits("AC", pssm,
+        score.thresh = -0.01,
+        prior = 0, bidirect = TRUE, direction = "below"
+    )
+    expect_true(nrow(result2) > 0)
+    # Forward strand "AC" scores ~-0.06, reverse "GT" scores ~-9.21
+    # Forward needs edits, reverse is already below -0.01
+    # Best is reverse strand with 0 edits
+    expect_equal(result2$n_edits[1], 0L)
+})
+
+test_that("gseq.pwm_edits direction=below with max_indels=1", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "ACGT" is a perfect match — try to destroy it with indels allowed
+    result <- gseq.pwm_edits("ACGT", pssm,
+        score.thresh = -1.0,
+        max_indels = 1L, prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    expect_true(is.data.frame(result))
+    expect_true(nrow(result) > 0)
+    expect_true("edit_type" %in% colnames(result))
+
+    # Should find edits needed to bring score below threshold
+    rows_with_edits <- result[result$n_edits > 0, ]
+    expect_true(nrow(rows_with_edits) > 0)
+
+    # score_after should be at or below threshold
+    expect_true(all(rows_with_edits$score_after <= -1.0 + 1e-9),
+        info = "score_after should be at or below threshold"
+    )
+})
+
+test_that("gseq.pwm_edits direction=below: comparison with vtrack", {
+    gdb.init("/home/aviezerl/hg38")
+    remove_all_vtracks()
+
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # Find a region with a good match first
+    test_interval <- gintervals("chr1", 10000, 10010)
+    seq <- gseq.extract(test_interval)
+
+    thresh <- -5.0
+
+    # Use gseq.pwm_edits with direction=below
+    result <- gseq.pwm_edits(seq, pssm,
+        score.thresh = thresh,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    # Create vtrack with direction=below
+    gvtrack.create("edist_below", NULL, "pwm.edit_distance",
+        pssm = pssm, score.thresh = thresh,
+        bidirect = FALSE, prior = 0, extend = FALSE,
+        direction = "below"
+    )
+    vtrack_result <- gextract("edist_below",
+        intervals = test_interval, iterator = test_interval
+    )
+
+    # The n_edits from gseq.pwm_edits should match the vtrack result
+    if (nrow(result) > 0 && !is.na(vtrack_result$edist_below)) {
+        expect_equal(result$n_edits[1], as.integer(vtrack_result$edist_below),
+            info = "n_edits from gseq.pwm_edits should match vtrack"
+        )
+    }
+
+    remove_all_vtracks()
+})
+
+test_that("gseq.pwm_edits direction=below vs direction=above are complementary", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01
+        ),
+        nrow = 2, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    threshold <- -1.0
+
+    # "AC" is a perfect match
+    result_above <- gseq.pwm_edits("AC", pssm,
+        score.thresh = threshold,
+        prior = 0, bidirect = FALSE, direction = "above"
+    )
+    result_below <- gseq.pwm_edits("AC", pssm,
+        score.thresh = threshold,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    # "AC" is already above threshold: above should return 0 edits, below should need edits
+    expect_equal(result_above$n_edits[1], 0L,
+        info = "AC is already above threshold, direction=above should need 0 edits"
+    )
+    expect_true(result_below$n_edits[1] > 0,
+        info = "AC is above threshold, direction=below should need edits"
+    )
+
+    # "TT" is well below threshold
+    result_above_tt <- gseq.pwm_edits("TT", pssm,
+        score.thresh = threshold,
+        prior = 0, bidirect = FALSE, direction = "above"
+    )
+    result_below_tt <- gseq.pwm_edits("TT", pssm,
+        score.thresh = threshold,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    # "TT" is below threshold: above should need edits, below should return 0 edits
+    expect_true(result_above_tt$n_edits[1] > 0,
+        info = "TT is below threshold, direction=above should need edits"
+    )
+    expect_equal(result_below_tt$n_edits[1], 0L,
+        info = "TT is already below threshold, direction=below should need 0 edits"
+    )
+})
+
+test_that("gseq.pwm_edits direction=below with longer sequence picks best window", {
+    pssm <- matrix(
+        c(
+            0.97, 0.01, 0.01, 0.01,
+            0.01, 0.97, 0.01, 0.01,
+            0.01, 0.01, 0.97, 0.01,
+            0.01, 0.01, 0.01, 0.97
+        ),
+        nrow = 4, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # Sequence with a perfect ACGT match embedded in a longer context
+    seq <- "TTTTACGTTTTT"
+    threshold <- -1.0
+
+    result <- gseq.pwm_edits(seq, pssm,
+        score.thresh = threshold,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    expect_true(nrow(result) > 0)
+    # The best (highest-scoring) window should be found — the one containing ACGT
+    # For direction=below, we want to destroy the BEST match
+    rows_with_edits <- result[result$n_edits > 0, ]
+    if (nrow(rows_with_edits) > 0) {
+        # The window_seq should be the best-matching window
+        expect_true(rows_with_edits$score_before[1] > threshold,
+            info = "score_before should be above threshold (best window)"
+        )
+    }
+})
+
+test_that("gseq.pwm_edits direction=below with highly informative PSSM", {
+    # PSSM with near-zero but non-zero probabilities (to avoid -Inf issues)
+    pssm <- matrix(
+        c(
+            0.99, 0.003, 0.003, 0.004,
+            0.003, 0.99, 0.003, 0.004
+        ),
+        nrow = 2, byrow = TRUE,
+        dimnames = list(NULL, c("A", "C", "G", "T"))
+    )
+
+    # "AC" is a near-perfect match — score is 2*log(0.99) ~ -0.02
+    # For direction=below, we need to make it score below threshold
+    result <- gseq.pwm_edits("AC", pssm,
+        score.thresh = -0.5,
+        prior = 0, bidirect = FALSE, direction = "below"
+    )
+
+    expect_true(nrow(result) > 0)
+    # Switching one position to a non-preferred base drops score dramatically
+    rows_with_edits <- result[result$n_edits > 0, ]
+    expect_true(nrow(rows_with_edits) > 0)
+    expect_equal(rows_with_edits$n_edits[1], 1L,
+        info = "One edit should suffice to bring score below threshold"
+    )
+    # Verify the score after is actually below threshold
+    expect_true(rows_with_edits$score_after[1] <= -0.5 + 1e-9)
+})

--- a/tests/testthat/test-pwm-edit-distance-below.R
+++ b/tests/testthat/test-pwm-edit-distance-below.R
@@ -1255,3 +1255,546 @@ test_that("direction=below with indels: 1bp iterator matches interval-level resu
         }
     }
 })
+
+# --------------------------------------------------------------------------
+# LSE edit distance with direction=below
+# --------------------------------------------------------------------------
+
+test_that("pwm.edit_distance.lse direction=below basic functionality works", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 250)
+
+    # Get the actual LSE score for this interval
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    lse_score <- lse_result$v_lse_score[1]
+
+    # Set threshold above the LSE score so the score is already below it
+    # => should require 0 edits
+    high_thresh <- lse_score + 5.0
+    gvtrack.create("v_lse_below_easy", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = high_thresh,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("v_lse_below_easy", test_interval, iterator = test_interval)
+    expect_equal(result$v_lse_below_easy[1], 0, tolerance = 1e-6)
+})
+
+test_that("pwm.edit_distance.lse direction=below needs edits when score is above threshold", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 250)
+
+    # Get the actual LSE score
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    lse_score <- lse_result$v_lse_score[1]
+
+    # Set threshold well below the LSE score so edits are needed
+    low_thresh <- lse_score - 10.0
+    gvtrack.create("v_lse_below_hard", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = low_thresh,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("v_lse_below_hard", test_interval, iterator = test_interval)
+
+    # Should need at least 1 edit since the score is above threshold
+    if (!is.na(result$v_lse_below_hard[1])) {
+        expect_true(result$v_lse_below_hard[1] >= 1,
+            info = paste("LSE score", lse_score, "above threshold", low_thresh, "should need edits")
+        )
+    }
+})
+
+test_that("pwm.edit_distance.lse direction=below returns 0 when already below", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    test_interval <- gintervals(1, 200, 240)
+
+    # Very high threshold: LSE score will certainly be below it
+    threshold <- 100.0
+    gvtrack.create("v_lse_below_already", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("v_lse_below_already", test_interval, iterator = test_interval)
+    expect_equal(result$v_lse_below_already[1], 0, tolerance = 1e-6)
+})
+
+test_that("pwm.edit_distance.lse direction=below returns NA for unreachable threshold", {
+    remove_all_vtracks()
+
+    # With prior=0, the minimum per-window score can be -Inf (zero probability columns),
+    # so LSE can go to -Inf. Use a PSSM with no zeros so the minimum is bounded.
+    pssm <- matrix(c(
+        0.25, 0.25, 0.25, 0.25,
+        0.25, 0.25, 0.25, 0.25
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 240)
+
+    # With uniform PSSM and no prior, all windows have the same score = 2*log(0.25).
+    # LSE = log(N * exp(2*log(0.25))) where N = number of windows.
+    # This is bounded. A threshold far below this should be unreachable.
+    threshold <- -1000.0
+    gvtrack.create("v_lse_below_impossible", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("v_lse_below_impossible", test_interval, iterator = test_interval)
+    expect_true(is.na(result$v_lse_below_impossible[1]))
+})
+
+test_that("pwm.edit_distance.lse direction=below vs above are complementary", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 240)
+
+    # Get the actual LSE score
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    lse_score <- lse_result$v_lse_score[1]
+
+    # Use a threshold below the actual score
+    low_thresh <- lse_score - 5.0
+    gvtrack.create("v_lse_above_low", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = low_thresh,
+        direction = "above",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("v_lse_below_low", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = low_thresh,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("v_lse_above_low", "v_lse_below_low"),
+        test_interval, iterator = test_interval
+    )
+
+    above_val <- result$v_lse_above_low[1]
+    below_val <- result$v_lse_below_low[1]
+
+    # Score is above the threshold, so:
+    # - "above" direction should need 0 edits (already above)
+    # - "below" direction should need >= 1 edit (need to push score down)
+    expect_equal(above_val, 0, tolerance = 1e-6)
+    if (!is.na(below_val)) {
+        expect_true(below_val >= 1,
+            info = paste("Below should need edits when score", lse_score, "is above threshold", low_thresh)
+        )
+    }
+
+    # Now use a threshold above the actual score
+    high_thresh <- lse_score + 5.0
+    gvtrack.create("v_lse_above_high", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = high_thresh,
+        direction = "above",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("v_lse_below_high", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = high_thresh,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result2 <- gextract(c("v_lse_above_high", "v_lse_below_high"),
+        test_interval, iterator = test_interval
+    )
+
+    above_val2 <- result2$v_lse_above_high[1]
+    below_val2 <- result2$v_lse_below_high[1]
+
+    # Score is below the threshold, so:
+    # - "above" direction should need >= 1 edit (need to push score up)
+    # - "below" direction should need 0 edits (already below)
+    expect_equal(below_val2, 0, tolerance = 1e-6)
+    if (!is.na(above_val2)) {
+        expect_true(above_val2 >= 1,
+            info = paste("Above should need edits when score", lse_score, "is below threshold", high_thresh)
+        )
+    }
+})
+
+test_that("pwm.edit_distance.lse.pos direction=below returns valid position", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    motif_len <- nrow(pssm)
+    test_interval <- gintervals(1, 200, 250)
+
+    # Get the actual LSE score
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    lse_score <- lse_result$v_lse_score[1]
+
+    # Set threshold below the LSE score so edits are needed
+    threshold <- lse_score - 5.0
+
+    gvtrack.create("v_lse_below_edist", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    gvtrack.create("v_lse_below_pos", NULL,
+        func = "pwm.edit_distance.lse.pos",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("v_lse_below_edist", "v_lse_below_pos"),
+        test_interval, iterator = test_interval
+    )
+
+    edist_val <- result$v_lse_below_edist[1]
+    pos_val <- result$v_lse_below_pos[1]
+
+    # If edit distance is not NA, position should also not be NA
+    if (!is.na(edist_val) && edist_val >= 1) {
+        expect_false(is.na(pos_val),
+            info = "Position should be defined when edits are needed"
+        )
+        # Position should be a valid 1-based offset within the interval
+        interval_len <- test_interval$end - test_interval$start
+        expect_true(pos_val >= 1,
+            info = paste("Position", pos_val, "should be >= 1")
+        )
+        expect_true(pos_val <= interval_len,
+            info = paste("Position", pos_val, "should be within interval length", interval_len)
+        )
+    }
+
+    # If already below (0 edits), position is typically NA
+    if (!is.na(edist_val) && edist_val == 0) {
+        expect_true(is.na(pos_val),
+            info = "Position should be NA when no edits are needed"
+        )
+    }
+})
+
+test_that("pwm.edit_distance.lse direction=below edit count is consistent with max-mode below", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 250)
+
+    # Get the actual LSE score and the max-window score
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("v_max_score", NULL, func = "pwm.max",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    scores <- gextract(c("v_lse_score", "v_max_score"), test_interval, iterator = test_interval)
+    lse_score <- scores$v_lse_score[1]
+    max_score <- scores$v_max_score[1]
+
+    # Use a threshold based on the max score (the max-mode below problem)
+    threshold <- max_score - 2.0
+
+    gvtrack.create("v_lse_below_edist", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("v_max_below_edist", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("v_lse_below_edist", "v_max_below_edist"),
+        test_interval, iterator = test_interval
+    )
+
+    lse_edits <- result$v_lse_below_edist[1]
+    max_edits <- result$v_max_below_edist[1]
+
+    # The LSE score is always >= the max score (LSE = log-sum-exp >= max).
+    # So to bring the LSE below a threshold, we generally need at least as many edits
+    # as bringing the max below the same threshold.
+    # In other words, LSE below edits >= max below edits.
+    if (!is.na(lse_edits) && !is.na(max_edits)) {
+        expect_true(lse_edits >= max_edits,
+            info = paste(
+                "LSE below edits (", lse_edits, ") should be >= max below edits (",
+                max_edits, ") for the same threshold"
+            )
+        )
+    }
+
+    # If max below is reachable, LSE below may or may not be reachable
+    # (LSE is harder to push down since all windows contribute)
+    # Both should be non-negative when not NA
+    if (!is.na(lse_edits)) expect_true(lse_edits >= 0)
+    if (!is.na(max_edits)) expect_true(max_edits >= 0)
+})
+
+test_that("pwm.edit_distance.lse direction=below threshold monotonicity", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 240)
+
+    # Get the actual LSE score
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    lse_score <- lse_result$v_lse_score[1]
+
+    # Thresholds from low to high
+    thresholds <- c(lse_score - 15, lse_score - 10, lse_score - 5, lse_score, lse_score + 5)
+    vnames <- sprintf("v_lse_below_t%d", seq_along(thresholds))
+
+    for (i in seq_along(thresholds)) {
+        gvtrack.create(vnames[i], NULL,
+            func = "pwm.edit_distance.lse",
+            pssm = pssm, score.thresh = thresholds[i],
+            direction = "below",
+            bidirect = FALSE, extend = FALSE, prior = 0
+        )
+    }
+
+    result <- gextract(vnames, test_interval, iterator = test_interval)
+
+    edits <- sapply(vnames, function(v) result[[v]][1])
+
+    # Lower thresholds should require more (or equal) edits to bring the score below them.
+    # So as threshold increases, edits should decrease (non-increasing).
+    for (i in 2:length(edits)) {
+        if (!is.na(edits[i - 1]) && !is.na(edits[i])) {
+            expect_true(edits[i] <= edits[i - 1],
+                info = paste(
+                    "Edits at threshold", thresholds[i], "=", edits[i],
+                    "should be <= edits at threshold", thresholds[i - 1], "=", edits[i - 1]
+                )
+            )
+        }
+        # If a higher threshold is reachable, lower thresholds may not be
+        # but if a lower threshold is reachable, the higher one must also be
+        if (!is.na(edits[i - 1])) {
+            expect_false(is.na(edits[i]),
+                info = paste(
+                    "Threshold", thresholds[i], "should be reachable since lower threshold",
+                    thresholds[i - 1], "is reachable"
+                )
+            )
+        }
+    }
+})
+
+test_that("pwm.edit_distance.lse direction=below with bidirectional", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 250)
+
+    # Get LSE score to set a meaningful threshold
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    threshold <- lse_result$v_lse_score[1] - 3.0
+
+    # Forward only
+    gvtrack.create("v_lse_below_fwd", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, strand = 1, extend = FALSE, prior = 0
+    )
+
+    # Reverse only
+    gvtrack.create("v_lse_below_rev", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, strand = -1, extend = FALSE, prior = 0
+    )
+
+    # Bidirectional
+    gvtrack.create("v_lse_below_bidi", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = TRUE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("v_lse_below_fwd", "v_lse_below_rev", "v_lse_below_bidi"),
+        test_interval, iterator = test_interval
+    )
+
+    fwd <- result$v_lse_below_fwd[1]
+    rev <- result$v_lse_below_rev[1]
+    bidi <- result$v_lse_below_bidi[1]
+
+    # All should be non-negative when not NA
+    if (!is.na(fwd)) expect_true(fwd >= 0)
+    if (!is.na(rev)) expect_true(rev >= 0)
+    if (!is.na(bidi)) expect_true(bidi >= 0)
+
+    # The bidirectional version operates on both strands. Since a single edit
+    # can reduce scores on both strands simultaneously, the bidirectional edit
+    # count may be less than, equal to, or greater than individual strands.
+    # We verify all three produce valid results.
+    if (!is.na(fwd) || !is.na(rev)) {
+        # If at least one strand is reachable, bidirectional should also be reachable
+        # (the algorithm can always degrade both strands or one)
+        expect_false(is.na(bidi),
+            info = "Bidirectional should be reachable when at least one strand is"
+        )
+    }
+})
+
+test_that("pwm.edit_distance.lse direction=below with max_edits cap", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 250)
+
+    # Get LSE score to set a threshold that needs edits
+    gvtrack.create("v_lse_score", NULL, func = "pwm",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
+    threshold <- lse_result$v_lse_score[1] - 8.0
+
+    # Unlimited edits
+    gvtrack.create("v_lse_below_unlim", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # max_edits = 1
+    gvtrack.create("v_lse_below_max1", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold, max_edits = 1,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # max_edits = 5
+    gvtrack.create("v_lse_below_max5", NULL,
+        func = "pwm.edit_distance.lse",
+        pssm = pssm, score.thresh = threshold, max_edits = 5,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("v_lse_below_unlim", "v_lse_below_max1", "v_lse_below_max5"),
+        test_interval, iterator = test_interval
+    )
+
+    unlim <- result$v_lse_below_unlim[1]
+    max1 <- result$v_lse_below_max1[1]
+    max5 <- result$v_lse_below_max5[1]
+
+    # If unlimited finds a solution, capped versions should find the same or NA
+    if (!is.na(unlim)) {
+        if (unlim <= 1) {
+            expect_equal(max1, unlim, tolerance = 1e-6)
+        } else {
+            expect_true(is.na(max1),
+                info = paste("max_edits=1 should be NA when unlimited needs", unlim)
+            )
+        }
+
+        if (unlim <= 5) {
+            expect_equal(max5, unlim, tolerance = 1e-6)
+        } else {
+            expect_true(is.na(max5),
+                info = paste("max_edits=5 should be NA when unlimited needs", unlim)
+            )
+        }
+    }
+
+    # Non-negative when not NA
+    if (!is.na(unlim)) expect_true(unlim >= 0)
+    if (!is.na(max1)) expect_true(max1 >= 0)
+    if (!is.na(max5)) expect_true(max5 >= 0)
+})

--- a/tests/testthat/test-pwm-edit-distance-below.R
+++ b/tests/testthat/test-pwm-edit-distance-below.R
@@ -693,3 +693,565 @@ test_that("pwm.edit_distance direction=below with gscreen works", {
         expect_true(all(c("chrom", "start", "end") %in% names(result)))
     }
 })
+
+# --------------------------------------------------------------------------
+# direction=below with indels (max_indels parameter)
+# --------------------------------------------------------------------------
+
+test_that("direction=below with max_indels=1: indels can reduce total edits", {
+    remove_all_vtracks()
+
+    # 4bp motif with strong preferences
+    pssm <- matrix(c(
+        0.97, 0.01, 0.01, 0.01, # A
+        0.01, 0.97, 0.01, 0.01, # C
+        0.01, 0.01, 0.97, 0.01, # G
+        0.01, 0.01, 0.01, 0.97 # T
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(
+        chrom = c(1, 1, 1),
+        start = c(200, 500, 1000),
+        end = c(260, 560, 1060)
+    )
+    threshold <- -3.0
+
+    # Substitution-only
+    gvtrack.create("edist_below_sub", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 0,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # With 1 indel
+    gvtrack.create("edist_below_indel1", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_below_sub", "edist_below_indel1"),
+        test_intervals,
+        iterator = test_intervals
+    )
+
+    for (i in seq_len(nrow(result))) {
+        sub_val <- result$edist_below_sub[i]
+        indel_val <- result$edist_below_indel1[i]
+
+        # Indels can only help or stay the same: with indels <= without indels
+        if (!is.na(sub_val) && !is.na(indel_val)) {
+            expect_true(indel_val <= sub_val,
+                info = paste("Row", i, ": indel result", indel_val, "should be <= sub-only", sub_val)
+            )
+        }
+
+        # If substitution-only finds a result, indel version should too
+        if (!is.na(sub_val)) {
+            expect_false(is.na(indel_val),
+                info = paste("Row", i, ": indel version should not be NA when sub-only is", sub_val)
+            )
+        }
+
+        # Both should be non-negative when not NA
+        if (!is.na(sub_val)) expect_true(sub_val >= 0)
+        if (!is.na(indel_val)) expect_true(indel_val >= 0)
+    }
+})
+
+test_that("direction=below with max_indels=2: more indels can further reduce edits", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.97, 0.01, 0.01, 0.01, # A
+        0.01, 0.97, 0.01, 0.01, # C
+        0.01, 0.01, 0.97, 0.01, # G
+        0.01, 0.01, 0.01, 0.97 # T
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(
+        chrom = c(1, 1, 1),
+        start = c(200, 500, 1000),
+        end = c(260, 560, 1060)
+    )
+    threshold <- -3.0
+
+    # Compare max_indels = 0, 1, 2
+    gvtrack.create("edist_below_d0", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 0,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_d1", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_d2", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 2,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_below_d0", "edist_below_d1", "edist_below_d2"),
+        test_intervals,
+        iterator = test_intervals
+    )
+
+    for (i in seq_len(nrow(result))) {
+        d0 <- result$edist_below_d0[i]
+        d1 <- result$edist_below_d1[i]
+        d2 <- result$edist_below_d2[i]
+
+        # Monotonicity: d2 <= d1 <= d0 (more indels can only help or stay the same)
+        if (!is.na(d0) && !is.na(d1)) {
+            expect_true(d1 <= d0,
+                info = paste("Row", i, ": d1=", d1, "should be <= d0=", d0)
+            )
+        }
+        if (!is.na(d1) && !is.na(d2)) {
+            expect_true(d2 <= d1,
+                info = paste("Row", i, ": d2=", d2, "should be <= d1=", d1)
+            )
+        }
+        if (!is.na(d0) && !is.na(d2)) {
+            expect_true(d2 <= d0,
+                info = paste("Row", i, ": d2=", d2, "should be <= d0=", d0)
+            )
+        }
+
+        # If d0 (sub-only) is reachable, d1 and d2 must also be reachable
+        if (!is.na(d0)) {
+            expect_false(is.na(d1),
+                info = paste("Row", i, ": d1 should not be NA when d0 =", d0)
+            )
+            expect_false(is.na(d2),
+                info = paste("Row", i, ": d2 should not be NA when d0 =", d0)
+            )
+        }
+        if (!is.na(d1)) {
+            expect_false(is.na(d2),
+                info = paste("Row", i, ": d2 should not be NA when d1 =", d1)
+            )
+        }
+    }
+})
+
+test_that("direction=below with max_indels: substitution-only vs indels comparison", {
+    remove_all_vtracks()
+
+    # Longer 6bp motif for more interesting comparisons
+    pssm <- matrix(c(
+        0.9, 0.03, 0.03, 0.04,
+        0.03, 0.9, 0.03, 0.04,
+        0.03, 0.03, 0.9, 0.04,
+        0.04, 0.03, 0.03, 0.9,
+        0.9, 0.03, 0.03, 0.04,
+        0.03, 0.9, 0.03, 0.04
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 280)
+    threshold <- -5.0
+
+    # No indels
+    gvtrack.create("edist_below_noindel", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # With 1 indel
+    gvtrack.create("edist_below_1indel", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # With 2 indels
+    gvtrack.create("edist_below_2indels", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 2,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_noindel", "edist_below_1indel", "edist_below_2indels"),
+        test_interval,
+        iterator = test_interval
+    )
+
+    no_indel <- result$edist_below_noindel[1]
+    with_1 <- result$edist_below_1indel[1]
+    with_2 <- result$edist_below_2indels[1]
+
+    # More indels should always give the same or fewer total edits
+    if (!is.na(no_indel) && !is.na(with_1)) {
+        expect_true(with_1 <= no_indel)
+    }
+    if (!is.na(no_indel) && !is.na(with_2)) {
+        expect_true(with_2 <= no_indel)
+    }
+    if (!is.na(with_1) && !is.na(with_2)) {
+        expect_true(with_2 <= with_1)
+    }
+
+    # Substitution-only reachable implies indel versions reachable
+    if (!is.na(no_indel)) {
+        expect_false(is.na(with_1))
+        expect_false(is.na(with_2))
+    }
+})
+
+test_that("direction=below with max_indels: cap is respected", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.97, 0.01, 0.01, 0.01,
+        0.01, 0.97, 0.01, 0.01,
+        0.01, 0.01, 0.97, 0.01,
+        0.01, 0.01, 0.01, 0.97
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(
+        chrom = c(1, 1, 1, 1),
+        start = c(200, 500, 1000, 2000),
+        end = c(260, 560, 1060, 2060)
+    )
+    threshold <- -3.0
+
+    # max_indels=0 should match the default (no indels)
+    gvtrack.create("edist_below_cap_default", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_cap0", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 0,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_below_cap_default", "edist_below_cap0"),
+        test_intervals,
+        iterator = test_intervals
+    )
+
+    # max_indels=0 and no max_indels specified should produce identical results
+    for (i in seq_len(nrow(result))) {
+        if (is.na(result$edist_below_cap_default[i])) {
+            expect_true(is.na(result$edist_below_cap0[i]),
+                info = paste("Row", i, ": both should be NA")
+            )
+        } else {
+            expect_equal(result$edist_below_cap_default[i], result$edist_below_cap0[i],
+                tolerance = 1e-6,
+                info = paste("Row", i, ": default and max_indels=0 should match")
+            )
+        }
+    }
+})
+
+test_that("direction=below with indels: consistency - indels always <= sub-only", {
+    remove_all_vtracks()
+
+    # Test across many intervals to increase confidence
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05,
+        0.04, 0.03, 0.03, 0.9
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(
+        chrom = rep(1, 8),
+        start = seq(200, 900, by = 100),
+        end = seq(260, 960, by = 100)
+    )
+    threshold <- -4.0
+
+    gvtrack.create("edist_below_con_sub", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 0,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_con_indel1", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_con_indel2", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 2,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_con_sub", "edist_below_con_indel1", "edist_below_con_indel2"),
+        test_intervals,
+        iterator = test_intervals
+    )
+
+    for (i in seq_len(nrow(result))) {
+        sub_val <- result$edist_below_con_sub[i]
+        ind1_val <- result$edist_below_con_indel1[i]
+        ind2_val <- result$edist_below_con_indel2[i]
+
+        # Consistency: indel version should never return more edits
+        if (!is.na(sub_val) && !is.na(ind1_val)) {
+            expect_true(ind1_val <= sub_val,
+                info = paste("Row", i, ": indel1 should be <= sub-only")
+            )
+        }
+        if (!is.na(sub_val) && !is.na(ind2_val)) {
+            expect_true(ind2_val <= sub_val,
+                info = paste("Row", i, ": indel2 should be <= sub-only")
+            )
+        }
+        if (!is.na(ind1_val) && !is.na(ind2_val)) {
+            expect_true(ind2_val <= ind1_val,
+                info = paste("Row", i, ": indel2 should be <= indel1")
+            )
+        }
+
+        # If sub-only is reachable, indel versions must be too
+        if (!is.na(sub_val)) {
+            expect_false(is.na(ind1_val),
+                info = paste("Row", i, ": indel1 should not be NA when sub-only is", sub_val)
+            )
+            expect_false(is.na(ind2_val),
+                info = paste("Row", i, ": indel2 should not be NA when sub-only is", sub_val)
+            )
+        }
+    }
+})
+
+test_that("direction=below with indels: already below threshold still returns 0", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm() # AC motif
+
+    test_intervals <- gintervals(1, 200, 240)
+
+    # Very high threshold: all windows should score below it
+    threshold <- 100.0
+
+    gvtrack.create("edist_below_indel_already0", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 0,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_indel_already1", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    gvtrack.create("edist_below_indel_already2", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 2,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_indel_already0", "edist_below_indel_already1", "edist_below_indel_already2"),
+        test_intervals,
+        iterator = test_intervals
+    )
+
+    # All should return 0 regardless of max_indels setting
+    expect_equal(result$edist_below_indel_already0[1], 0, tolerance = 1e-6)
+    expect_equal(result$edist_below_indel_already1[1], 0, tolerance = 1e-6)
+    expect_equal(result$edist_below_indel_already2[1], 0, tolerance = 1e-6)
+})
+
+test_that("direction=below with indels: bidirectional considers both strands", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.97, 0.01, 0.01, 0.01,
+        0.01, 0.97, 0.01, 0.01,
+        0.01, 0.01, 0.97, 0.01,
+        0.01, 0.01, 0.01, 0.97
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 260)
+    threshold <- -3.0
+
+    # Forward only with indels
+    gvtrack.create("edist_below_indel_fwd", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, strand = 1, extend = FALSE, prior = 0
+    )
+
+    # Reverse only with indels
+    gvtrack.create("edist_below_indel_rev", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, strand = -1, extend = FALSE, prior = 0
+    )
+
+    # Bidirectional with indels
+    gvtrack.create("edist_below_indel_bidi", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = TRUE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_indel_fwd", "edist_below_indel_rev", "edist_below_indel_bidi"),
+        test_interval,
+        iterator = test_interval
+    )
+
+    fwd <- result$edist_below_indel_fwd[1]
+    rev <- result$edist_below_indel_rev[1]
+    bidi <- result$edist_below_indel_bidi[1]
+
+    # Bidirectional should return minimum of both strands
+    if (!is.na(fwd) && !is.na(rev)) {
+        expect_equal(bidi, min(fwd, rev), tolerance = 1e-6)
+    } else if (!is.na(fwd)) {
+        expect_equal(bidi, fwd, tolerance = 1e-6)
+    } else if (!is.na(rev)) {
+        expect_equal(bidi, rev, tolerance = 1e-6)
+    }
+})
+
+test_that("direction=below with indels: max_edits cap interacts correctly with max_indels", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.9, 0.03, 0.03, 0.04,
+        0.03, 0.9, 0.03, 0.04,
+        0.03, 0.03, 0.9, 0.04,
+        0.04, 0.03, 0.03, 0.9
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 260)
+    threshold <- -5.0
+
+    # Unlimited edits with 1 indel
+    gvtrack.create("edist_below_indel_unlim", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # max_edits=1 with 1 indel (tight cap)
+    gvtrack.create("edist_below_indel_max1", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1, max_edits = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # max_edits=3 with 1 indel
+    gvtrack.create("edist_below_indel_max3", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1, max_edits = 3,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_indel_unlim", "edist_below_indel_max1", "edist_below_indel_max3"),
+        test_interval,
+        iterator = test_interval
+    )
+
+    unlim <- result$edist_below_indel_unlim[1]
+    max1 <- result$edist_below_indel_max1[1]
+    max3 <- result$edist_below_indel_max3[1]
+
+    # If unlimited finds a solution, capped versions should find same or NA
+    if (!is.na(unlim)) {
+        if (unlim <= 1) {
+            expect_equal(max1, unlim, tolerance = 1e-6,
+                info = "max_edits=1 should find same result when unlimited needs <= 1"
+            )
+        } else {
+            expect_true(is.na(max1),
+                info = paste("max_edits=1 should be NA when unlimited needs", unlim, "edits")
+            )
+        }
+
+        if (unlim <= 3) {
+            expect_equal(max3, unlim, tolerance = 1e-6,
+                info = "max_edits=3 should find same result when unlimited needs <= 3"
+            )
+        } else {
+            expect_true(is.na(max3),
+                info = paste("max_edits=3 should be NA when unlimited needs", unlim, "edits")
+            )
+        }
+    }
+})
+
+test_that("direction=below with indels: 1bp iterator matches interval-level result", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.97, 0.01, 0.01, 0.01,
+        0.01, 0.97, 0.01, 0.01,
+        0.01, 0.01, 0.97, 0.01
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    motif_len <- nrow(pssm)
+    test_interval <- gintervals(1, 200, 210)
+    threshold <- -4.0
+
+    # Interval-level result with indels
+    gvtrack.create("edist_below_indel_int", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # 1bp iterator result with indels
+    gvtrack.create("edist_below_indel_1bp", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below", max_indels = 1,
+        bidirect = FALSE, extend = TRUE, prior = 0
+    )
+
+    result_int <- gextract("edist_below_indel_int", test_interval, iterator = test_interval)
+    result_1bp <- gextract("edist_below_indel_1bp", test_interval, iterator = 1)
+
+    # The interval-level minimum should equal the minimum across 1bp windows
+    if (nrow(result_1bp) > 0) {
+        min_1bp <- min(result_1bp$edist_below_indel_1bp, na.rm = TRUE)
+        if (is.finite(min_1bp) && !is.na(result_int$edist_below_indel_int[1])) {
+            expect_equal(result_int$edist_below_indel_int[1], min_1bp, tolerance = 1e-6)
+        }
+    }
+})

--- a/tests/testthat/test-pwm-edit-distance-below.R
+++ b/tests/testthat/test-pwm-edit-distance-below.R
@@ -1193,7 +1193,8 @@ test_that("direction=below with indels: max_edits cap interacts correctly with m
     # If unlimited finds a solution, capped versions should find same or NA
     if (!is.na(unlim)) {
         if (unlim <= 1) {
-            expect_equal(max1, unlim, tolerance = 1e-6,
+            expect_equal(max1, unlim,
+                tolerance = 1e-6,
                 info = "max_edits=1 should find same result when unlimited needs <= 1"
             )
         } else {
@@ -1203,7 +1204,8 @@ test_that("direction=below with indels: max_edits cap interacts correctly with m
         }
 
         if (unlim <= 3) {
-            expect_equal(max3, unlim, tolerance = 1e-6,
+            expect_equal(max3, unlim,
+                tolerance = 1e-6,
                 info = "max_edits=3 should find same result when unlimited needs <= 3"
             )
         } else {
@@ -1273,7 +1275,8 @@ test_that("pwm.edit_distance.lse direction=below basic functionality works", {
     test_interval <- gintervals(1, 200, 250)
 
     # Get the actual LSE score for this interval
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1306,7 +1309,8 @@ test_that("pwm.edit_distance.lse direction=below needs edits when score is above
     test_interval <- gintervals(1, 200, 250)
 
     # Get the actual LSE score
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1391,7 +1395,8 @@ test_that("pwm.edit_distance.lse direction=below vs above are complementary", {
     test_interval <- gintervals(1, 200, 240)
 
     # Get the actual LSE score
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1413,7 +1418,8 @@ test_that("pwm.edit_distance.lse direction=below vs above are complementary", {
     )
 
     result <- gextract(c("v_lse_above_low", "v_lse_below_low"),
-        test_interval, iterator = test_interval
+        test_interval,
+        iterator = test_interval
     )
 
     above_val <- result$v_lse_above_low[1]
@@ -1445,7 +1451,8 @@ test_that("pwm.edit_distance.lse direction=below vs above are complementary", {
     )
 
     result2 <- gextract(c("v_lse_above_high", "v_lse_below_high"),
-        test_interval, iterator = test_interval
+        test_interval,
+        iterator = test_interval
     )
 
     above_val2 <- result2$v_lse_above_high[1]
@@ -1476,7 +1483,8 @@ test_that("pwm.edit_distance.lse.pos direction=below returns valid position", {
     test_interval <- gintervals(1, 200, 250)
 
     # Get the actual LSE score
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1500,7 +1508,8 @@ test_that("pwm.edit_distance.lse.pos direction=below returns valid position", {
     )
 
     result <- gextract(c("v_lse_below_edist", "v_lse_below_pos"),
-        test_interval, iterator = test_interval
+        test_interval,
+        iterator = test_interval
     )
 
     edist_val <- result$v_lse_below_edist[1]
@@ -1542,10 +1551,12 @@ test_that("pwm.edit_distance.lse direction=below edit count is consistent with m
     test_interval <- gintervals(1, 200, 250)
 
     # Get the actual LSE score and the max-window score
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
-    gvtrack.create("v_max_score", NULL, func = "pwm.max",
+    gvtrack.create("v_max_score", NULL,
+        func = "pwm.max",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     scores <- gextract(c("v_lse_score", "v_max_score"), test_interval, iterator = test_interval)
@@ -1569,7 +1580,8 @@ test_that("pwm.edit_distance.lse direction=below edit count is consistent with m
     )
 
     result <- gextract(c("v_lse_below_edist", "v_max_below_edist"),
-        test_interval, iterator = test_interval
+        test_interval,
+        iterator = test_interval
     )
 
     lse_edits <- result$v_lse_below_edist[1]
@@ -1607,7 +1619,8 @@ test_that("pwm.edit_distance.lse direction=below threshold monotonicity", {
     test_interval <- gintervals(1, 200, 240)
 
     # Get the actual LSE score
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1667,7 +1680,8 @@ test_that("pwm.edit_distance.lse direction=below with bidirectional", {
     test_interval <- gintervals(1, 200, 250)
 
     # Get LSE score to set a meaningful threshold
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1698,7 +1712,8 @@ test_that("pwm.edit_distance.lse direction=below with bidirectional", {
     )
 
     result <- gextract(c("v_lse_below_fwd", "v_lse_below_rev", "v_lse_below_bidi"),
-        test_interval, iterator = test_interval
+        test_interval,
+        iterator = test_interval
     )
 
     fwd <- result$v_lse_below_fwd[1]
@@ -1736,7 +1751,8 @@ test_that("pwm.edit_distance.lse direction=below with max_edits cap", {
     test_interval <- gintervals(1, 200, 250)
 
     # Get LSE score to set a threshold that needs edits
-    gvtrack.create("v_lse_score", NULL, func = "pwm",
+    gvtrack.create("v_lse_score", NULL,
+        func = "pwm",
         pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
     )
     lse_result <- gextract("v_lse_score", test_interval, iterator = test_interval)
@@ -1767,7 +1783,8 @@ test_that("pwm.edit_distance.lse direction=below with max_edits cap", {
     )
 
     result <- gextract(c("v_lse_below_unlim", "v_lse_below_max1", "v_lse_below_max5"),
-        test_interval, iterator = test_interval
+        test_interval,
+        iterator = test_interval
     )
 
     unlim <- result$v_lse_below_unlim[1]

--- a/tests/testthat/test-pwm-edit-distance-below.R
+++ b/tests/testthat/test-pwm-edit-distance-below.R
@@ -1,0 +1,695 @@
+create_isolated_test_db()
+
+test_that("pwm.edit_distance direction=below basic functionality works", {
+    remove_all_vtracks()
+
+    # Create simple PSSM: AC motif
+    pssm <- create_test_pssm()
+
+    test_intervals <- gintervals(1, 200, 240)
+    seq <- toupper(gseq.extract(test_intervals))
+
+    # Threshold low enough that most windows are already above it
+    # (requiring edits to bring score below)
+    threshold <- -5.0
+    gvtrack.create("edist_below", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("edist_below", test_intervals, iterator = test_intervals)
+
+    # Manual calculation
+    expected <- manual_pwm_edit_distance_below(seq, pssm, threshold)
+
+    if (is.na(expected)) {
+        expect_true(is.na(result$edist_below[1]))
+    } else {
+        expect_equal(result$edist_below[1], expected, tolerance = 1e-6)
+    }
+})
+
+test_that("pwm.edit_distance direction=below returns 0 when already below threshold", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm() # AC motif
+
+    test_intervals <- gintervals(1, 200, 240)
+
+    # Threshold very high: all windows should already score below it
+    threshold <- 100.0
+    gvtrack.create("edist_below_already", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("edist_below_already", test_intervals, iterator = test_intervals)
+
+    # Should need 0 edits since all windows score way below the high threshold
+    expect_equal(result$edist_below_already[1], 0, tolerance = 1e-6)
+})
+
+test_that("pwm.edit_distance direction=below returns NA for unreachable threshold", {
+    remove_all_vtracks()
+
+    # Create a PSSM where minimum score is bounded
+    # If all positions have uniform probabilities, col_min is known
+    pssm <- matrix(c(
+        0.25, 0.25, 0.25, 0.25, # Uniform
+        0.25, 0.25, 0.25, 0.25 # Uniform
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(1, 200, 240)
+
+    # Threshold far below what's possible: S_min = 2 * log(0.25) = -2.77
+    # Any threshold below S_min should be unreachable
+    threshold <- -100.0
+    gvtrack.create("edist_below_impossible", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("edist_below_impossible", test_intervals, iterator = test_intervals)
+
+    # Should return NA: even switching all bases to worst can't push score below -100
+    expect_true(is.na(result$edist_below_impossible[1]))
+})
+
+test_that("pwm.edit_distance direction=below matches R reference on multiple intervals", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05, # Strong A
+        0.1, 0.8, 0.05, 0.05, # Strong C
+        0.1, 0.05, 0.8, 0.05 # Strong G
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(
+        chrom = c(1, 1, 1),
+        start = c(200, 300, 400),
+        end = c(230, 330, 430)
+    )
+
+    threshold <- -3.5
+
+    gvtrack.create("edist_below_ref", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("edist_below_ref", test_intervals, iterator = test_intervals)
+
+    # Verify each interval against manual reference
+    for (i in seq_len(nrow(test_intervals))) {
+        seq <- toupper(gseq.extract(test_intervals[i, ]))
+        expected <- manual_pwm_edit_distance_below(seq, pssm, threshold)
+
+        if (is.na(expected)) {
+            expect_true(is.na(result$edist_below_ref[i]),
+                info = paste("Interval", i, "expected NA")
+            )
+        } else {
+            expect_equal(result$edist_below_ref[i], expected,
+                tolerance = 1e-6,
+                info = paste("Interval", i)
+            )
+        }
+    }
+})
+
+test_that("pwm.edit_distance direction=below max_edits cap works", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    test_intervals <- gintervals(1, 200, 240)
+    seq <- toupper(gseq.extract(test_intervals))
+
+    # Use a threshold that requires edits
+    threshold <- -5.0
+
+    # Without max_edits
+    gvtrack.create("edist_below_exact", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # With max_edits = 1 (only windows needing at most 1 edit work)
+    gvtrack.create("edist_below_max1", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold, max_edits = 1,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_below_exact", "edist_below_max1"),
+        test_intervals,
+        iterator = test_intervals
+    )
+
+    exact_edits <- manual_pwm_edit_distance_below(seq, pssm, threshold)
+    max1_edits <- manual_pwm_edit_distance_below(seq, pssm, threshold, max_edits = 1)
+
+    if (is.na(exact_edits)) {
+        expect_true(is.na(result$edist_below_exact[1]))
+    } else {
+        expect_equal(result$edist_below_exact[1], exact_edits, tolerance = 1e-6)
+    }
+
+    if (is.na(max1_edits)) {
+        expect_true(is.na(result$edist_below_max1[1]))
+    } else {
+        expect_equal(result$edist_below_max1[1], max1_edits, tolerance = 1e-6)
+    }
+
+    # If exact needs > 1 edit, max1 should return NA
+    if (!is.na(exact_edits) && exact_edits > 1) {
+        expect_true(is.na(result$edist_below_max1[1]))
+    }
+})
+
+test_that("pwm.edit_distance direction=below bidirectional considers both strands", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    test_interval <- gintervals(1, 200, 240)
+    threshold <- -5.0
+
+    # Forward only
+    gvtrack.create("edist_below_fwd", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, strand = 1, extend = FALSE, prior = 0
+    )
+
+    # Reverse only
+    gvtrack.create("edist_below_rev", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, strand = -1, extend = FALSE, prior = 0
+    )
+
+    # Bidirectional
+    gvtrack.create("edist_below_bidi", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = TRUE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_below_fwd", "edist_below_rev", "edist_below_bidi"),
+        test_interval,
+        iterator = test_interval
+    )
+
+    # Bidirectional should return minimum of both strands
+    fwd <- result$edist_below_fwd[1]
+    rev <- result$edist_below_rev[1]
+    bidi <- result$edist_below_bidi[1]
+
+    if (!is.na(fwd) && !is.na(rev)) {
+        expect_equal(bidi, min(fwd, rev), tolerance = 1e-6)
+    } else if (!is.na(fwd)) {
+        expect_equal(bidi, fwd, tolerance = 1e-6)
+    } else if (!is.na(rev)) {
+        expect_equal(bidi, rev, tolerance = 1e-6)
+    }
+})
+
+test_that("pwm.edit_distance.pos and pwm.max.edit_distance work with direction=below", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05,
+        0.1, 0.05, 0.8, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    motif_len <- nrow(pssm)
+    test_interval <- gintervals(1, 200, 250)
+    seq <- toupper(gseq.extract(test_interval))
+    threshold <- -4.0
+
+    gvtrack.create("edist_below_min", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    gvtrack.create("edist_below_pos", NULL,
+        func = "pwm.edit_distance.pos",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    gvtrack.create("edist_below_max_site", NULL,
+        func = "pwm.max.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    gvtrack.create("pwm_max_pos_below", NULL,
+        func = "pwm.max.pos",
+        pssm = pssm, bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_min", "edist_below_pos", "edist_below_max_site", "pwm_max_pos_below"),
+        test_interval,
+        iterator = test_interval
+    )
+
+    # Check min edit distance against R reference
+    expected_min <- manual_pwm_edit_distance_below(seq, pssm, threshold)
+    if (is.na(expected_min)) {
+        expect_true(is.na(result$edist_below_min[1]))
+    } else {
+        expect_equal(result$edist_below_min[1], expected_min, tolerance = 1e-6)
+    }
+
+    # Check position: find the first window that achieves the minimum edit distance
+    if (!is.na(expected_min)) {
+        best_pos_idx <- NA_integer_
+        for (start_idx in seq_len(nchar(seq) - motif_len + 1)) {
+            window_seq <- substr(seq, start_idx, start_idx + motif_len - 1)
+            cand_edits <- manual_pwm_edit_distance_below(window_seq, pssm, threshold, scan_all = FALSE)
+            if (!is.na(cand_edits) && abs(cand_edits - expected_min) < 1e-6) {
+                best_pos_idx <- start_idx
+                break
+            }
+        }
+        expect_false(is.na(best_pos_idx))
+        expect_equal(result$edist_below_pos[1], best_pos_idx, tolerance = 1e-6)
+    }
+
+    # Check pwm.max.edit_distance: edits at the max-scoring window
+    pwm_pos_val <- result$pwm_max_pos_below[1]
+    if (!is.na(pwm_pos_val)) {
+        pwm_start_offset <- as.integer(round(pwm_pos_val)) - 1L
+        expect_true(pwm_start_offset >= 0)
+        pwm_window <- gintervals(
+            test_interval$chrom,
+            test_interval$start + pwm_start_offset,
+            test_interval$start + pwm_start_offset + motif_len
+        )
+        pwm_seq <- toupper(gseq.extract(pwm_window))
+        expected_pwm_edits <- manual_pwm_edit_distance_below(pwm_seq, pssm, threshold, scan_all = FALSE)
+        if (is.na(expected_pwm_edits)) {
+            expect_true(is.na(result$edist_below_max_site[1]))
+        } else {
+            expect_equal(result$edist_below_max_site[1], expected_pwm_edits, tolerance = 1e-6)
+        }
+    }
+})
+
+test_that("pwm.edit_distance direction=below with score.min/score.max filtering", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    test_interval <- gintervals(1, 200, 240)
+    threshold <- -5.0
+
+    # Without score filters
+    gvtrack.create("edist_below_nofilt", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # With -Inf score.min (should not filter anything)
+    gvtrack.create("edist_below_lowfilt", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        score.min = -Inf,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # With very high score.min (filters out most windows)
+    gvtrack.create("edist_below_highfilt", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        score.min = 0.0,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(
+        c("edist_below_nofilt", "edist_below_lowfilt", "edist_below_highfilt"),
+        test_interval,
+        iterator = test_interval
+    )
+
+    # Low filter should match no-filter
+    expect_equal(result$edist_below_nofilt[1], result$edist_below_lowfilt[1], tolerance = 1e-6)
+
+    # High filter should either be NA or >= unfiltered result
+    if (!is.na(result$edist_below_highfilt[1]) && !is.na(result$edist_below_nofilt[1])) {
+        expect_true(result$edist_below_highfilt[1] >= result$edist_below_nofilt[1])
+    }
+})
+
+test_that("pwm.edit_distance direction=below with 1bp iterator matches R reference", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+    motif_len <- nrow(pssm)
+
+    test_interval <- gintervals(1, 200, 210)
+    threshold <- -5.0
+
+    gvtrack.create("edist_below_1bp", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = TRUE, prior = 0
+    )
+
+    result_1bp <- gextract("edist_below_1bp", test_interval, iterator = 1)
+
+    expect_true(nrow(result_1bp) > 0)
+
+    # Check a few positions manually
+    for (idx in 1:min(3, nrow(result_1bp))) {
+        pos <- result_1bp$start[idx]
+        seq_window <- toupper(gseq.extract(gintervals(1, pos, pos + motif_len)))
+        expected <- manual_pwm_edit_distance_below(seq_window, pssm, threshold)
+
+        if (is.na(expected)) {
+            expect_true(is.na(result_1bp$edist_below_1bp[idx]),
+                info = paste("Position", pos)
+            )
+        } else {
+            expect_equal(result_1bp$edist_below_1bp[idx], expected,
+                tolerance = 1e-6,
+                info = paste("Position", pos)
+            )
+        }
+    }
+})
+
+test_that("pwm.edit_distance direction=below vs direction=above are complementary", {
+    remove_all_vtracks()
+
+    pssm <- matrix(c(
+        0.8, 0.1, 0.05, 0.05,
+        0.1, 0.8, 0.05, 0.05
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 240)
+    threshold <- -3.0
+
+    gvtrack.create("edist_above", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "above",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    gvtrack.create("edist_below", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_above", "edist_below"), test_interval, iterator = test_interval)
+
+    above_val <- result$edist_above[1]
+    below_val <- result$edist_below[1]
+
+    # If above needs 0 edits (score >= threshold), below should need >= 1 edit
+    # (since score is already at/above threshold, need to push it down).
+    # Conversely, if below needs 0 edits (score <= threshold), above needs >= 1.
+    # They can't both be 0 unless the score equals the threshold exactly.
+    if (!is.na(above_val) && above_val == 0 && !is.na(below_val)) {
+        # Score >= threshold, so below needs edits (or happens to be exactly at threshold)
+        expect_true(below_val >= 0)
+    }
+    if (!is.na(below_val) && below_val == 0 && !is.na(above_val)) {
+        # Score <= threshold, so above needs edits (or exactly at threshold)
+        expect_true(above_val >= 0)
+    }
+
+    # Both should always be non-negative when not NA
+    if (!is.na(above_val)) expect_true(above_val >= 0)
+    if (!is.na(below_val)) expect_true(below_val >= 0)
+})
+
+test_that("pwm.edit_distance direction=below with longer motif matches R reference", {
+    remove_all_vtracks()
+
+    # 6bp motif
+    pssm <- matrix(c(
+        0.9, 0.03, 0.03, 0.04,
+        0.03, 0.9, 0.03, 0.04,
+        0.03, 0.03, 0.9, 0.04,
+        0.04, 0.03, 0.03, 0.9,
+        0.9, 0.03, 0.03, 0.04,
+        0.03, 0.9, 0.03, 0.04
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 250)
+    seq <- toupper(gseq.extract(test_interval))
+    threshold <- -5.0
+
+    gvtrack.create("edist_below_6bp", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("edist_below_6bp", test_interval, iterator = test_interval)
+
+    expected <- manual_pwm_edit_distance_below(seq, pssm, threshold)
+
+    if (is.na(expected)) {
+        expect_true(is.na(result$edist_below_6bp[1]))
+    } else {
+        expect_equal(result$edist_below_6bp[1], expected, tolerance = 1e-6)
+    }
+})
+
+test_that("pwm.edit_distance direction=below with different thresholds is monotone", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    test_interval <- gintervals(1, 200, 240)
+    seq <- toupper(gseq.extract(test_interval))
+
+    # Thresholds from low to high
+    thresholds <- c(-10.0, -5.0, -2.0, 0.0)
+    vnames <- sprintf("edist_below_%d", seq_along(thresholds))
+
+    for (i in seq_along(thresholds)) {
+        gvtrack.create(vnames[i], NULL,
+            func = "pwm.edit_distance",
+            pssm = pssm, score.thresh = thresholds[i],
+            direction = "below",
+            bidirect = FALSE, extend = FALSE, prior = 0
+        )
+    }
+
+    result <- gextract(vnames, test_interval, iterator = test_interval)
+
+    # Lower thresholds should require more (or equal) edits to reach below them
+    edits <- sapply(vnames, function(v) result[[v]][1])
+    finite_edits <- edits[!is.na(edits)]
+    if (length(finite_edits) > 1) {
+        # Lower thresholds require more edits in the "below" direction
+        # Since thresholds go from low to high, edits should go from high to low
+        expect_true(all(diff(finite_edits) <= 0),
+            info = paste("Edits should decrease with increasing threshold. Got:", paste(finite_edits, collapse = ", "))
+        )
+    }
+
+    # Verify each against R reference
+    for (i in seq_along(thresholds)) {
+        expected <- manual_pwm_edit_distance_below(seq, pssm, thresholds[i])
+        if (is.na(expected)) {
+            expect_true(is.na(result[[vnames[i]]][1]))
+        } else {
+            expect_equal(result[[vnames[i]]][1], expected, tolerance = 1e-6)
+        }
+    }
+})
+
+test_that("pwm.edit_distance direction=below with max_edits consistency", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    test_interval <- gintervals(1, 200, 240)
+    threshold <- -5.0
+
+    # Create vtracks with different max_edits settings
+    gvtrack.create("edist_below_exact", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    for (k in 1:3) {
+        vname <- sprintf("edist_below_max%d", k)
+        gvtrack.create(vname, NULL,
+            func = "pwm.edit_distance",
+            pssm = pssm, score.thresh = threshold, max_edits = k,
+            direction = "below",
+            bidirect = FALSE, extend = FALSE, prior = 0
+        )
+    }
+
+    vnames <- c("edist_below_exact", sprintf("edist_below_max%d", 1:3))
+    result <- gextract(vnames, test_interval, iterator = test_interval)
+
+    exact <- result$edist_below_exact[1]
+
+    for (k in 1:3) {
+        vname <- sprintf("edist_below_max%d", k)
+        if (!is.na(exact) && exact <= k) {
+            expect_equal(result[[vname]][1], exact,
+                tolerance = 1e-6,
+                info = paste("max_edits =", k, "should match exact when exact <=", k)
+            )
+        }
+        if (!is.na(exact) && exact > k) {
+            expect_true(is.na(result[[vname]][1]),
+                info = paste("max_edits =", k, "should be NA when exact =", exact)
+            )
+        }
+    }
+})
+
+test_that("pwm.edit_distance direction=below with extend flag works", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+    motif_len <- nrow(pssm)
+
+    test_interval <- gintervals(1, 200, 202)
+    threshold <- -5.0
+
+    gvtrack.create("edist_below_ext", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = TRUE, prior = 0
+    )
+
+    gvtrack.create("edist_below_noext", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract(c("edist_below_ext", "edist_below_noext"), test_interval, iterator = test_interval)
+
+    # With extend=TRUE, window is expanded to include full motif
+    seq_ext <- toupper(gseq.extract(gintervals(1, 200, 200 + motif_len)))
+    expected_ext <- manual_pwm_edit_distance_below(seq_ext, pssm, threshold)
+
+    # With extend=FALSE, window stays as-is (may be smaller than motif)
+    seq_noext <- toupper(gseq.extract(test_interval))
+    expected_noext <- manual_pwm_edit_distance_below(seq_noext, pssm, threshold)
+
+    if (is.na(expected_ext)) {
+        expect_true(is.na(result$edist_below_ext[1]))
+    } else {
+        expect_equal(result$edist_below_ext[1], expected_ext, tolerance = 1e-6)
+    }
+
+    if (is.na(expected_noext)) {
+        expect_true(is.na(result$edist_below_noext[1]))
+    } else {
+        expect_equal(result$edist_below_noext[1], expected_noext, tolerance = 1e-6)
+    }
+})
+
+test_that("pwm.edit_distance direction=below with zero-probability columns", {
+    remove_all_vtracks()
+
+    # PSSM with zero probabilities: log(0) = -Inf
+    pssm <- matrix(c(
+        1.0, 0.0, 0.0, 0.0, # Only A
+        0.0, 1.0, 0.0, 0.0 # Only C
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_interval <- gintervals(1, 200, 240)
+    seq <- toupper(gseq.extract(test_interval))
+    threshold <- -5.0
+
+    gvtrack.create("edist_below_zeros", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    result <- gextract("edist_below_zeros", test_interval, iterator = test_interval)
+
+    # For a window like "GT" (neither A nor C at first/second position):
+    # score would be log(0) + log(0) = -Inf, which is below any finite threshold.
+    # So if any window has a non-matching base, it's already below.
+    # For "AC": score = log(1) + log(1) = 0 > -5, needs 1 edit to push below.
+    # Manual reference should match.
+    expected <- manual_pwm_edit_distance_below(seq, pssm, threshold)
+
+    if (is.na(expected)) {
+        expect_true(is.na(result$edist_below_zeros[1]))
+    } else {
+        expect_equal(result$edist_below_zeros[1], expected, tolerance = 1e-6)
+    }
+})
+
+test_that("pwm.edit_distance direction=below with gscreen works", {
+    remove_all_vtracks()
+
+    pssm <- create_test_pssm()
+
+    threshold <- -5.0
+
+    gvtrack.create("edist_below_screen", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+
+    # Screen for intervals where below-direction edit distance equals 0
+    # (i.e., score is already at or below threshold)
+    test_intervals <- gintervals(1, 200, 300)
+    result <- gscreen("!is.na(edist_below_screen)", test_intervals, iterator = 10)
+
+    # Result should be a valid intervals data frame (could be empty if all NA)
+    if (!is.null(result) && is.data.frame(result) && nrow(result) > 0) {
+        expect_true(all(c("chrom", "start", "end") %in% names(result)))
+    }
+})


### PR DESCRIPTION
## Summary

- Added `direction` parameter (`"above"`/`"below"`, default `"above"`) to all PWM edit distance functions
- `direction="below"` computes minimum edits to bring PWM score **below** a threshold (motif disruption), symmetric to the existing `"above"` (motif matching)
- Covers all modes: substitution-only, indels, LSE, and `gseq.pwm_edits()`

## Implementation

The "below" direction reuses the existing bin/histogram machinery with loss values (score - col_min) instead of gain values (col_max - score). The greedy algorithm is identical once the bins and deficit are set direction-dependently. For indels, the banded DP minimizes score instead of maximizing. For LSE, the greedy/exhaustive search picks score-reducing edits.

## Test plan

- [x] Substitution-only below: 14 tests (37 expectations) with R reference implementation
- [x] Indel below: 9 tests covering monotonicity, max_indels cap, bidirectional
- [x] LSE below: 9 tests covering exhaustive k≤2, greedy k≥3, threshold monotonicity
- [x] gseq.pwm_edits below: 13 tests (42 expectations) verifying edit correctness, score arithmetic
- [x] Full regression: all existing "above" tests pass unchanged (260 + 200 + 135 = 595 expectations)