### PR TITLE
fix: pwm.max.pos returns wrong strand sign

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.12
+Version: 5.6.13
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.13
+
+* Fixed `pwm.max.pos` returning wrong strand sign. The direction (positive/negative) of the returned position was determined by the last scanned position in the interval rather than the position with the best score. Bug existed since `pwm.max.pos` was introduced (v4.3.0).
+
 # misha 5.6.12 
 
 * Fixed child processes surviving `rexit()` due to R's SIGTERM handler. All multitasked operations (`gmultitasking = TRUE`) were affected: after forking, child processes continued executing R-level post-processing code instead of terminating. Track-creating functions (`gtrack.create`, `gtrack.smooth`, `gtrack.create_pwm_energy`) could corrupt data on indexed databases — children ran `gtrack.convert_to_indexed` concurrently, reading incomplete files and deleting files still being written by other children. On non-indexed databases, track data was correct. Query functions (`gextract`, `gscreen`, `gdist`, `gquantiles`, `gcor`, `gsummary`, `gcis.decay`, `gapply`, `gbins.quantiles`, `gbins.summary`) returned correct results since data was written to shared memory before the failed exit.

--- a/src/DnaPSSM.cpp
+++ b/src/DnaPSSM.cpp
@@ -320,6 +320,7 @@ string::const_iterator DnaPSSM::max_like_match(const string &target,
 		}
 
 		float total_logp = logp;
+		int cur_dir = 1;
 
 		if(m_bidirect) {
 			float rlogp = 0;
@@ -345,23 +346,20 @@ string::const_iterator DnaPSSM::max_like_match(const string &target,
 			if (combine_strands) {
 				// Combine probabilities by adding them in log space
 				log_sum_log(total_logp, rlogp);
-				best_dir = 0; // Indicate combined strands
+				cur_dir = 0; // Indicate combined strands
 			} else {
 				// select best strand
 				if(rlogp > logp) {
 					total_logp = rlogp;
-					best_dir = -1;
-				} else {
-					best_dir = 1;
+					cur_dir = -1;
 				}
 			}
-		} else {
-			best_dir = 1;
 		}
 
 		if(total_logp > best_logp) {
 			best_logp = total_logp;
 			best_pos = i;
+			best_dir = cur_dir;
 		}
 	}
 	return(best_pos);


### PR DESCRIPTION
## Summary

- `DnaPSSM::max_like_match()` updated `best_dir` at every loop iteration, but only updated `best_pos`/`best_logp` when a new maximum was found. This caused the strand sign of `pwm.max.pos` to reflect the last scanned position rather than the best-scoring one.
- Introduced a local `cur_dir` variable; `best_dir` is now only assigned inside the `if(total_logp > best_logp)` block — matching the pattern already used in the spatial code path.
- Bug existed since `pwm.max.pos` was introduced (v4.3.0). Only the non-spatial path (`score_without_spatial`) was affected; the spatial and sliding-window paths were already correct.

## Test plan

- [x] Reproduced with CTCF motif on PrimatesAnc069 — verified strand sign now matches per-strand scores
- [x] All 1374 PWM tests pass
- [x] All 151 sliding window tests pass (regenerated 8 regression snapshots that contained buggy sign values)