### PR TITLE
fix: child processes survive rexit() due to R's SIGTERM handler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # misha 5.6.12 
 
-* Fixed child processes surviving `rexit()` due to R's SIGTERM handler. All multitasked operations (`gmultitasking = TRUE`) were affected: after forking, child processes continued executing R-level post-processing code instead of terminating. On indexed databases, `gtrack.create`/`gtrack.smooth` children could run `gtrack.convert_to_indexed` concurrently, reading incomplete data and deleting files still being written by other children. Query functions (`gextract`, `gscreen`, etc.) returned correct results since data was written to shared memory before the failed exit.
+* Fixed child processes surviving `rexit()` due to R's SIGTERM handler. All multitasked operations (`gmultitasking = TRUE`) were affected: after forking, child processes continued executing R-level post-processing code instead of terminating. Track-creating functions (`gtrack.create`, `gtrack.smooth`, `gtrack.create_pwm_energy`) could corrupt data on indexed databases — children ran `gtrack.convert_to_indexed` concurrently, reading incomplete files and deleting files still being written by other children. On non-indexed databases, track data was correct. Query functions (`gextract`, `gscreen`, `gdist`, `gquantiles`, `gcor`, `gsummary`, `gcis.decay`, `gapply`, `gbins.quantiles`, `gbins.summary`) returned correct results since data was written to shared memory before the failed exit.
 
 # misha 5.6.11
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.12 
+
+* Fixed child processes surviving `rexit()` due to R's SIGTERM handler. All multitasked operations (`gmultitasking = TRUE`) were affected: after forking, child processes continued executing R-level post-processing code instead of terminating. On indexed databases, `gtrack.create`/`gtrack.smooth` children could run `gtrack.convert_to_indexed` concurrently, reading incomplete data and deleting files still being written by other children. Query functions (`gextract`, `gscreen`, etc.) returned correct results since data was written to shared memory before the failed exit.
+
 # misha 5.6.11
 
 * Added `ggenome.implant()` for replacing intervals in a reference genome with donor sequences and writing a new FASTA. Supports literal donor sequences or extraction from a misha database, with optional trackdb creation.

--- a/src/GseqString.cpp
+++ b/src/GseqString.cpp
@@ -1071,11 +1071,25 @@ SEXP C_gseq_pwm_multitask(SEXP r_seqs, SEXP r_pssm, SEXP r_mode, SEXP r_bidirect
 
                     UNPROTECT(3);  // seqs_chunk, roi_start_chunk, roi_end_chunk
                     // Use signal-based exit to avoid CRAN issues with _exit()
-                    // (similar to rexit() but without RdbInitializer dependency)
+                    // (similar to rexit() but without RdbInitializer dependency).
+                    // Reset SIGTERM to SIG_DFL first — R's handler would just
+                    // set a flag and the child would continue executing R code.
+                    {
+                        struct sigaction sa;
+                        sa.sa_handler = SIG_DFL;
+                        sigemptyset(&sa.sa_mask);
+                        sa.sa_flags = 0;
+                        sigaction(MISHA_EXIT_SIG, &sa, NULL);
+                    }
                     kill(getpid(), MISHA_EXIT_SIG);
 
                 } catch (...) {
                     // Use signal-based exit for error case as well
+                    struct sigaction sa;
+                    sa.sa_handler = SIG_DFL;
+                    sigemptyset(&sa.sa_mask);
+                    sa.sa_flags = 0;
+                    sigaction(MISHA_EXIT_SIG, &sa, NULL);
                     kill(getpid(), MISHA_EXIT_SIG);
                 }
             } else {

--- a/src/rdbutils.cpp
+++ b/src/rdbutils.cpp
@@ -385,25 +385,35 @@ void RdbInitializer::check_kids_state(bool ignore_errors)
                 swap(*ipid, s_running_pids.back());
                 s_running_pids.pop_back();
 
-                if (!ignore_errors && !WIFEXITED(status) && WIFSIGNALED(status) && WTERMSIG(status) != MISHA_EXIT_SIG){
-                    // Check if the child wrote an error message to shared memory
-                    char error_msg_copy[1000];
-                    bool has_error_msg = false;
-                    {
-                        SemLocker sl(s_shm_sem);
-                        if (s_shm->error_msg[0]) {
-                            strncpy(error_msg_copy, s_shm->error_msg, sizeof(error_msg_copy) - 1);
-                            error_msg_copy[sizeof(error_msg_copy) - 1] = '\0';
-                            has_error_msg = true;
+                if (!ignore_errors) {
+                    // Expected exit: killed by MISHA_EXIT_SIG (SIGTERM with SIG_DFL).
+                    // Any other exit is abnormal — either a different signal, or
+                    // a normal exit(0) from R that escaped rexit().
+                    bool expected_exit = WIFSIGNALED(status) && WTERMSIG(status) == MISHA_EXIT_SIG;
+
+                    if (!expected_exit) {
+                        // Check if the child wrote an error message to shared memory
+                        char error_msg_copy[1000];
+                        bool has_error_msg = false;
+                        {
+                            SemLocker sl(s_shm_sem);
+                            if (s_shm->error_msg[0]) {
+                                strncpy(error_msg_copy, s_shm->error_msg, sizeof(error_msg_copy) - 1);
+                                error_msg_copy[sizeof(error_msg_copy) - 1] = '\0';
+                                has_error_msg = true;
+                            }
+                        }
+                        // Call verror AFTER releasing the semaphore to avoid deadlock
+                        if (has_error_msg) {
+                            verror("%s", error_msg_copy);
+                        } else if (WIFEXITED(status)) {
+                            verror("Child process %d exited unexpectedly with status %d (expected signal termination via rexit)",
+                                   (int)pid, WEXITSTATUS(status));
+                        } else {
+                            verror("Child process %d ended unexpectedly (signal %d)", (int)pid, WTERMSIG(status));
                         }
                     }
-                    // Call verror AFTER releasing the semaphore to avoid deadlock
-                    if (has_error_msg) {
-                        verror("%s", error_msg_copy);
-                    } else {
-                        verror("Child process %d ended unexpectedly", (int)ipid->pid);
-                    }
-				}
+                }
 
                 // choose a new untouchable kid: the one with maximal memory consumption
                 if (kid_idx == s_shm->untouchable_kid_idx && s_running_pids.size()) {

--- a/src/rdbutils.h
+++ b/src/rdbutils.h
@@ -503,6 +503,17 @@ inline void rexit() {
 		// messages cannot be submitted to CRAN. Yet the child process MUST end
 		// the R sessions, that's the whole point. Solution? Send a signal to
 		// itself. Fortunately "R CMD check" allows signals.
+		//
+		// IMPORTANT: Reset the signal handler to SIG_DFL before sending.
+		// R installs its own SIGTERM handler that merely sets a flag instead
+		// of terminating the process. Without this reset, the child survives
+		// the signal and continues executing R-level code (e.g., gtrack.create
+		// post-processing), causing file corruption and early parent return.
+		struct sigaction sa;
+		sa.sa_handler = SIG_DFL;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = 0;
+		sigaction(MISHA_EXIT_SIG, &sa, NULL);
 		kill(getpid(), MISHA_EXIT_SIG);
 	} else {
 		rdb::verror("rexit is called from parent process");


### PR DESCRIPTION
## Summary

R installs a SIGTERM handler that sets a flag instead of terminating the process. When misha's `rexit()` calls `kill(getpid(), SIGTERM)`, the child **survives** the signal and continues executing R-level code after the C function returns. This has been present since the original multitasking implementation.

**Root cause:** After `rexit()` fails to kill the child, control returns to R. The child's R interpreter resumes and runs post-processing code that was intended only for the parent — `.gdb.add_track()`, `.gtrack.attr.set()`, and critically `gtrack.convert_to_indexed()`. Multiple children + the parent run this concurrently.

**Evidence:** Confirmed by testing that R forked children survive SIGTERM:
```
Child alive after SIGTERM? TRUE
Child alive after 2 more seconds? TRUE
```

## What's affected

**ALL functions using `gmultitasking = TRUE`** (the default) are affected, but the severity varies:

### Track-creating functions — potential data corruption on indexed DBs

`gtrack.create()`, `gtrack.smooth()`, `gtrack.create_pwm_energy()`

- Per-chromosome track **data is correct** (files are written and closed before `rexit()`)
- Children that finish early run `gtrack.convert_to_indexed()` concurrently — reads incomplete per-chromosome files from still-running children **and deletes them**
- **On indexed databases**: can cause permanent data loss (deleted files while other children still writing)
- **On non-indexed databases**: track data is correct; metadata has benign races (parent overwrites last)

### Query functions — results are correct

`gextract()`, `gscreen()`, `gdist()`, `gquantiles()`, `gcor()`, `gsummary()`, `gcis.decay()`, `gapply()`, `gbins.quantiles()`, `gbins.summary()`

- Results are written to shared memory **before** `rexit()`, so **numerical results are correct**
- Children escaping to R hit errors on NULL results and exit harmlessly

## User advisory

**Users should re-create tracks ONLY if ALL of these apply:**
1. Track was created with `gtrack.create()`, `gtrack.smooth()`, or `gtrack.create_pwm_energy()`
2. The database uses **indexed format** (`.gdb.is_indexed()` returns `TRUE`)
3. `gmultitasking` was `TRUE` (the default)

**Not affected:**
- All query results (`gextract`, `gscreen`, etc.) — correct regardless
- Tracks on non-indexed databases — data is correct
- Any operation with `gmultitasking = FALSE`

## Fix

1. **`rexit()` in `rdbutils.h`**: Reset SIGTERM to `SIG_DFL` before `kill()`, so the default terminate action runs regardless of R's handler
2. **`check_kids_state()` in `rdbutils.cpp`**: Tighten exit status check — only `WIFSIGNALED && WTERMSIG == MISHA_EXIT_SIG` is a successful child exit. Normal exits (`WIFEXITED`) now trigger error reporting (defense in depth)
3. **`GseqString.cpp`**: Same `SIG_DFL` fix for the independent fork path in GLM parallel prediction

## Test plan

- [x] Full test suite passes (17979 tests, 0 failures)
- [x] `gtrack.create` specific tests pass (42 tests)
- [x] Clean compile with no warnings
- [x] Smoke test: `gtrack.create` with `gmultitasking=TRUE` produces correct track readable immediately after creation