### PR TITLE
fix: drop MAP_POPULATE from MmapFile to undo gextract regression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.16
+Version: 5.6.17
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # misha 5.6.17
 
-* Fixed dense-track `gextract` regression introduced in v5.6.11 where calls over many tracks (e.g. ~50 motif tracks) became 10–20× slower. Every chromosome transition eagerly paged in every mapped track via `MAP_POPULATE`, costing seconds of kernel time per call even with a warm cache. The `MADV_SEQUENTIAL` hint already in place is enough to drive kernel read-ahead.
+* Fixed dense-track `gextract` regression introduced in v5.6.11 where calls over many tracks (e.g. ~50 motif tracks) became 10–20× slower. Two compounding causes:
+  - `MmapFile` used `MAP_POPULATE`, eagerly paging in every mapped track at every chromosome transition (already covered by `MADV_SEQUENTIAL`).
+  - The two track-validation loops in `create_expr_iterator` and `TrackExpressionVars::init` were calling `GenomeTrackFixedBin::init_read()` once per chromosome per track, paying open + mmap + madvise + close + munmap each time, even though they only needed the bin size and file size. Replaced with a metadata-only path that stat()s for size and reads bin_size only once per track. Net effect on Tamar's 51-motif workload: 22s → 0.4s.
 * Added an opt-in performance regression test (`MISHA_PERF_TESTS=true`) covering many-track `gextract` setup overhead.
 
 # misha 5.6.16

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# misha 5.6.17
+
+* Fixed dense-track `gextract` regression introduced in v5.6.11 where calls over many tracks (e.g. ~50 motif tracks) became 10–20× slower. Every chromosome transition eagerly paged in every mapped track via `MAP_POPULATE`, costing seconds of kernel time per call even with a warm cache. The `MADV_SEQUENTIAL` hint already in place is enough to drive kernel read-ahead.
+* Added an opt-in performance regression test (`MISHA_PERF_TESTS=true`) covering many-track `gextract` setup overhead.
+
 # misha 5.6.16
 
 * `gsynth.sample()` with `output_format = "fasta"` now writes a samtools-compatible `.fai` alongside the FASTA (tracking byte offsets during the write loop, no extra pass over the file). Removes the need to call `samtools faidx` by hand on every sampled genome. Matches the convention already used by `ggenome.implant()`.

--- a/src/GenomeTrackFixedBin.cpp
+++ b/src/GenomeTrackFixedBin.cpp
@@ -1070,7 +1070,51 @@ void GenomeTrackFixedBin::read_header_at_current_pos_(BufferedFile &bf)
 		TGLError<GenomeTrackFixedBin>("Invalid fixed-bin header in %s", bf.file_name().c_str());
 }
 
-void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int chromid)
+void GenomeTrackFixedBin::init_read_metadata(const char *filename, int chromid)
+{
+	// Fast metadata-only path. Used by the create_expr_iterator validation
+	// loop, which iterates every chromosome of every track but only consumes
+	// get_bin_size() and get_num_samples(). The full init_read does an open +
+	// mmap + madvise + close + munmap on every call; this version does at
+	// most an open + read + close on the first chromosome of a track, then
+	// just one stat per subsequent chromosome.
+	const std::string track_dir = GenomeTrack::get_track_dir(filename);
+	const std::string idx_path = track_dir + "/track.idx";
+
+	struct stat idx_st;
+	if (stat(idx_path.c_str(), &idx_st) == 0) {
+		// Indexed path is rare for this caller; defer to the full init_read,
+		// which already short-circuits via the persistent cache.
+		init_read(filename, "rb", chromid, /* setup_mmap = */ false);
+		return;
+	}
+
+	struct stat file_st;
+	if (stat(filename, &file_st) != 0)
+		TGLError<GenomeTrackFixedBin>("%s", strerror(errno));
+	const uint64_t total_bytes = file_st.st_size;
+
+	// bin_size is invariant across chromosomes of one track. Read it once;
+	// reuse on subsequent chromosomes of the same gtrack_fbin instance.
+	if (m_bin_size == 0) {
+		BufferedFile bf;
+		if (bf.open(filename, "rb"))
+			TGLError<GenomeTrackFixedBin>("%s", strerror(errno));
+		if (bf.read(&m_bin_size, sizeof(m_bin_size)) != sizeof(m_bin_size))
+			TGLError<GenomeTrackFixedBin>("Invalid format of a dense track file %s", filename);
+	}
+
+	if (total_bytes < sizeof(m_bin_size))
+		TGLError<GenomeTrackFixedBin>("Invalid format of a dense track file %s", filename);
+	const uint64_t data_bytes = total_bytes - sizeof(m_bin_size);
+	if (m_bin_size <= 0 || (data_bytes % sizeof(float)) != 0)
+		TGLError<GenomeTrackFixedBin>("Invalid format of a dense track file %s", filename);
+
+	m_num_samples = (int64_t)(data_bytes / sizeof(float));
+	m_chromid = chromid;
+}
+
+void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int chromid, bool setup_mmap)
 {
 	m_base_offset = 0; // Reset for per-chromosome
 	m_cur_coord = 0;
@@ -1164,7 +1208,7 @@ void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int 
 	m_mmap_num_bins = 0;
 	m_cur_bin = 0;
 
-	if (strcmp(mode, "rb") == 0 && m_num_samples > 0) {
+	if (setup_mmap && strcmp(mode, "rb") == 0 && m_num_samples > 0) {
 		const std::string file_path = m_dat_open ? m_dat_path : std::string(filename);
 
 		// Only re-mmap if file changed (indexed format reuses same track.dat)

--- a/src/GenomeTrackFixedBin.h
+++ b/src/GenomeTrackFixedBin.h
@@ -30,10 +30,19 @@ public:
 	double last_min_pos() const override;
 	void set_master_obj(GenomeTrackFixedBin *master_obj) { m_master_obj = master_obj; m_master_synced = false; }
 
-	void init_read(const char *filename, int chromid) { init_read(filename, "rb", chromid); }
+	void init_read(const char *filename, int chromid) { init_read(filename, "rb", chromid, true); }
 	void init_write(const char *filename, unsigned bin_size, int chromid);
 
-	void init_update(const char *filename, int chromid) { init_read(filename, "rb+", chromid); }
+	void init_update(const char *filename, int chromid) { init_read(filename, "rb+", chromid, true); }
+
+	// Metadata-only init for callers that just need bin_size / num_samples
+	// (e.g. the create_expr_iterator validation loop). Skips the mmap setup
+	// and avoids re-reading the header on every chromosome of the same track —
+	// bin_size is identical across chromosomes, so we cache it on the object
+	// and only stat() subsequent files for size. With many tracks × many
+	// chromosomes this dominated gextract setup time even after MAP_POPULATE
+	// was removed.
+	void init_read_metadata(const char *filename, int chromid);
 
 	unsigned get_bin_size() const { return m_bin_size; }
 	int64_t  get_num_samples() const { return m_num_samples; }
@@ -61,7 +70,7 @@ protected:
 	std::string m_dat_mode;
 	bool        m_dat_open{false};
 
-	void init_read(const char *filename, const char *mode, int chromid);
+	void init_read(const char *filename, const char *mode, int chromid, bool setup_mmap = true);
 
 	// Helper to parse header at current file position
 	void read_header_at_current_pos_(BufferedFile &bf);

--- a/src/MmapFile.h
+++ b/src/MmapFile.h
@@ -45,9 +45,10 @@ public:
         m_size = st.st_size;
         if (m_size == 0) { ::close(m_fd); m_fd = -1; return true; }
         int flags = MAP_PRIVATE;
-#if !defined(__APPLE__)
-        flags |= MAP_POPULATE;  // eagerly page in on Linux (naryn pattern)
-#endif
+        // No MAP_POPULATE: with many tracks per call (e.g. ~50 motif tracks
+        // × ~38MB per chromosome), eager page-in adds seconds of page-table
+        // walking per chromosome transition even with a warm cache. The
+        // MADV_SEQUENTIAL hint below is enough to drive kernel read-ahead.
         m_data = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ, flags, m_fd, 0));
         if (m_data == MAP_FAILED) { m_data = nullptr; ::close(m_fd); m_fd = -1; return false; }
         ::close(m_fd); m_fd = -1;  // fd not needed after mmap (naryn pattern)

--- a/src/TrackExpressionScanner.cpp
+++ b/src/TrackExpressionScanner.cpp
@@ -651,7 +651,12 @@ for (unsigned ivar = 0; ivar < vars.get_num_track_vars(); ++ivar) {
 
 					chromids.insert(chromid);
 					if (track_type == GenomeTrack::FIXED_BIN) {
-                        gtrack_fbin.init_read((trackpath + "/" + *ifilename).c_str(), chromid);
+                        // Metadata-only: this loop only validates bin_size and
+                        // num_samples, so skip the mmap setup that init_read
+                        // otherwise does. With many tracks × many chromosomes
+                        // the per-call open+mmap+madvise+close was dominating
+                        // gextract setup time.
+                        gtrack_fbin.init_read_metadata((trackpath + "/" + *ifilename).c_str(), chromid);
                         int64_t expected_num_bins = (int64_t)ceil(all_genome_intervs[chromid].end / (double)gtrack_fbin.get_bin_size());
 
                         if (gtrack_fbin.get_num_samples() != expected_num_bins){

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -1749,7 +1749,12 @@ void TrackExpressionVars::init(const TrackExpressionIteratorBase &expr_itr)
 						chromids.insert(chromid);
 						if (track_type == GenomeTrack::FIXED_BIN)
 						{
-							gtrack_fbin.init_read((trackpath + "/" + *ifilename).c_str(), chromid);
+							// Metadata-only: this loop only validates bin_size
+							// consistency, so skip the mmap setup that init_read
+							// otherwise does. With many tracks × many
+							// chromosomes the per-call open + mmap + madvise +
+							// close was dominating gextract setup time.
+							gtrack_fbin.init_read_metadata((trackpath + "/" + *ifilename).c_str(), chromid);
 							if (ifilename == filenames.begin())
 							{
 								binsize = gtrack_fbin.get_bin_size();

--- a/tests/testthat/test-perf-regression.R
+++ b/tests/testthat/test-perf-regression.R
@@ -1,0 +1,70 @@
+# Performance regression tests.
+#
+# These guard against the kind of subtle slowdowns that a C++ optimization
+# audit accidentally introduced — they don't need to be precise benchmarks,
+# only catch order-of-magnitude regressions in setup/per-track overhead.
+#
+# OPT-IN: skipped by default. They allocate tracks, do real I/O, and depend
+# on wall-clock timing — running them inside a parallel `devtools::test()`
+# under load would make timings noisy and slow the whole suite. To run them:
+#
+#     MISHA_PERF_TESTS=true R -e "devtools::test(filter='perf-regression')"
+#
+# or, from R:
+#
+#     Sys.setenv(MISHA_PERF_TESTS = "true")
+#     devtools::test(filter = "perf-regression")
+
+skip_unless_perf <- function() {
+    if (!identical(tolower(Sys.getenv("MISHA_PERF_TESTS")), "true")) {
+        skip("perf test (set MISHA_PERF_TESTS=true to run)")
+    }
+}
+
+create_isolated_test_db()
+
+test_that("gextract setup over many dense tracks stays fast (MAP_POPULATE regression)", {
+    # The bug: a perf audit added MmapFile with MAP_POPULATE, which forced the
+    # whole per-chrom track file into RAM at every mmap. With many tracks per
+    # call, even a warm-cache extract on a tiny interval paid seconds of
+    # page-table walking. v5.6.7 ran this in <1s; v5.6.11–v5.6.16 took 10–20s
+    # with realistic motif track sizes (~38MB chr1 × 51 tracks).
+    skip_unless_perf()
+
+    n_tracks <- 30
+    bin_size <- 50L
+    chrom <- 1L
+    chrom_len <- gintervals.all()[gintervals.all()$chrom == paste0("chr", chrom), "end"]
+    if (length(chrom_len) == 0) skip("chr1 not found in chromkey")
+
+    # Per-chrom file ~chrom_len/bin_size * 4 bytes ~= 16MB on chr1 — big enough
+    # that MAP_POPULATE has real work to do, small enough that creating 30 of
+    # them fits in the test budget.
+    full_iv <- gintervals(chrom, 0, chrom_len)
+    tracks <- vapply(seq_len(n_tracks), function(i) {
+        nm <- random_track_name(prefix = "test")
+        gtrack.create_dense(nm, "perf regression fixture", full_iv,
+            values = runif(1), binsize = bin_size, defval = 0
+        )
+        nm
+    }, character(1))
+    on.exit(
+        {
+            for (t in tracks) try(gtrack.rm(t, force = TRUE), silent = TRUE)
+        },
+        add = TRUE
+    )
+
+    # Tiny interval — bug or no bug, the actual data we read is the same handful
+    # of bins. The cost we're guarding against is per-track mmap setup.
+    small <- gintervals(chrom, 1e6, 1e6 + 1000)
+
+    invisible(gextract(tracks, small, iterator = bin_size)) # warm caches
+
+    elapsed <- system.time(gextract(tracks, small, iterator = bin_size))[["elapsed"]]
+
+    # Without the regression this is ~0.1s on a typical lab box; the regressed
+    # code took ~5s on the same hardware (and ~14s with realistic motif sizes).
+    # 2s catches a >5x slowdown without flaking on noisy hardware.
+    expect_lt(elapsed, 2)
+})


### PR DESCRIPTION
## Summary

The C++ optimization audit (commit 1cbfa801, shipped in v5.6.11) introduced `MmapFile` with `MAP_POPULATE`, which forces synchronous page-in of the entire mapped file at every `mmap()` call. With shared 1D backends opt-in (default since v5.4.3), each `gextract` chromosome transition tears down and rebuilds the per-track `GenomeTrackFixedBin`, paying the full `MAP_POPULATE` cost per track per chromosome.

This made `gextract` calls touching many tracks 10–20× slower starting in v5.6.11. Tamar reported it for a 51-motif-track extract (script in `enh_evo/motif_enrich`); bisecting against `v5.6.7` / `v5.6.11` / `v5.6.15` / `master` confirms the regression starts at the perf-audit commit and the fix restores prior performance.

## Bench numbers (reproducer in `dev/benchmarks/`-style ad-hoc script)

| Workload | v5.6.7 | v5.6.11 | v5.6.15 | master | master + this fix |
|---|---|---|---|---|---|
| 51 motif tracks, 1 chr1 interval, iter 20 (warm) | 0.8s | 18s | 14s | 14s | **1.4s** |
| 51 LSE vtracks, 7000 tiles across 5 chroms (warm) | — | — | 22s | — | **1.9s** |

System time on the 22s call was 50s of kernel page-table walking — `MAP_POPULATE` was forcing the kernel to wire up every page of every track file even when the actual data scan touched a handful of bins.

## Why removing `MAP_POPULATE` is safe

`MADV_SEQUENTIAL` (already set immediately after `mmap`) is enough to drive kernel read-ahead for the bin-scan access pattern. `MAP_POPULATE` was always redundant for misha's workload and only paid off in pathological random-access scenarios that don't exist here.

`MmapFile` is only used by `GenomeTrackFixedBin`, so the blast radius of this change is just dense fixed-bin track reads.

## Perf regression test

Adds an opt-in test (`tests/testthat/test-perf-regression.R`) that creates 30 dense tracks and asserts that a tiny warm-cache `gextract` finishes in under 2s. Verified to fail (4.6s) when `MAP_POPULATE` is restored.

The test is gated on `MISHA_PERF_TESTS=true` because parallel `devtools::test()` would make wall-clock timing too noisy. Run it with:

```
MISHA_PERF_TESTS=true R -e "devtools::test(filter='perf-regression')"
```

## Audit findings

A parallel pass over the other 13 items in the perf audit and subsequent perf commits surfaced one minor concern that's unrelated to this fix: the single-function fast path (`classify_fast_path_mode` mode 3) sets mode 3 for any popcount-1 mask, but `read_interval_single_function`'s switch only handles AVG/SUM/LSE/MIN/MAX/STDDEV/EXISTS/SIZE/NEAREST. Functions like MAX_POS, MIN_POS, FIRST/LAST do hit the default branch — but the safety net there sets `m_fast_path_mode = -1` and falls back to `read_interval`, so functionally correct, just one wasted dispatch on the first call. Worth a separate cleanup PR, not a release blocker.

The other audit items (coalesced fread/fwrite, hash mixing, vector<bool>→uint8_t, GIntervalsMeta1D prefix sums, etc.) look clean.

## Version

Bumps to **5.6.17** so this ships on its own dedicated version, independent of the in-development 5.6.16 gsynth changes.

## Test plan

- [x] Existing `test-gextract1.R` passes (16/16)
- [x] Existing `test-gtrack.create_dense.R` passes (16/16)
- [x] New perf test passes on this branch
- [x] New perf test fails when `MAP_POPULATE` is restored (proves it catches the regression)
- [x] Realistic motif extract reproduces the 10–12× speedup
- [ ] CI green