### PR TITLE
fix(synth): resolve chromids via full chromkey, not input subset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.14
+Version: 5.6.15
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.15
+
+* Fixed `gsynth.train()`, `gsynth.sample()`, and `gsynth.random_seqs()` silently reading sequences from the wrong chromosomes when the input `intervals` omitted chromosomes that sort earlier in the chromkey. The R wrapper resolved chromids positionally against the input subset rather than misha's internal chromkey.
+
 # misha 5.6.14
 
 * Fixed indexed tracks re-mmapping the entire `track.dat` for every chromosome during iterator init and chromosome transitions. Made indexed tracks unusable on genomes with many contigs (e.g. Pan_troglodytes with 4344 contigs).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # misha 5.6.15
 
-* Fixed `gsynth.train()`, `gsynth.sample()`, and `gsynth.random_seqs()` silently reading sequences from the wrong chromosomes when the input `intervals` omitted chromosomes that sort earlier in the chromkey. The R wrapper resolved chromids positionally against the input subset rather than misha's internal chromkey.
+* Fixed `gsynth.train()`, `gsynth.sample()`, and `gsynth.random_seqs()` silently reading sequences from the wrong chromosome when the `intervals` argument covered a subset of the genome that omitted one or more earlier chromosomes in the chromkey. For every chromosome in the input that came after a missing one, the C++ side opened the wrong chromosome's sequence (shifted by the number of earlier missing chromosomes), producing invalid models and corrupted sampled genomes without any error. Calls that passed `intervals = gintervals.all()` or left `intervals` at its default (which is `gintervals.all()`) were not affected. Users who ran these functions on custom interval subsets should re-run them with this version.
 
 # misha 5.6.14
 

--- a/R/synth.R
+++ b/R/synth.R
@@ -511,14 +511,18 @@ gsynth.train <- function(...,
         # All positions map to bin 1 in R (will be converted to 0-based for C++)
         flat_indices <- rep(1L, n_positions)
 
-        # Get chromosome info for processing
+        # Get chromosome info for processing. Use levels() (full chromkey order
+        # from gintervals_chrom_sizes) rather than chrom_sizes$chrom (only chroms
+        # present in the input subset) so chromids match misha's internal chromkey
+        # even when the input is missing chroms that sort earlier in the chromkey.
         chrom_sizes <- gintervals.chrom_sizes(intervals)
-        chrom_ids <- match(as.character(intervals$chrom), chrom_sizes$chrom) - 1L
+        chrom_key <- levels(chrom_sizes$chrom)
+        chrom_ids <- match(as.character(intervals$chrom), chrom_key) - 1L
         chrom_starts <- intervals$start
         chrom_ends <- intervals$end
 
         # Prepare iterator position data
-        iter_chroms <- match(as.character(iter_info$chrom), chrom_sizes$chrom) - 1L
+        iter_chroms <- match(as.character(iter_info$chrom), chrom_key) - 1L
         iter_starts <- as.integer(iter_info$start)
     } else {
         # Multi-dimensional model: existing logic
@@ -562,14 +566,16 @@ gsynth.train <- function(...,
         # Compute flat bin indices using vectorized helper
         flat_indices <- .compute_flat_indices(per_dim_indices, dim_sizes)
 
-        # Get chromosome info for processing
+        # Get chromosome info for processing. See note above re: levels() vs
+        # chrom_sizes$chrom.
         chrom_sizes <- gintervals.chrom_sizes(intervals)
-        chrom_ids <- match(as.character(intervals$chrom), chrom_sizes$chrom) - 1L
+        chrom_key <- levels(chrom_sizes$chrom)
+        chrom_ids <- match(as.character(intervals$chrom), chrom_key) - 1L
         chrom_starts <- intervals$start
         chrom_ends <- intervals$end
 
         # Prepare iterator position data
-        iter_chroms <- match(as.character(track_data$chrom), chrom_sizes$chrom) - 1L
+        iter_chroms <- match(as.character(track_data$chrom), chrom_key) - 1L
         iter_starts <- as.integer(track_data$start)
     }
 
@@ -1243,9 +1249,12 @@ gsynth.sample <- function(model,
         # All positions map to bin 1 in R (will be converted to 0-based for C++)
         flat_indices <- rep(1L, n_positions)
 
-        # Get chromosome info
+        # Get chromosome info. Use levels() (full chromkey order) rather than
+        # chrom_sizes$chrom (only chroms present in the input) so chromids match
+        # misha's internal chromkey.
         chrom_sizes <- gintervals.chrom_sizes(intervals)
-        iter_chroms <- match(as.character(iter_info$chrom), chrom_sizes$chrom) - 1L
+        chrom_key <- levels(chrom_sizes$chrom)
+        iter_chroms <- match(as.character(iter_info$chrom), chrom_key) - 1L
         iter_starts <- as.integer(iter_info$start)
     } else {
         # Multi-dimensional model: extract track values and compute bins
@@ -1322,9 +1331,10 @@ gsynth.sample <- function(model,
         # Compute flat bin indices using vectorized helper
         flat_indices <- .compute_flat_indices(per_dim_indices, dim_sizes)
 
-        # Get chromosome info
+        # Get chromosome info. See note above re: levels() vs chrom_sizes$chrom.
         chrom_sizes <- gintervals.chrom_sizes(intervals)
-        iter_chroms <- match(as.character(track_data$chrom), chrom_sizes$chrom) - 1L
+        chrom_key <- levels(chrom_sizes$chrom)
+        iter_chroms <- match(as.character(track_data$chrom), chrom_key) - 1L
         iter_starts <- as.integer(track_data$start)
     }
 
@@ -1613,9 +1623,12 @@ gsynth.random <- function(intervals = NULL,
     # All positions map to bin 0 (single bin)
     flat_indices <- rep(0L, n_positions)
 
-    # Get chromosome info
+    # Get chromosome info. Use levels() (full chromkey order) rather than
+    # chrom_sizes$chrom (only chroms present in the input) so chromids match
+    # misha's internal chromkey.
     chrom_sizes <- gintervals.chrom_sizes(intervals)
-    iter_chroms <- match(as.character(iter_info$chrom), chrom_sizes$chrom) - 1L
+    chrom_key <- levels(chrom_sizes$chrom)
+    iter_chroms <- match(as.character(iter_info$chrom), chrom_key) - 1L
     iter_starts <- as.integer(iter_info$start)
 
     # Create CDF from probabilities: [P(A), P(A)+P(C), P(A)+P(C)+P(G), 1]

--- a/tests/testthat/test-synth-chromid.R
+++ b/tests/testthat/test-synth-chromid.R
@@ -1,0 +1,54 @@
+test_that("gsynth.train resolves chromids via full chromkey, not input subset", {
+    # Regression test for positional chromid bug in R/synth.R.
+    #
+    # BUG: chrom_ids/iter_chroms were computed via
+    #   match(as.character(intervals$chrom), chrom_sizes$chrom) - 1L
+    # where `chrom_sizes$chrom` (as coerced to character by match()) only
+    # contains chromosomes present in the input subset. When the input is
+    # missing a chromosome that sorts earlier in the chromkey, every later
+    # chromosome's ID shifts down, and the C++ code reads sequences from the
+    # WRONG chromosome (silently).
+    #
+    # FIX: match against `levels(chrom_sizes$chrom)`, which the C++ side
+    # populates with the FULL chromkey in ID order (see
+    # GenomeIntervalUtils.cpp::gintervals_chrom_sizes).
+    #
+    # Test scenario: the test DB has chr1, chr2, chrX. Passing intervals on
+    # chrX only excludes chr1 and chr2 from the input subset. Under the bug,
+    # chrX-input chromid resolves to 0 (chr1's chromkey ID), so gsynth.train
+    # reads chr1 sequence instead of chrX, and the resulting model matches
+    # a chr1-only-input model. After the fix, the two models differ.
+
+    gdb.init_examples()
+
+    chr1_intervs <- gintervals("chr1", 0, 100000)
+    chrX_intervs <- gintervals("chrX", 0, 100000)
+
+    # Sanity: chr1 and chrX carry different sequences in the test DB
+    expect_false(
+        gseq.extract(gintervals("chr1", 0, 1000)) ==
+            gseq.extract(gintervals("chrX", 0, 1000))
+    )
+
+    # Zero-dim model: no dim_specs, so gsynth.train just counts k-mers
+    # across the input intervals. This isolates the chromid resolution
+    # from track-extraction logic.
+    model_chr1 <- gsynth.train(
+        intervals = chr1_intervs,
+        iterator = 100
+    )
+    model_chrX <- gsynth.train(
+        intervals = chrX_intervs,
+        iterator = 100
+    )
+
+    # Both models should be valid
+    expect_s3_class(model_chr1, "gsynth.model")
+    expect_s3_class(model_chrX, "gsynth.model")
+
+    # Under the bug: chrX-input loads chr1's sequence → the two CDFs match.
+    # After the fix: each loads its own chromosome → the CDFs differ.
+    cdf_chr1 <- model_chr1$model_data$cdf[[1]]
+    cdf_chrX <- model_chrX$model_data$cdf[[1]]
+    expect_false(isTRUE(all.equal(cdf_chr1, cdf_chrX, tolerance = 1e-6)))
+})


### PR DESCRIPTION
## Summary

Fixes a silent correctness bug in `gsynth.train()`, `gsynth.sample()`, and `gsynth.random_seqs()` where passing `intervals` that omitted earlier chromosomes in misha's chromkey caused the C++ side to read sequence from the wrong chromosome. Bug was flagged (but left out of scope) in the GlmFeatureExtractor chromid fix on `feat/glm-pred`; this PR closes that follow-up.

The R wrapper resolved chromids via `match(as.character(X$chrom), chrom_sizes$chrom) - 1L`, where `chrom_sizes$chrom` (coerced through `match`) contains only chromosomes present in the input subset. When the subset omitted a chrom sorting earlier in the chromkey (e.g. `intervals` on chrX only), every later chrom's positional ID shifted down; the C++ then opened the wrong chromosome's sequence.

Fix: match against `levels(chrom_sizes$chrom)` instead, which the C++ side of `gintervals_chrom_sizes` populates with the full chromkey in ID order (see `GenomeIntervalUtils.cpp::gintervals_chrom_sizes`). Pure R-side change — no C++ changes.

Users of `gintervals.all()` (or the default) were unaffected, since no chromosomes are missing.

## Test plan

- [x] New regression test `tests/testthat/test-synth-chromid.R`: trains zero-dim models on chr1-only vs chrX-only intervals in the test DB (chroms: chr1/chr2/chrX). Under the bug, chrX input silently loads chr1 sequence → identical CDFs. Test asserts the two CDFs differ.
- [x] Verified the test fails on the buggy code (CDFs identical) and passes after the fix.
- [x] Full gsynth suite still green (`alutil::tst(filter = 'gsynth', parallel = TRUE)`: 12,088 tests, 0 failures).
- [ ] CI green (R-CMD-check, tests).