### PR TITLE
fix: indexed tracks re-mmap entire track.dat per chromosome

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.13
+Version: 5.6.14
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.14
+
+* Fixed indexed tracks re-mmapping the entire `track.dat` for every chromosome during iterator init and chromosome transitions. Made indexed tracks unusable on genomes with many contigs (e.g. Pan_troglodytes with 4344 contigs).
+
 # misha 5.6.13
 
 * Fixed `pwm.max.pos` returning wrong strand sign. The direction (positive/negative) of the returned position was determined by the last scanned position in the interval rather than the position with the best score. Bug existed since `pwm.max.pos` was introduced (v4.3.0).

--- a/src/GTrackLiftover.cpp
+++ b/src/GTrackLiftover.cpp
@@ -493,8 +493,8 @@ SEXP gtrack_liftover(SEXP _track,
 
 			// write the target intervals + values to the temporary files
 			if (src_track_type == GenomeTrack::FIXED_BIN) {
+				GenomeTrackFixedBin src_track;
 				for (vector<string>::const_iterator ichrom = src_id2chrom.begin(); ichrom != src_id2chrom.end(); ++ichrom) {
-					GenomeTrackFixedBin src_track;
 					int src_chromid_in_chain = ichrom - src_id2chrom.begin();  // chromid in the chain's coordinate system
 					int chromid_to_use = src_chromid_in_chain;  // Default to chain chromid
 					float val;
@@ -555,8 +555,8 @@ SEXP gtrack_liftover(SEXP _track,
 					progress.report(1);
 				}
 			} else if (src_track_type == GenomeTrack::SPARSE) {
+				GenomeTrackSparse src_track;
 				for (vector<string>::const_iterator ichrom = src_id2chrom.begin(); ichrom != src_id2chrom.end(); ++ichrom) {
-					GenomeTrackSparse src_track;
 					int src_chromid_in_chain = ichrom - src_id2chrom.begin();  // chromid in the chain's coordinate system
 					int chromid_to_use = src_chromid_in_chain;  // Default to chain chromid
 

--- a/src/GenomeTrackExtract.cpp
+++ b/src/GenomeTrackExtract.cpp
@@ -666,9 +666,9 @@ SEXP C_gextract(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iterator_pol
 			}
 
 			// Truncate all vectors to actual size
-			SETLENGTH(r_chroms, row);
-			SETLENGTH(r_starts, row);
-			SETLENGTH(r_ends, row);
+			r_chroms = rprotect_ptr(Rf_lengthgets(r_chroms, row));
+			r_starts = rprotect_ptr(Rf_lengthgets(r_starts, row));
+			r_ends   = rprotect_ptr(Rf_lengthgets(r_ends, row));
 
 			// Set chrom as factor
 			unsigned num_chroms_total = iu.get_chromkey().get_num_chroms();
@@ -734,12 +734,12 @@ SEXP C_gextract(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iterator_pol
 			}
 
 			// Truncate all vectors to actual size
-			SETLENGTH(r_chroms1, row);
-			SETLENGTH(r_starts1, row);
-			SETLENGTH(r_ends1, row);
-			SETLENGTH(r_chroms2, row);
-			SETLENGTH(r_starts2, row);
-			SETLENGTH(r_ends2, row);
+			r_chroms1 = rprotect_ptr(Rf_lengthgets(r_chroms1, row));
+			r_starts1 = rprotect_ptr(Rf_lengthgets(r_starts1, row));
+			r_ends1   = rprotect_ptr(Rf_lengthgets(r_ends1, row));
+			r_chroms2 = rprotect_ptr(Rf_lengthgets(r_chroms2, row));
+			r_starts2 = rprotect_ptr(Rf_lengthgets(r_starts2, row));
+			r_ends2   = rprotect_ptr(Rf_lengthgets(r_ends2, row));
 
 			// Set chrom1 and chrom2 as factors
 			unsigned num_chroms_total = iu.get_chromkey().get_num_chroms();
@@ -768,9 +768,9 @@ SEXP C_gextract(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iterator_pol
 
 		// Truncate shared columns to actual size
 		for (unsigned i = 0; i < num_exprs; i++)
-			SETLENGTH(r_expr_vals[i], row);
-		SETLENGTH(r_ids, row);
-		SETLENGTH(r_row_names, row);
+			r_expr_vals[i] = rprotect_ptr(Rf_lengthgets(r_expr_vals[i], row));
+		r_ids = rprotect_ptr(Rf_lengthgets(r_ids, row));
+		r_row_names = rprotect_ptr(Rf_lengthgets(r_row_names, row));
 
 		// Set expression value columns
 		for (unsigned iexpr = 0; iexpr < num_exprs; iexpr++)

--- a/src/TrackExpressionScanner.cpp
+++ b/src/TrackExpressionScanner.cpp
@@ -636,10 +636,12 @@ for (unsigned ivar = 0; ivar < vars.get_num_track_vars(); ++ivar) {
 
 			if (GenomeTrack::is_1d(track_type)) {
 				set<int> chromids;
+				// Declare outside the loop so init_read can reuse mmap for indexed
+				// tracks (single track.dat) instead of re-mmapping per chromosome.
+				GenomeTrackFixedBin gtrack_fbin;
 
-				for (vector<string>::const_iterator ifilename = filenames.begin(); ifilename != filenames.end(); ++ifilename) {										
+				for (vector<string>::const_iterator ifilename = filenames.begin(); ifilename != filenames.end(); ++ifilename) {
 					int chromid = -1;
-					GenomeTrackFixedBin gtrack_fbin;
 
 					try {
 						 chromid = GenomeTrack::get_chromid_1d(m_iu.get_chromkey(), *ifilename);

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -1901,7 +1901,7 @@ void TrackExpressionVars::start_chrom(const GInterval &interval)
 
 			// For indexed tracks, reuse the persistent backend to avoid
 			// re-mmapping the entire track.dat on every chromosome transition.
-			const IndexedBackendKey idx_key{itrack_n_imdf->type, track_dir};
+			const IndexedBackendKey idx_key{itrack_n_imdf->type, track_dir, 0};
 			auto idx_it = m_indexed_track_backends.find(idx_key);
 
 			if (idx_it != m_indexed_track_backends.end()) {
@@ -1927,11 +1927,14 @@ void TrackExpressionVars::start_chrom(const GInterval &interval)
 				// If this is an indexed track, add to persistent cache
 				struct stat idx_st;
 				if (stat((track_dir + "/track.idx").c_str(), &idx_st) == 0 && supports_shared_1d_backend(itrack_n_imdf->type)) {
-					// Find the master in the shared cache (just added by init_1d_track_with_shared_backend)
 					const BackendKey bk{itrack_n_imdf->type, interval.chromid, filename};
 					auto master_it = m_shared_1d_track_masters.find(bk);
-					if (master_it != m_shared_1d_track_masters.end())
+					if (master_it != m_shared_1d_track_masters.end()) {
 						m_indexed_track_backends.emplace(idx_key, master_it->second);
+					} else {
+						// Shared backends disabled — cache the track directly
+						m_indexed_track_backends.emplace(idx_key, new_track);
+					}
 				}
 			}
 		}
@@ -1982,8 +1985,10 @@ void TrackExpressionVars::start_chrom(const GInterval2D &interval)
 				}
 
 				if (chromid != itrack_n_imdf->imdf1d->interval.chromid) {
-					// For indexed tracks, reuse the persistent backend to avoid re-mmapping
-					const IndexedBackendKey idx_key{itrack_n_imdf->type, track_dir};
+					// For indexed tracks, reuse the persistent backend to avoid re-mmapping.
+					// Key includes dim so DIM1/DIM2 projections get independent masters.
+					const int dim = static_cast<int>(itrack_n_imdf->imdf1d->dim);
+					const IndexedBackendKey idx_key{itrack_n_imdf->type, track_dir, dim};
 					auto idx_it = m_indexed_track_backends.find(idx_key);
 
 					if (idx_it != m_indexed_track_backends.end()) {
@@ -2009,8 +2014,12 @@ void TrackExpressionVars::start_chrom(const GInterval2D &interval)
 						if (stat((track_dir + "/track.idx").c_str(), &idx_st) == 0 && supports_shared_1d_backend(itrack_n_imdf->type)) {
 							const BackendKey bk{itrack_n_imdf->type, chromid, filename};
 							auto master_it = m_shared_1d_track_masters.find(bk);
-							if (master_it != m_shared_1d_track_masters.end())
+							if (master_it != m_shared_1d_track_masters.end()) {
 								m_indexed_track_backends.emplace(idx_key, master_it->second);
+							} else {
+								// Shared backends disabled — cache the track directly
+								m_indexed_track_backends.emplace(idx_key, new_track);
+							}
 						}
 					}
 				} else if (should_manage_shared_masters) {

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <cmath>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <unordered_set>
 
@@ -1730,11 +1731,11 @@ void TrackExpressionVars::init(const TrackExpressionIteratorBase &expr_itr)
 				if (GenomeTrack::is_1d(track_type))
 				{
 					set<int> chromids;
+					GenomeTrackFixedBin gtrack_fbin;
 
 					for (vector<string>::const_iterator ifilename = filenames.begin(); ifilename != filenames.end(); ++ifilename)
 					{
 						int chromid = -1;
-						GenomeTrackFixedBin gtrack_fbin;
 
 						try
 						{
@@ -1897,12 +1898,42 @@ void TrackExpressionVars::start_chrom(const GInterval &interval)
 			string track_dir = track2path(m_iu.get_env(), itrack_n_imdf->name);
 			string resolved = GenomeTrack::find_existing_1d_filename(m_iu.get_chromkey(), track_dir, interval.chromid);
 			string filename(track_dir + "/" + resolved);
-			shared_ptr<GenomeTrack> new_track = init_1d_track_with_shared_backend(filename, interval.chromid, itrack_n_imdf->type);
-			if (!new_track) {
-				verror("Internal error: track %s of type %s is not supported by 1D iterators",
-					   itrack_n_imdf->name.c_str(), GenomeTrack::TYPE_NAMES[itrack_n_imdf->type]);
+
+			// For indexed tracks, reuse the persistent backend to avoid
+			// re-mmapping the entire track.dat on every chromosome transition.
+			const IndexedBackendKey idx_key{itrack_n_imdf->type, track_dir};
+			auto idx_it = m_indexed_track_backends.find(idx_key);
+
+			if (idx_it != m_indexed_track_backends.end()) {
+				// Reuse existing indexed track object — init_read reuses the mmap
+				shared_ptr<GenomeTrack> master = idx_it->second;
+				if (itrack_n_imdf->type == GenomeTrack::FIXED_BIN) {
+					static_cast<GenomeTrackFixedBin *>(master.get())->init_read(filename.c_str(), interval.chromid);
+				} else if (itrack_n_imdf->type == GenomeTrack::SPARSE) {
+					static_cast<GenomeTrackSparse *>(master.get())->init_read(filename.c_str(), interval.chromid);
+				}
+				const BackendKey bk{itrack_n_imdf->type, interval.chromid, filename};
+				m_shared_1d_track_masters.emplace(bk, master);
+				shared_ptr<GenomeTrack> dependent = create_dependent_1d_track(itrack_n_imdf->type, master);
+				itrack_n_imdf->track = dependent ? dependent : master;
+			} else {
+				shared_ptr<GenomeTrack> new_track = init_1d_track_with_shared_backend(filename, interval.chromid, itrack_n_imdf->type);
+				if (!new_track) {
+					verror("Internal error: track %s of type %s is not supported by 1D iterators",
+						   itrack_n_imdf->name.c_str(), GenomeTrack::TYPE_NAMES[itrack_n_imdf->type]);
+				}
+				itrack_n_imdf->track = new_track;
+
+				// If this is an indexed track, add to persistent cache
+				struct stat idx_st;
+				if (stat((track_dir + "/track.idx").c_str(), &idx_st) == 0 && supports_shared_1d_backend(itrack_n_imdf->type)) {
+					// Find the master in the shared cache (just added by init_1d_track_with_shared_backend)
+					const BackendKey bk{itrack_n_imdf->type, interval.chromid, filename};
+					auto master_it = m_shared_1d_track_masters.find(bk);
+					if (master_it != m_shared_1d_track_masters.end())
+						m_indexed_track_backends.emplace(idx_key, master_it->second);
+				}
 			}
-			itrack_n_imdf->track = new_track;
 		}
 		catch (TGLException &e)
 		{
@@ -1951,12 +1982,37 @@ void TrackExpressionVars::start_chrom(const GInterval2D &interval)
 				}
 
 				if (chromid != itrack_n_imdf->imdf1d->interval.chromid) {
-					shared_ptr<GenomeTrack> new_track = init_1d_track_with_shared_backend(filename, chromid, itrack_n_imdf->type);
-					if (!new_track) {
-						verror("Internal error: track %s of type %s is not supported by 1D iterators (projected from 2D)",
-							   itrack_n_imdf->name.c_str(), GenomeTrack::TYPE_NAMES[itrack_n_imdf->type]);
+					// For indexed tracks, reuse the persistent backend to avoid re-mmapping
+					const IndexedBackendKey idx_key{itrack_n_imdf->type, track_dir};
+					auto idx_it = m_indexed_track_backends.find(idx_key);
+
+					if (idx_it != m_indexed_track_backends.end()) {
+						shared_ptr<GenomeTrack> master = idx_it->second;
+						if (itrack_n_imdf->type == GenomeTrack::FIXED_BIN)
+							static_cast<GenomeTrackFixedBin *>(master.get())->init_read(filename.c_str(), chromid);
+						else if (itrack_n_imdf->type == GenomeTrack::SPARSE)
+							static_cast<GenomeTrackSparse *>(master.get())->init_read(filename.c_str(), chromid);
+						const BackendKey bk{itrack_n_imdf->type, chromid, filename};
+						m_shared_1d_track_masters.emplace(bk, master);
+						shared_ptr<GenomeTrack> dependent = create_dependent_1d_track(itrack_n_imdf->type, master);
+						itrack_n_imdf->track = dependent ? dependent : master;
+					} else {
+						shared_ptr<GenomeTrack> new_track = init_1d_track_with_shared_backend(filename, chromid, itrack_n_imdf->type);
+						if (!new_track) {
+							verror("Internal error: track %s of type %s is not supported by 1D iterators (projected from 2D)",
+								   itrack_n_imdf->name.c_str(), GenomeTrack::TYPE_NAMES[itrack_n_imdf->type]);
+						}
+						itrack_n_imdf->track = new_track;
+
+						// If indexed, add to persistent cache
+						struct stat idx_st;
+						if (stat((track_dir + "/track.idx").c_str(), &idx_st) == 0 && supports_shared_1d_backend(itrack_n_imdf->type)) {
+							const BackendKey bk{itrack_n_imdf->type, chromid, filename};
+							auto master_it = m_shared_1d_track_masters.find(bk);
+							if (master_it != m_shared_1d_track_masters.end())
+								m_indexed_track_backends.emplace(idx_key, master_it->second);
+						}
 					}
-					itrack_n_imdf->track = new_track;
 				} else if (should_manage_shared_masters) {
 					const BackendKey backend_key{itrack_n_imdf->type, chromid, filename};
 					auto imaster = m_shared_1d_track_masters.find(backend_key);

--- a/src/TrackExpressionVars.h
+++ b/src/TrackExpressionVars.h
@@ -301,6 +301,28 @@ private:
 
 	std::unordered_map<BackendKey, std::shared_ptr<GenomeTrack>, BackendKeyHash> m_shared_1d_track_masters;
 
+	// Persistent cache for indexed track backends, keyed by {type, track_dir}.
+	// Survives reset_shared_1d_track_masters() so that mmap can be reused across
+	// chromosome transitions instead of re-mapping the entire track.dat each time.
+	struct IndexedBackendKey {
+		GenomeTrack::Type type;
+		std::string track_dir;
+
+		bool operator==(const IndexedBackendKey &other) const {
+			return type == other.type && track_dir == other.track_dir;
+		}
+	};
+
+	struct IndexedBackendKeyHash {
+		size_t operator()(const IndexedBackendKey &k) const {
+			size_t h = std::hash<int>()(static_cast<int>(k.type));
+			h ^= std::hash<std::string>()(k.track_dir) * 40503ULL;
+			return h;
+		}
+	};
+
+	std::unordered_map<IndexedBackendKey, std::shared_ptr<GenomeTrack>, IndexedBackendKeyHash> m_indexed_track_backends;
+
 	// Shared sequence fetcher for all sequence-based vtracks to enable caching
 	GenomeSeqFetch          m_shared_seqfetch;
 

--- a/src/TrackExpressionVars.h
+++ b/src/TrackExpressionVars.h
@@ -301,15 +301,18 @@ private:
 
 	std::unordered_map<BackendKey, std::shared_ptr<GenomeTrack>, BackendKeyHash> m_shared_1d_track_masters;
 
-	// Persistent cache for indexed track backends, keyed by {type, track_dir}.
+	// Persistent cache for indexed track backends, keyed by {type, track_dir, dim}.
 	// Survives reset_shared_1d_track_masters() so that mmap can be reused across
 	// chromosome transitions instead of re-mapping the entire track.dat each time.
+	// The dim field distinguishes DIM1/DIM2 projections in 2D iterators so that
+	// each projection gets its own master with independent chromosome state.
 	struct IndexedBackendKey {
 		GenomeTrack::Type type;
 		std::string track_dir;
+		int dim;  // Iterator_modifier1D::Dimension (DIM_NONE for 1D iterators)
 
 		bool operator==(const IndexedBackendKey &other) const {
-			return type == other.type && track_dir == other.track_dir;
+			return type == other.type && track_dir == other.track_dir && dim == other.dim;
 		}
 	};
 
@@ -317,6 +320,7 @@ private:
 		size_t operator()(const IndexedBackendKey &k) const {
 			size_t h = std::hash<int>()(static_cast<int>(k.type));
 			h ^= std::hash<std::string>()(k.track_dir) * 40503ULL;
+			h ^= std::hash<int>()(k.dim) * 2246822519ULL;
 			return h;
 		}
 	};

--- a/tests/testthat/test-gtrack.array.R
+++ b/tests/testthat/test-gtrack.array.R
@@ -39,6 +39,7 @@ test_that("Testing gtrack.array column name functions", {
     expect_error(gtrack.array.set_colnames("test.array", "col1"))
     cols <- gtrack.array.get_colnames("test.array")
     gtrack.array.set_colnames("test.array", paste(cols, "blabla", sep = ""))
+    withr::defer(gtrack.array.set_colnames("test.array", cols))
     r <- gtrack.array.get_colnames("test.array")
     gtrack.array.set_colnames("test.array", cols)
     expect_regression(r, "gtrack_array_set_colnames")
@@ -46,14 +47,14 @@ test_that("Testing gtrack.array column name functions", {
 
 test_that("Import and extraction with gtrack.array", {
     withr::local_options(list(.ginteractive = FALSE))
-    withr::defer(gtrack.rm("test_track1", TRUE))
-    withr::defer(gtrack.rm("test_track2", TRUE))
-    withr::defer(unlink(c(f1, f2, f3)))
     f1 <- tempfile()
     gextract("test.sparse", gintervals(c(1, 2)), file = f1)
     f2 <- tempfile()
     gtrack.array.extract("test.array", c("col2", "col3", "col4"), gintervals(c(1, 2)), file = f2)
     f3 <- tempfile()
+    withr::defer(unlink(c(f1, f2, f3)))
+    withr::defer(try(gtrack.rm("test_track1", TRUE), silent = TRUE))
+    withr::defer(try(gtrack.rm("test_track2", TRUE), silent = TRUE))
     gtrack.array.extract("test.array", c("col1", "col3"), gintervals(c(1, 2)), file = f3)
 
     gtrack.array.import("test_track1", "", f1, f2)

--- a/tests/testthat/test-indexed-integration.R
+++ b/tests/testthat/test-indexed-integration.R
@@ -265,7 +265,8 @@ test_that("indexed dense track works correctly across many chromosomes", {
     test_fasta <- tempfile(fileext = ".fasta")
     for (i in seq_len(n_chroms)) {
         cat(sprintf(">chr%d\n%s\n", i, paste(rep("ACGT", 25), collapse = "")),
-            file = test_fasta, append = (i > 1))
+            file = test_fasta, append = (i > 1)
+        )
     }
 
     test_db <- tempfile()

--- a/tests/testthat/test-indexed-integration.R
+++ b/tests/testthat/test-indexed-integration.R
@@ -257,5 +257,74 @@ test_that("indexed format validates on init", {
     }
 })
 
+test_that("indexed dense track works correctly across many chromosomes", {
+    # Regression test: indexed tracks previously re-mmapped the entire track.dat
+    # for every chromosome during iterator init and chromosome transitions,
+    # making them unusable on genomes with many contigs.
+    n_chroms <- 50
+    test_fasta <- tempfile(fileext = ".fasta")
+    for (i in seq_len(n_chroms)) {
+        cat(sprintf(">chr%d\n%s\n", i, paste(rep("ACGT", 25), collapse = "")),
+            file = test_fasta, append = (i > 1))
+    }
+
+    test_db <- tempfile()
+    withr::defer({
+        unlink(test_db, recursive = TRUE)
+        unlink(test_fasta)
+    })
+
+    withr::local_options(list(
+        gmulticontig.indexed_format = TRUE,
+        gmultitasking = FALSE
+    ))
+    gdb.create(groot = test_db, fasta = test_fasta, verbose = FALSE)
+    gdb.init(test_db)
+
+    # Create a dense track with known values on all chromosomes
+    all_intervs <- gintervals.all()
+    gdir.create("testidx")
+
+    all_track_intervs <- do.call(rbind, lapply(seq_len(nrow(all_intervs)), function(i) {
+        chrom <- as.character(all_intervs$chrom[i])
+        chrom_end <- all_intervs$end[i]
+        data.frame(
+            chrom = chrom,
+            start = seq(0, chrom_end - 10, by = 10),
+            end = seq(10, chrom_end, by = 10)
+        )
+    }))
+    all_vals <- rep(1.0, nrow(all_track_intervs))
+    gtrack.create_dense("testidx.dense1", "Test dense track", all_track_intervs, all_vals, 10, 0)
+
+    # Convert to indexed format
+    gtrack.convert_to_indexed("testidx.dense1")
+
+    # Verify indexed format was applied
+    info <- gtrack.info("testidx.dense1")
+    expect_equal(info$format, "indexed")
+
+    # Single-chromosome extraction should work and return correct values
+    first_chrom <- as.character(all_intervs$chrom[1])
+    result <- gextract("testidx.dense1", gintervals(first_chrom, 0, 20))
+    expect_equal(nrow(result), 2)
+    expect_true(all(result$testidx.dense1 == 1.0))
+
+    # Multi-chromosome extraction across all chromosomes should work
+    # This exercises the start_chrom code path for every chromosome
+    result_all <- gextract("testidx.dense1", gintervals.all())
+    expect_equal(nrow(result_all), sum(all_intervs$end) / 10)
+
+    # Virtual track with function should work across chromosome transitions
+    gvtrack.create("v_max", "testidx.dense1", func = "max")
+    result_vtrack <- gextract("v_max", gintervals(first_chrom, 0, 100))
+    expect_true(all(result_vtrack$v_max == 1.0))
+    gvtrack.rm("v_max")
+
+    # Clean up
+    gtrack.rm("testidx.dense1", force = TRUE)
+    gdir.rm("testidx", force = TRUE, recursive = TRUE)
+})
+
 # Restore the test database after all integration tests
 suppressMessages(gdb.init("/net/mraid20/export/tgdata/db/tgdb/misha_test_db/"))


### PR DESCRIPTION
## Summary

- Fixed indexed tracks re-mmapping the entire `track.dat` for every chromosome, making them unusable on genomes with many contigs (e.g. Pan_troglodytes: 4344 contigs, 1.2GB track.dat — every operation hangs)
- Root cause 1: validation loop in `create_expr_iterator` created a local `GenomeTrackFixedBin` per iteration, defeating `init_read`'s mmap reuse logic. Moved declaration outside the loop.
- Root cause 2: `start_chrom()` destroyed all cached track objects on every chromosome transition via `reset_shared_1d_track_masters()`. Added a persistent indexed-track cache (`m_indexed_track_backends`) keyed by `{type, track_dir}` that survives the per-chrom reset.

## Test plan

- [ ] Existing indexed integration tests pass (25 tests)
- [ ] New regression test: 50-chromosome genome with indexed dense track — single-chrom extract, all-chrom extract, virtual track across chromosome transitions
- [ ] Full test suite shows no regressions
- [ ] Manual test on Pan_troglodytes `chipseq.ctcf.LCL.ptrEB176JC` completes instead of hanging