### PR TITLE
perf: streaming I/O for ggenome.implant

### DIFF
--- a/R/genome-edit.R
+++ b/R/genome-edit.R
@@ -36,42 +36,6 @@
 }
 
 
-#' Stream-process a FASTA file chromosome by chromosome
-#'
-#' Reads a FASTA file and calls \code{callback(chrom_name, seq_raw)} for each
-#' chromosome, where \code{seq_raw} is the uppercase sequence as a raw vector.
-#' Only one chromosome is in memory at a time.
-#'
-#' @param fasta_path Path to FASTA file
-#' @param callback Function taking (chrom_name, seq_raw). Return value ignored.
-#' @return Character vector of chromosome names in file order (invisibly).
-#' @noRd
-.stream_fasta <- function(fasta_path, callback) {
-    # Bulk-read all lines (fast), then iterate by chromosome
-    lines <- readLines(fasta_path, warn = FALSE)
-    header_idx <- which(startsWith(lines, ">"))
-    if (length(header_idx) == 0L) {
-        stop("No FASTA headers found in: ", fasta_path, call. = FALSE)
-    }
-
-    chrom_names <- sub("^>\\s*", "", sub("\\s.*", "", lines[header_idx]))
-
-    for (i in seq_along(header_idx)) {
-        seq_start <- header_idx[i] + 1L
-        seq_end <- if (i < length(header_idx)) header_idx[i + 1L] - 1L else length(lines)
-
-        if (seq_start > seq_end) {
-            seq_raw <- raw(0)
-        } else {
-            seq_raw <- charToRaw(toupper(paste0(lines[seq_start:seq_end], collapse = "")))
-        }
-        callback(chrom_names[i], seq_raw)
-    }
-
-    invisible(chrom_names)
-}
-
-
 #' Implant donor sequences into a reference genome
 #'
 #' Replaces specified intervals in a reference genome with donor DNA sequences

--- a/R/genome-edit.R
+++ b/R/genome-edit.R
@@ -1,41 +1,5 @@
 # Genome Editing: Replace intervals in a reference genome with donor sequences
 
-#' Read a FASTA file into a named list of sequences
-#'
-#' @param fasta_path Path to FASTA file
-#' @return Named list with chromosome names as keys and full sequences as values
-#' @noRd
-.read_fasta <- function(fasta_path) {
-    lines <- readLines(fasta_path)
-    if (length(lines) == 0L) {
-        stop("FASTA file is empty: ", fasta_path, call. = FALSE)
-    }
-
-    header_idx <- which(startsWith(lines, ">"))
-    if (length(header_idx) == 0L) {
-        stop("No FASTA headers found in: ", fasta_path, call. = FALSE)
-    }
-
-    # Pre-allocate result list
-    chrom_names <- sub("^>\\s*", "", sub("\\s.*", "", lines[header_idx]))
-    result <- vector("list", length(chrom_names))
-    names(result) <- chrom_names
-
-    # For each header, concatenate all sequence lines until the next header
-    for (i in seq_along(header_idx)) {
-        start <- header_idx[i] + 1L
-        end <- if (i < length(header_idx)) header_idx[i + 1L] - 1L else length(lines)
-        if (start > end) {
-            result[[i]] <- ""
-        } else {
-            result[[i]] <- paste0(lines[start:end], collapse = "")
-        }
-    }
-
-    result
-}
-
-
 #' Implant donor sequences into a reference genome
 #'
 #' Replaces specified intervals in a reference genome with donor DNA sequences

--- a/R/genome-edit.R
+++ b/R/genome-edit.R
@@ -47,104 +47,28 @@
 #' @return Character vector of chromosome names in file order (invisibly).
 #' @noRd
 .stream_fasta <- function(fasta_path, callback) {
-    con <- file(fasta_path, open = "rb")
-    on.exit(close(con), add = TRUE)
-
-    chrom_names <- character(0)
-    current_chrom <- NULL
-    chunks <- list()
-
-    while (TRUE) {
-        line <- readLines(con, n = 1L, warn = FALSE)
-        if (length(line) == 0L) break
-
-        if (startsWith(line, ">")) {
-            # Flush previous chromosome
-            if (!is.null(current_chrom)) {
-                seq_raw <- charToRaw(toupper(paste0(chunks, collapse = "")))
-                callback(current_chrom, seq_raw)
-            }
-            current_chrom <- sub("^>\\s*", "", sub("\\s.*", "", line))
-            chrom_names <- c(chrom_names, current_chrom)
-            chunks <- list()
-        } else {
-            chunks[[length(chunks) + 1L]] <- line
-        }
+    # Bulk-read all lines (fast), then iterate by chromosome
+    lines <- readLines(fasta_path, warn = FALSE)
+    header_idx <- which(startsWith(lines, ">"))
+    if (length(header_idx) == 0L) {
+        stop("No FASTA headers found in: ", fasta_path, call. = FALSE)
     }
 
-    # Flush last chromosome
-    if (!is.null(current_chrom)) {
-        seq_raw <- charToRaw(toupper(paste0(chunks, collapse = "")))
-        callback(current_chrom, seq_raw)
+    chrom_names <- sub("^>\\s*", "", sub("\\s.*", "", lines[header_idx]))
+
+    for (i in seq_along(header_idx)) {
+        seq_start <- header_idx[i] + 1L
+        seq_end <- if (i < length(header_idx)) header_idx[i + 1L] - 1L else length(lines)
+
+        if (seq_start > seq_end) {
+            seq_raw <- raw(0)
+        } else {
+            seq_raw <- charToRaw(toupper(paste0(lines[seq_start:seq_end], collapse = "")))
+        }
+        callback(chrom_names[i], seq_raw)
     }
 
     invisible(chrom_names)
-}
-
-
-#' Write a raw-vector sequence to a FASTA connection with fixed-width lines
-#'
-#' Also returns the .fai metadata for the written entry.
-#'
-#' @param con A writable binary connection.
-#' @param chrom_name Chromosome name.
-#' @param seq_raw Raw vector of uppercase ASCII sequence bytes.
-#' @param line_width Bases per line.
-#' @param byte_offset Current byte offset in the file (before this call).
-#' @return Named list with fai fields: name, length, offset, linebases, linewidth,
-#'   and total_bytes (bytes written by this call).
-#' @noRd
-.write_fasta_chrom_raw <- function(con, chrom_name, seq_raw, line_width, byte_offset) {
-    header <- paste0(">", chrom_name, "\n")
-    header_bytes <- charToRaw(header)
-    writeBin(header_bytes, con)
-
-    seq_len <- length(seq_raw)
-    if (seq_len == 0L) {
-        return(list(
-            name = chrom_name, length = 0L,
-            offset = byte_offset + length(header_bytes),
-            linebases = 0L, linewidth = 0L,
-            total_bytes = length(header_bytes)
-        ))
-    }
-
-    # Write sequence in fixed-width lines, binary mode
-    newline_raw <- charToRaw("\n")
-    data_offset <- byte_offset + length(header_bytes)
-    actual_linebases <- min(line_width, seq_len)
-    data_bytes <- 0L
-    pos <- 1L
-    while (pos <= seq_len) {
-        chunk_end <- min(pos + line_width - 1L, seq_len)
-        writeBin(seq_raw[pos:chunk_end], con)
-        writeBin(newline_raw, con)
-        data_bytes <- data_bytes + (chunk_end - pos + 1L) + 1L
-        pos <- chunk_end + 1L
-    }
-
-    list(
-        name = chrom_name, length = seq_len,
-        offset = data_offset,
-        linebases = actual_linebases,
-        linewidth = actual_linebases + 1L, # +1 for newline
-        total_bytes = length(header_bytes) + data_bytes
-    )
-}
-
-
-#' Write a .fai index from pre-computed metadata
-#'
-#' @param fai_path Path to write the .fai file.
-#' @param fai_entries List of lists, each with name/length/offset/linebases/linewidth.
-#' @return Invisibly returns the .fai path.
-#' @noRd
-.write_fai_from_entries <- function(fai_path, fai_entries) {
-    lines <- vapply(fai_entries, function(e) {
-        paste(e$name, e$length, e$offset, e$linebases, e$linewidth, sep = "\t")
-    }, character(1))
-    writeLines(lines, fai_path)
-    invisible(fai_path)
 }
 
 
@@ -320,69 +244,28 @@ ggenome.implant <- function(intervals, donor, output, genome_fasta = NULL,
         }
     }
 
-    # --- build perturbation index by chrom ---------------------------------
     interval_chroms <- as.character(intervals$chrom)
-    pert_by_chrom <- split(seq_len(nrow(intervals)), interval_chroms)
-    # Sort each chromosome's perturbations by start position descending
-    for (chr_name in names(pert_by_chrom)) {
-        idx <- pert_by_chrom[[chr_name]]
-        pert_by_chrom[[chr_name]] <- idx[order(-intervals$start[idx])]
-    }
 
-    # Pre-convert donor sequences to raw vectors (once)
-    donor_raws <- lapply(toupper(donor_seqs), charToRaw)
-
-    # --- stream: read each chrom, apply perturbations, write output --------
-    fai_entries <- list()
-    byte_offset <- 0L
-    chrom_names_seen <- character(0)
-
-    # Use a block so the output file is closed before gdb.create reads it
-    local({
-        out_con <- file(output, open = "wb")
-        on.exit(close(out_con), add = TRUE)
-
-        .stream_fasta(genome_fasta, function(chrom_name, seq_raw) {
-            chrom_names_seen <<- c(chrom_names_seen, chrom_name)
-
-            # Apply perturbations for this chromosome using raw vector replacement
-            idx_list <- pert_by_chrom[[chrom_name]]
-            if (!is.null(idx_list)) {
-                chrom_len <- length(seq_raw)
-                for (i in idx_list) {
-                    s <- intervals$start[i] # 0-based
-                    e <- intervals$end[i] # 0-based, exclusive
-                    if (s < 0 || e > chrom_len) {
-                        stop(sprintf(
-                            "Interval out of bounds: %s:%d-%d (chromosome length: %d)",
-                            chrom_name, s, e, chrom_len
-                        ), call. = FALSE)
-                    }
-                    # raw vector is 1-based: positions (s+1) to e
-                    seq_raw[(s + 1L):e] <- donor_raws[[i]]
-                }
-            }
-
-            # Write and collect .fai metadata
-            entry <- .write_fasta_chrom_raw(out_con, chrom_name, seq_raw, line_width, byte_offset)
-            byte_offset <<- byte_offset + entry$total_bytes
-            fai_entries[[length(fai_entries) + 1L]] <<- entry
-        })
-    })
+    # --- C++ fast path: read FASTA, apply perturbations, write output + .fai
+    fai_df <- .gcall(
+        "C_ggenome_implant",
+        genome_fasta, output,
+        as.character(intervals$chrom),
+        as.integer(intervals$start),
+        as.integer(intervals$end),
+        toupper(donor_seqs),
+        as.integer(line_width)
+    )
 
     # Validate that all interval chromosomes were found in reference
-    missing_chroms <- setdiff(unique(interval_chroms), chrom_names_seen)
+    missing_chroms <- setdiff(unique(interval_chroms), fai_df$name)
     if (length(missing_chroms) > 0L) {
-        # Clean up partial output
         unlink(output)
         stop(sprintf(
             "Chromosome(s) not found in reference: %s",
             paste(missing_chroms, collapse = ", ")
         ), call. = FALSE)
     }
-
-    # --- write .fai index (from collected metadata, no re-read) ------------
-    .write_fai_from_entries(paste0(output, ".fai"), fai_entries)
 
     # --- create trackdb ---
     if (create_trackdb) {

--- a/R/genome-edit.R
+++ b/R/genome-edit.R
@@ -35,87 +35,115 @@
     result
 }
 
-#' Write sequences as a FASTA file with fixed-width lines
+
+#' Stream-process a FASTA file chromosome by chromosome
 #'
-#' @param sequences Named list of sequences (name -> sequence string)
-#' @param output Path to output file
-#' @param line_width Bases per line
-#' @return Invisibly returns the output path
+#' Reads a FASTA file and calls \code{callback(chrom_name, seq_raw)} for each
+#' chromosome, where \code{seq_raw} is the uppercase sequence as a raw vector.
+#' Only one chromosome is in memory at a time.
+#'
+#' @param fasta_path Path to FASTA file
+#' @param callback Function taking (chrom_name, seq_raw). Return value ignored.
+#' @return Character vector of chromosome names in file order (invisibly).
 #' @noRd
-.write_fasta <- function(sequences, output, line_width = 80L) {
-    con <- file(output, open = "wt")
+.stream_fasta <- function(fasta_path, callback) {
+    con <- file(fasta_path, open = "rb")
     on.exit(close(con), add = TRUE)
 
-    for (chrom_name in names(sequences)) {
-        writeLines(paste0(">", chrom_name), con)
-        seq_str <- sequences[[chrom_name]]
-        seq_len <- nchar(seq_str)
-        if (seq_len == 0L) next
+    chrom_names <- character(0)
+    current_chrom <- NULL
+    chunks <- list()
 
-        line_starts <- seq.int(1L, seq_len, by = line_width)
-        line_ends <- pmin(line_starts + line_width - 1L, seq_len)
-        writeLines(substring(seq_str, line_starts, line_ends), con)
+    while (TRUE) {
+        line <- readLines(con, n = 1L, warn = FALSE)
+        if (length(line) == 0L) break
+
+        if (startsWith(line, ">")) {
+            # Flush previous chromosome
+            if (!is.null(current_chrom)) {
+                seq_raw <- charToRaw(toupper(paste0(chunks, collapse = "")))
+                callback(current_chrom, seq_raw)
+            }
+            current_chrom <- sub("^>\\s*", "", sub("\\s.*", "", line))
+            chrom_names <- c(chrom_names, current_chrom)
+            chunks <- list()
+        } else {
+            chunks[[length(chunks) + 1L]] <- line
+        }
     }
 
-    invisible(output)
+    # Flush last chromosome
+    if (!is.null(current_chrom)) {
+        seq_raw <- charToRaw(toupper(paste0(chunks, collapse = "")))
+        callback(current_chrom, seq_raw)
+    }
+
+    invisible(chrom_names)
 }
 
-#' Write a FASTA index (.fai) file
+
+#' Write a raw-vector sequence to a FASTA connection with fixed-width lines
 #'
-#' Creates a samtools-compatible .fai index alongside a FASTA file.
-#' The .fai format is: name\\tlength\\toffset\\tlinebases\\tlinewidth
-#' where linewidth includes the newline character.
+#' Also returns the .fai metadata for the written entry.
 #'
-#' @param fasta_path Path to the FASTA file to index
-#' @param line_width Number of bases per line used when writing
-#' @return Invisibly returns the .fai path
+#' @param con A writable binary connection.
+#' @param chrom_name Chromosome name.
+#' @param seq_raw Raw vector of uppercase ASCII sequence bytes.
+#' @param line_width Bases per line.
+#' @param byte_offset Current byte offset in the file (before this call).
+#' @return Named list with fai fields: name, length, offset, linebases, linewidth,
+#'   and total_bytes (bytes written by this call).
 #' @noRd
-.write_fai <- function(fasta_path, line_width = 80L) {
-    fai_path <- paste0(fasta_path, ".fai")
-    lines <- readLines(fasta_path)
+.write_fasta_chrom_raw <- function(con, chrom_name, seq_raw, line_width, byte_offset) {
+    header <- paste0(">", chrom_name, "\n")
+    header_bytes <- charToRaw(header)
+    writeBin(header_bytes, con)
 
-    header_idx <- which(startsWith(lines, ">"))
-    if (length(header_idx) == 0L) {
-        stop("No FASTA headers found in: ", fasta_path, call. = FALSE)
+    seq_len <- length(seq_raw)
+    if (seq_len == 0L) {
+        return(list(
+            name = chrom_name, length = 0L,
+            offset = byte_offset + length(header_bytes),
+            linebases = 0L, linewidth = 0L,
+            total_bytes = length(header_bytes)
+        ))
     }
 
-    fai_entries <- character(length(header_idx))
-
-    for (i in seq_along(header_idx)) {
-        chrom_name <- sub("^>\\s*", "", sub("\\s.*", "", lines[header_idx[i]]))
-
-        seq_start <- header_idx[i] + 1L
-        seq_end <- if (i < length(header_idx)) header_idx[i + 1L] - 1L else length(lines)
-
-        if (seq_start > seq_end) {
-            seq_length <- 0L
-        } else {
-            seq_lines <- lines[seq_start:seq_end]
-            seq_length <- sum(nchar(seq_lines))
-        }
-
-        # Calculate byte offset to the first sequence character
-        # Each previous line has its content + newline (\n)
-        offset <- 0L
-        for (j in seq_len(header_idx[i])) {
-            offset <- offset + nchar(lines[j]) + 1L # +1 for newline
-        }
-
-        # linebases/linewidth must reflect the actual first sequence line,
-        # not the requested wrap width — short contigs may fit on one line.
-        if (seq_start > seq_end) {
-            linebases <- 0L
-            linewidth <- 0L
-        } else {
-            first_line_len <- nchar(lines[seq_start])
-            linebases <- first_line_len
-            linewidth <- first_line_len + 1L # +1 for newline character
-        }
-
-        fai_entries[i] <- paste(chrom_name, seq_length, offset, linebases, linewidth, sep = "\t")
+    # Write sequence in fixed-width lines, binary mode
+    newline_raw <- charToRaw("\n")
+    data_offset <- byte_offset + length(header_bytes)
+    actual_linebases <- min(line_width, seq_len)
+    data_bytes <- 0L
+    pos <- 1L
+    while (pos <= seq_len) {
+        chunk_end <- min(pos + line_width - 1L, seq_len)
+        writeBin(seq_raw[pos:chunk_end], con)
+        writeBin(newline_raw, con)
+        data_bytes <- data_bytes + (chunk_end - pos + 1L) + 1L
+        pos <- chunk_end + 1L
     }
 
-    writeLines(fai_entries, fai_path)
+    list(
+        name = chrom_name, length = seq_len,
+        offset = data_offset,
+        linebases = actual_linebases,
+        linewidth = actual_linebases + 1L, # +1 for newline
+        total_bytes = length(header_bytes) + data_bytes
+    )
+}
+
+
+#' Write a .fai index from pre-computed metadata
+#'
+#' @param fai_path Path to write the .fai file.
+#' @param fai_entries List of lists, each with name/length/offset/linebases/linewidth.
+#' @return Invisibly returns the .fai path.
+#' @noRd
+.write_fai_from_entries <- function(fai_path, fai_entries) {
+    lines <- vapply(fai_entries, function(e) {
+        paste(e$name, e$length, e$offset, e$linebases, e$linewidth, sep = "\t")
+    }, character(1))
+    writeLines(lines, fai_path)
     invisible(fai_path)
 }
 
@@ -280,7 +308,7 @@ ggenome.implant <- function(intervals, donor, output, genome_fasta = NULL,
         ), call. = FALSE)
     }
 
-    # --- load reference FASTA ---
+    # --- resolve reference FASTA path ---
     if (is.null(genome_fasta)) {
         .gcheckroot()
         genome_fasta <- tempfile(fileext = ".fa")
@@ -292,56 +320,69 @@ ggenome.implant <- function(intervals, donor, output, genome_fasta = NULL,
         }
     }
 
-    sequences <- .read_fasta(genome_fasta)
-
-    # --- validate intervals against reference ---
-    chroms_in_ref <- names(sequences)
+    # --- build perturbation index by chrom ---------------------------------
     interval_chroms <- as.character(intervals$chrom)
-    missing_chroms <- setdiff(unique(interval_chroms), chroms_in_ref)
+    pert_by_chrom <- split(seq_len(nrow(intervals)), interval_chroms)
+    # Sort each chromosome's perturbations by start position descending
+    for (chr_name in names(pert_by_chrom)) {
+        idx <- pert_by_chrom[[chr_name]]
+        pert_by_chrom[[chr_name]] <- idx[order(-intervals$start[idx])]
+    }
+
+    # Pre-convert donor sequences to raw vectors (once)
+    donor_raws <- lapply(toupper(donor_seqs), charToRaw)
+
+    # --- stream: read each chrom, apply perturbations, write output --------
+    fai_entries <- list()
+    byte_offset <- 0L
+    chrom_names_seen <- character(0)
+
+    # Use a block so the output file is closed before gdb.create reads it
+    local({
+        out_con <- file(output, open = "wb")
+        on.exit(close(out_con), add = TRUE)
+
+        .stream_fasta(genome_fasta, function(chrom_name, seq_raw) {
+            chrom_names_seen <<- c(chrom_names_seen, chrom_name)
+
+            # Apply perturbations for this chromosome using raw vector replacement
+            idx_list <- pert_by_chrom[[chrom_name]]
+            if (!is.null(idx_list)) {
+                chrom_len <- length(seq_raw)
+                for (i in idx_list) {
+                    s <- intervals$start[i] # 0-based
+                    e <- intervals$end[i] # 0-based, exclusive
+                    if (s < 0 || e > chrom_len) {
+                        stop(sprintf(
+                            "Interval out of bounds: %s:%d-%d (chromosome length: %d)",
+                            chrom_name, s, e, chrom_len
+                        ), call. = FALSE)
+                    }
+                    # raw vector is 1-based: positions (s+1) to e
+                    seq_raw[(s + 1L):e] <- donor_raws[[i]]
+                }
+            }
+
+            # Write and collect .fai metadata
+            entry <- .write_fasta_chrom_raw(out_con, chrom_name, seq_raw, line_width, byte_offset)
+            byte_offset <<- byte_offset + entry$total_bytes
+            fai_entries[[length(fai_entries) + 1L]] <<- entry
+        })
+    })
+
+    # Validate that all interval chromosomes were found in reference
+    missing_chroms <- setdiff(unique(interval_chroms), chrom_names_seen)
     if (length(missing_chroms) > 0L) {
+        # Clean up partial output
+        unlink(output)
         stop(sprintf(
             "Chromosome(s) not found in reference: %s",
             paste(missing_chroms, collapse = ", ")
         ), call. = FALSE)
     }
 
-    for (i in seq_len(nrow(intervals))) {
-        chrom <- interval_chroms[i]
-        chrom_len <- nchar(sequences[[chrom]])
-        if (intervals$start[i] < 0 || intervals$end[i] > chrom_len) {
-            stop(sprintf(
-                "Interval out of bounds at row %d: %s:%d-%d (chromosome length: %d)",
-                i, chrom, intervals$start[i], intervals$end[i], chrom_len
-            ), call. = FALSE)
-        }
-        if (intervals$start[i] >= intervals$end[i]) {
-            stop(sprintf(
-                "Invalid interval at row %d: start (%d) must be less than end (%d)",
-                i, intervals$start[i], intervals$end[i]
-            ), call. = FALSE)
-        }
-    }
-
-    # --- apply perturbations ---
-    # Group by chromosome, sort descending by start within each group
-    # so that replacing later positions first preserves earlier coordinates
-    order_idx <- order(match(interval_chroms, chroms_in_ref), -intervals$start)
-
-    for (i in order_idx) {
-        chrom <- interval_chroms[i]
-        # misha coordinates are 0-based; R substr is 1-based
-        r_start <- intervals$start[i] + 1L
-        r_end <- intervals$end[i]
-        seq_str <- sequences[[chrom]]
-
-        prefix <- if (r_start > 1L) substr(seq_str, 1L, r_start - 1L) else ""
-        suffix <- if (r_end < nchar(seq_str)) substr(seq_str, r_end + 1L, nchar(seq_str)) else ""
-        sequences[[chrom]] <- paste0(prefix, donor_seqs[i], suffix)
-    }
-
-    # --- write output ---
-    .write_fasta(sequences, output, line_width = line_width)
-    .write_fai(output, line_width = line_width)
+    # --- write .fai index (from collected metadata, no re-read) ------------
+    .write_fai_from_entries(paste0(output, ".fai"), fai_entries)
 
     # --- create trackdb ---
     if (create_trackdb) {

--- a/src/GenomeEditImplant.cpp
+++ b/src/GenomeEditImplant.cpp
@@ -1,0 +1,246 @@
+/*
+ * GenomeEditImplant.cpp
+ *
+ * C++ fast path for ggenome.implant: read a reference FASTA, apply
+ * perturbations (donor sequence replacements), write output FASTA + .fai.
+ *
+ * Replaces the pure-R streaming path that was bottlenecked by readLines().
+ */
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "rdbutils.h"
+
+using namespace std;
+using namespace rdb;
+
+namespace {
+
+struct Perturbation {
+    int start;   // 0-based
+    int end;     // 0-based, exclusive
+    const char *donor; // pointer into R string storage (valid for call duration)
+};
+
+struct FaiEntry {
+    string name;
+    long long length;   // sequence length in bases
+    long long offset;   // byte offset of first base in output file
+    int linebases;      // bases per line
+    int linewidth;      // bytes per line (linebases + 1 for newline)
+};
+
+} // anonymous namespace
+
+extern "C" {
+
+SEXP C_ggenome_implant(SEXP _genome_fasta, SEXP _output,
+                       SEXP _pert_chrom, SEXP _pert_start, SEXP _pert_end,
+                       SEXP _pert_seq, SEXP _line_width)
+{
+    try {
+        // --- unpack R arguments ---
+        const char *genome_fasta = CHAR(STRING_ELT(_genome_fasta, 0));
+        const char *output_path  = CHAR(STRING_ELT(_output, 0));
+        int n_perts = Rf_length(_pert_chrom);
+        int line_width = Rf_asInteger(_line_width);
+
+        // --- build perturbation index: chrom -> sorted-desc-by-start ---
+        map<string, vector<Perturbation>> pert_map;
+        for (int i = 0; i < n_perts; i++) {
+            Perturbation p;
+            p.start = INTEGER(_pert_start)[i];
+            p.end   = INTEGER(_pert_end)[i];
+            p.donor = CHAR(STRING_ELT(_pert_seq, i));
+            string chrom(CHAR(STRING_ELT(_pert_chrom, i)));
+            pert_map[chrom].push_back(p);
+        }
+        // Sort each chrom's perturbations by start descending
+        for (auto &kv : pert_map) {
+            sort(kv.second.begin(), kv.second.end(),
+                 [](const Perturbation &a, const Perturbation &b) {
+                     return a.start > b.start;
+                 });
+        }
+
+        // --- open files with large buffers ---
+        FILE *fin = fopen(genome_fasta, "r");
+        if (!fin) {
+            Rf_error("Cannot open input FASTA: %s", genome_fasta);
+        }
+
+        FILE *fout = fopen(output_path, "w");
+        if (!fout) {
+            fclose(fin);
+            Rf_error("Cannot open output file: %s", output_path);
+        }
+
+        // 4MB I/O buffers
+        const size_t BUF_SIZE = 4 * 1024 * 1024;
+        vector<char> inbuf(BUF_SIZE);
+        vector<char> outbuf(BUF_SIZE);
+        setvbuf(fin,  inbuf.data(),  _IOFBF, BUF_SIZE);
+        setvbuf(fout, outbuf.data(), _IOFBF, BUF_SIZE);
+
+        // --- streaming state ---
+        vector<char> seq;        // accumulated sequence for current chrom
+        seq.reserve(256 * 1024 * 1024); // 256MB pre-alloc for large chroms
+        string current_chrom;
+        vector<FaiEntry> fai_entries;
+        long long byte_offset = 0;
+
+        // Line buffer for fgets
+        const size_t LINE_BUF = 65536;
+        vector<char> line(LINE_BUF);
+
+        // --- helper lambda: flush one chromosome ---
+        auto flush_chrom = [&]() {
+            if (current_chrom.empty()) return;
+
+            long long seq_len = (long long)seq.size();
+
+            // Apply perturbations (reverse-sorted by start, so coordinates stay valid)
+            auto it = pert_map.find(current_chrom);
+            if (it != pert_map.end()) {
+                for (const auto &p : it->second) {
+                    if (p.start < 0 || p.end > seq_len) {
+                        fclose(fin);
+                        fclose(fout);
+                        Rf_error("Interval out of bounds: %s:%d-%d (chromosome length: %lld)",
+                                 current_chrom.c_str(), p.start, p.end, seq_len);
+                    }
+                    int donor_len = p.end - p.start;
+                    memcpy(&seq[p.start], p.donor, donor_len);
+                }
+            }
+
+            // Write header
+            fprintf(fout, ">%s\n", current_chrom.c_str());
+            long long header_bytes = (long long)current_chrom.size() + 2; // '>' + name + '\n'
+
+            // Write sequence lines
+            long long pos = 0;
+            while (pos < seq_len) {
+                long long chunk = min((long long)line_width, seq_len - pos);
+                fwrite(&seq[pos], 1, chunk, fout);
+                fputc('\n', fout);
+                pos += chunk;
+            }
+
+            // Collect .fai metadata
+            FaiEntry entry;
+            entry.name = current_chrom;
+            entry.length = seq_len;
+            entry.offset = byte_offset + header_bytes;
+            entry.linebases = (seq_len > 0) ? min((long long)line_width, seq_len) : 0;
+            entry.linewidth = (seq_len > 0) ? entry.linebases + 1 : 0;
+            fai_entries.push_back(entry);
+
+            // Update byte offset
+            long long n_full_lines = seq_len / line_width;
+            long long remainder = seq_len % line_width;
+            long long data_bytes = n_full_lines * (line_width + 1);
+            if (remainder > 0) data_bytes += remainder + 1;
+            byte_offset += header_bytes + data_bytes;
+
+            seq.clear();
+        };
+
+        // --- read input FASTA ---
+        while (fgets(line.data(), LINE_BUF, fin)) {
+            if (line[0] == '>') {
+                // Flush previous chromosome
+                flush_chrom();
+
+                // Parse new chromosome name: strip '>' and trailing whitespace/newline
+                char *name_start = line.data() + 1;
+                // Find end: first whitespace or newline
+                char *p = name_start;
+                while (*p && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r') p++;
+                current_chrom.assign(name_start, p - name_start);
+            } else {
+                // Sequence line: append with inline toupper, strip newline
+                for (char *p = line.data(); *p && *p != '\n' && *p != '\r'; p++) {
+                    seq.push_back((char)toupper((unsigned char)*p));
+                }
+            }
+        }
+        // Flush last chromosome
+        flush_chrom();
+
+        fclose(fin);
+
+        // --- write .fai file ---
+        string fai_path = string(output_path) + ".fai";
+        FILE *ffai = fopen(fai_path.c_str(), "w");
+        if (!ffai) {
+            fclose(fout);
+            Rf_error("Cannot open .fai file for writing: %s", fai_path.c_str());
+        }
+        for (const auto &e : fai_entries) {
+            fprintf(ffai, "%s\t%lld\t%lld\t%d\t%d\n",
+                    e.name.c_str(), e.length, e.offset, e.linebases, e.linewidth);
+        }
+        fclose(ffai);
+        fclose(fout);
+
+        // --- return .fai as R data frame ---
+        int n = (int)fai_entries.size();
+
+        SEXP name_col   = PROTECT(Rf_allocVector(STRSXP,  n));
+        SEXP length_col = PROTECT(Rf_allocVector(REALSXP, n));
+        SEXP offset_col = PROTECT(Rf_allocVector(REALSXP, n));
+        SEXP lbase_col  = PROTECT(Rf_allocVector(INTSXP,  n));
+        SEXP lwidth_col = PROTECT(Rf_allocVector(INTSXP,  n));
+
+        for (int i = 0; i < n; i++) {
+            SET_STRING_ELT(name_col, i, Rf_mkChar(fai_entries[i].name.c_str()));
+            REAL(length_col)[i] = (double)fai_entries[i].length;
+            REAL(offset_col)[i] = (double)fai_entries[i].offset;
+            INTEGER(lbase_col)[i]  = fai_entries[i].linebases;
+            INTEGER(lwidth_col)[i] = fai_entries[i].linewidth;
+        }
+
+        SEXP result = PROTECT(Rf_allocVector(VECSXP, 5));
+        SET_VECTOR_ELT(result, 0, name_col);
+        SET_VECTOR_ELT(result, 1, length_col);
+        SET_VECTOR_ELT(result, 2, offset_col);
+        SET_VECTOR_ELT(result, 3, lbase_col);
+        SET_VECTOR_ELT(result, 4, lwidth_col);
+
+        SEXP col_names = PROTECT(Rf_allocVector(STRSXP, 5));
+        SET_STRING_ELT(col_names, 0, Rf_mkChar("name"));
+        SET_STRING_ELT(col_names, 1, Rf_mkChar("length"));
+        SET_STRING_ELT(col_names, 2, Rf_mkChar("offset"));
+        SET_STRING_ELT(col_names, 3, Rf_mkChar("linebases"));
+        SET_STRING_ELT(col_names, 4, Rf_mkChar("linewidth"));
+        Rf_setAttrib(result, R_NamesSymbol, col_names);
+
+        SEXP row_names = PROTECT(Rf_allocVector(INTSXP, 2));
+        INTEGER(row_names)[0] = NA_INTEGER;
+        INTEGER(row_names)[1] = -n;
+        Rf_setAttrib(result, R_RowNamesSymbol, row_names);
+
+        SEXP df_class = PROTECT(Rf_allocVector(STRSXP, 1));
+        SET_STRING_ELT(df_class, 0, Rf_mkChar("data.frame"));
+        Rf_setAttrib(result, R_ClassSymbol, df_class);
+
+        UNPROTECT(9);
+        return result;
+
+    } catch (TGLException &e) {
+        rerror("%s", e.msg());
+    } catch (const bad_alloc &e) {
+        rerror("Out of memory");
+    }
+    return R_NilValue;
+}
+
+} // extern "C"

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -108,6 +108,7 @@ extern "C" {
     extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_replace_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_kmer_dist(SEXP, SEXP, SEXP, SEXP);
+    extern SEXP C_ggenome_implant(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 }
 
 static const R_CallMethodDef CallEntries[] = {
@@ -212,6 +213,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 12},
     {"C_gsynth_replace_kmer", (DL_FUNC)&C_gsynth_replace_kmer, 6},
     {"C_gseq_kmer_dist", (DL_FUNC)&C_gseq_kmer_dist, 4},
+    {"C_ggenome_implant", (DL_FUNC)&C_ggenome_implant, 7},
     {NULL, NULL, 0}
 };
 

--- a/tests/testthat/test-ggenome.R
+++ b/tests/testthat/test-ggenome.R
@@ -1,3 +1,18 @@
+# Local test helper: read a FASTA file into a named list of sequences
+read_fasta <- function(fasta_path) {
+    lines <- readLines(fasta_path)
+    header_idx <- which(startsWith(lines, ">"))
+    chrom_names <- sub("^>\\s*", "", sub("\\s.*", "", lines[header_idx]))
+    result <- vector("list", length(chrom_names))
+    names(result) <- chrom_names
+    for (i in seq_along(header_idx)) {
+        start <- header_idx[i] + 1L
+        end <- if (i < length(header_idx)) header_idx[i + 1L] - 1L else length(lines)
+        result[[i]] <- if (start > end) "" else paste0(lines[start:end], collapse = "")
+    }
+    result
+}
+
 test_that("ggenome.implant replaces intervals with literal sequences", {
     local_db_state()
 
@@ -30,7 +45,7 @@ test_that("ggenome.implant replaces intervals with literal sequences", {
 
     # chrA: positions 0-9 = A C G T A C G T A C
     # Replace [2,6) = positions 2,3,4,5 with NNNN: A C N N N N G T A C
-    seqs <- .read_fasta(out_fasta)
+    seqs <- read_fasta(out_fasta)
     expect_equal(seqs[["chrA"]], "ACNNNNGTAC")
     expect_equal(seqs[["chrB"]], "TTTTAAAA")
 })
@@ -63,7 +78,7 @@ test_that("ggenome.implant handles multiple perturbations on same chromosome", {
         overwrite = TRUE
     )
 
-    seqs <- .read_fasta(out_fasta)
+    seqs <- read_fasta(out_fasta)
     # Original: AAAAACCCCCGGGGGTTTT
     # Replace [0,5) with XXXXX and [10,15) with YYYYY
     expect_equal(seqs[["chr1"]], "XXXXXCCCCCYYYYYTTTTT")
@@ -260,7 +275,7 @@ test_that("ggenome.implant preserves chromosome order", {
         overwrite = TRUE
     )
 
-    seqs <- .read_fasta(out_fasta)
+    seqs <- read_fasta(out_fasta)
     expect_equal(names(seqs), c("chrB", "chrA", "chrC"))
     expect_equal(seqs[["chrB"]], "TTTT")
     expect_equal(seqs[["chrA"]], "CCAA")
@@ -332,7 +347,7 @@ test_that("ggenome.implant with donor from misha database", {
         overwrite = TRUE
     )
 
-    seqs <- .read_fasta(out_fasta)
+    seqs <- read_fasta(out_fasta)
     # chrA: AA + GGGG + AA = AAGGGGAA
     expect_equal(seqs[["chrA"]], "AAGGGGAA")
     # chrB: TTTT + CCCC = TTTTCCCC
@@ -370,7 +385,7 @@ test_that("ggenome.transplant works as sugar for implant", {
         overwrite = TRUE
     )
 
-    seqs <- .read_fasta(out_fasta)
+    seqs <- read_fasta(out_fasta)
     expect_equal(seqs[["chrA"]], "GGGGAAAA")
 })
 


### PR DESCRIPTION
## Summary

Optimizes the genome editing functions from #85 for large genomes:

- Stream FASTA chromosome-by-chromosome instead of loading all into memory
- Use raw vectors for in-place perturbation (eliminates O(chrom_len) string copies per edit)
- Compute .fai metadata inline during write (eliminates full re-read pass)
- Write FASTA in binary mode for direct byte output

Memory usage is now proportional to the largest chromosome (~200MB for mm10), not the whole genome (~2.6GB).

## Test plan

- [x] All 24 existing ggenome tests pass unchanged