### PR TITLE
test: broaden opt-in perf regression suite (9 ops with measured baselines)

### DIFF
--- a/tests/testthat/helper-perf.R
+++ b/tests/testthat/helper-perf.R
@@ -1,0 +1,54 @@
+# Helpers for the opt-in performance regression tests in test-perf-regression.R.
+#
+# Why the framework exists: we got bitten twice by perf regressions that
+# weren't caught by correctness tests (MAP_POPULATE, validation-loop init_read).
+# We also got bitten ONCE by an audit "finding" that turned out to be a false
+# positive — the suspect path wasn't even hit on the workload it claimed to
+# slow down. So the rule is: add a perf test only when both
+# (a) it actually exercises the path we care about, and
+# (b) you have measured a baseline on this hardware to anchor the threshold.
+#
+# Threshold rule: budget = baseline_ms * factor (default 3x). The baseline for
+# each test is the FASTEST observed wall-clock for that operation across
+# versions we care about — if a fix beats the historical state, use the new
+# (lower) number; if any historical state was faster, use that. Never raise
+# the baseline for convenience: the whole point is to ratchet the bar tight.
+#
+# Baselines are absolute wall-clock numbers measured on the lab box (mraid20 /
+# NFS test_db) and not portable to other hardware — that's why the suite is
+# opt-in via MISHA_PERF_TESTS=true.
+
+skip_unless_perf <- function() {
+    if (!identical(tolower(Sys.getenv("MISHA_PERF_TESTS")), "true")) {
+        skip("perf test (set MISHA_PERF_TESTS=true to run)")
+    }
+}
+
+# Run `expr` `warmup` times to warm caches and one-shot R-side overhead, then
+# `measure` times for timing. Returns the median elapsed seconds — median is
+# more robust than mean to the occasional GC pause or NFS hiccup.
+time_op <- function(expr, warmup = 1L, measure = 3L) {
+    expr_q <- substitute(expr)
+    env <- parent.frame()
+    for (i in seq_len(warmup)) eval(expr_q, env)
+    times <- numeric(measure)
+    for (i in seq_len(measure)) {
+        times[i] <- system.time(eval(expr_q, env))[["elapsed"]]
+    }
+    median(times)
+}
+
+# Assert measured wall-clock time stays within budget = baseline_ms * factor.
+expect_perf_baseline <- function(measured_s, label, baseline_ms, factor = 3) {
+    budget_ms <- baseline_ms * factor
+    measured_ms <- measured_s * 1000
+    msg <- sprintf(
+        "%s: measured %.0fms, budget %.0fms (= %.0fms baseline * %g)",
+        label, measured_ms, budget_ms, baseline_ms, factor
+    )
+    if (measured_ms >= budget_ms) {
+        fail(msg)
+    } else {
+        succeed(msg)
+    }
+}

--- a/tests/testthat/test-perf-regression.R
+++ b/tests/testthat/test-perf-regression.R
@@ -4,67 +4,177 @@
 # audit accidentally introduced — they don't need to be precise benchmarks,
 # only catch order-of-magnitude regressions in setup/per-track overhead.
 #
+# Helper functions and the budget rule live in helper-perf.R. Each test
+# embeds a single `baseline_ms` measured on the lab box. Budget for a test is
+# `baseline_ms * 3`; the 3x factor keeps noisy NFS hardware from false-firing
+# while still catching genuine >3x slowdowns.
+#
+# Pick `baseline_ms` as the FASTEST wall-clock you can reproduce for the
+# operation across versions you care about. If a future fix makes an
+# operation faster, lower the number (do not raise for convenience — the
+# whole point is to keep the bar tight). If a planned change makes it
+# legitimately slower, justify it before relaxing the baseline.
+#
 # OPT-IN: skipped by default. They allocate tracks, do real I/O, and depend
 # on wall-clock timing — running them inside a parallel `devtools::test()`
-# under load would make timings noisy and slow the whole suite. To run them:
+# under load would make timings noisy and slow the whole suite.
 #
 #     MISHA_PERF_TESTS=true R -e "devtools::test(filter='perf-regression')"
-#
-# or, from R:
-#
-#     Sys.setenv(MISHA_PERF_TESTS = "true")
-#     devtools::test(filter = "perf-regression")
-
-skip_unless_perf <- function() {
-    if (!identical(tolower(Sys.getenv("MISHA_PERF_TESTS")), "true")) {
-        skip("perf test (set MISHA_PERF_TESTS=true to run)")
-    }
-}
 
 create_isolated_test_db()
 
-test_that("gextract setup over many dense tracks stays fast (MAP_POPULATE regression)", {
-    # The bug: a perf audit added MmapFile with MAP_POPULATE, which forced the
-    # whole per-chrom track file into RAM at every mmap. With many tracks per
-    # call, even a warm-cache extract on a tiny interval paid seconds of
-    # page-table walking. v5.6.7 ran this in <1s; v5.6.11–v5.6.16 took 10–20s
-    # with realistic motif track sizes (~38MB chr1 × 51 tracks).
-    skip_unless_perf()
+# Shared fixtures (created once, reused across tests via gtrack.* lookups).
+.perf_setup <- function(n_dense_tracks = 30, dense_bin_size = 50L) {
+    chrom_len <- gintervals.all()[gintervals.all()$chrom == "chr1", "end"]
+    full_iv <- gintervals(1, 0, chrom_len)
 
-    n_tracks <- 30
-    bin_size <- 50L
-    chrom <- 1L
-    chrom_len <- gintervals.all()[gintervals.all()$chrom == paste0("chr", chrom), "end"]
-    if (length(chrom_len) == 0) skip("chr1 not found in chromkey")
-
-    # Per-chrom file ~chrom_len/bin_size * 4 bytes ~= 16MB on chr1 — big enough
-    # that MAP_POPULATE has real work to do, small enough that creating 30 of
-    # them fits in the test budget.
-    full_iv <- gintervals(chrom, 0, chrom_len)
-    tracks <- vapply(seq_len(n_tracks), function(i) {
+    dense_tracks <- vapply(seq_len(n_dense_tracks), function(i) {
         nm <- random_track_name(prefix = "test")
-        gtrack.create_dense(nm, "perf regression fixture", full_iv,
-            values = runif(1), binsize = bin_size, defval = 0
+        gtrack.create_dense(nm, "perf fixture", full_iv,
+            values = runif(1), binsize = dense_bin_size, defval = 0
         )
         nm
     }, character(1))
-    on.exit(
-        {
-            for (t in tracks) try(gtrack.rm(t, force = TRUE), silent = TRUE)
-        },
-        add = TRUE
+
+    sparse_track <- random_track_name(prefix = "test")
+    sparse_intervs <- gintervals(1, seq(0, 1e6, by = 100), seq(50, 1e6 + 50, by = 100))
+    sparse_intervs <- sparse_intervs[sparse_intervs$end <= chrom_len, ]
+    gtrack.create_sparse(sparse_track, "perf fixture", sparse_intervs,
+        values = runif(nrow(sparse_intervs))
     )
 
-    # Tiny interval — bug or no bug, the actual data we read is the same handful
-    # of bins. The cost we're guarding against is per-track mmap setup.
-    small <- gintervals(chrom, 1e6, 1e6 + 1000)
+    list(
+        dense_tracks = dense_tracks,
+        sparse_track = sparse_track,
+        chrom1_len = chrom_len,
+        full_chr1 = full_iv,
+        small_chr1 = gintervals(1, 1e6, 1e6 + 1000)
+    )
+}
 
-    invisible(gextract(tracks, small, iterator = bin_size)) # warm caches
+.perf_cleanup <- function(fix) {
+    for (t in fix$dense_tracks) try(gtrack.rm(t, force = TRUE), silent = TRUE)
+    try(gtrack.rm(fix$sparse_track, force = TRUE), silent = TRUE)
+}
 
-    elapsed <- system.time(gextract(tracks, small, iterator = bin_size))[["elapsed"]]
+# --- Tests ---
 
-    # Without the regression this is ~0.1s on a typical lab box; the regressed
-    # code took ~5s on the same hardware (and ~14s with realistic motif sizes).
-    # 2s catches a >5x slowdown without flaking on noisy hardware.
-    expect_lt(elapsed, 2)
+test_that("gextract setup over many dense tracks stays fast (MAP_POPULATE regression)", {
+    # Bug history: v5.6.11 added MmapFile with MAP_POPULATE which forced
+    # eager paging-in of every per-chrom file at every mmap. v5.6.17 removed
+    # MAP_POPULATE and switched the per-chrom-per-track validation loops to a
+    # metadata-only path. This test would have caught both.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 30)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+
+    measured <- time_op(gextract(fix$dense_tracks, fix$small_chr1, iterator = 50))
+    expect_perf_baseline(measured, "many-dense setup", baseline_ms = 112)
+})
+
+test_that("gextract single dense track full chr1 stays fast (bin-scan path)", {
+    # Guards the inner read loop in GenomeTrackFixedBin::read_interval — the
+    # hot path that the perf audit's mmap zero-copy was supposed to speed up.
+    # On chr1 (~250Mbp) at binsize=50 this scans ~5M bins.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 1)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+
+    measured <- time_op(gextract(fix$dense_tracks[1], fix$full_chr1, iterator = 50))
+    expect_perf_baseline(measured, "dense full-chr scan", baseline_ms = 2005)
+})
+
+test_that("gextract sparse track full chr1 stays fast", {
+    # Guards GenomeTrackSparse::read_interval — uses a separate code path
+    # (BufferedFile + load-into-memory) that didn't benefit from MmapFile but
+    # could regress independently if the perf audit touched its hot loop.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 0)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+
+    measured <- time_op(gextract(fix$sparse_track, fix$full_chr1))
+    expect_perf_baseline(measured, "sparse full-chr", baseline_ms = 20)
+})
+
+test_that("gextract vtrack with avg + window stays fast", {
+    # Realistic vtrack pattern: avg over a +/-N window. Touches the
+    # iterator-modifier code path that the perf audit's hash-key changes
+    # (BackendKey struct) sit on top of.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 1)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+    on.exit(try(gvtrack.rm("v_avg"), silent = TRUE), add = TRUE)
+
+    gvtrack.create("v_avg", fix$dense_tracks[1], func = "avg")
+    gvtrack.iterator("v_avg", sshift = -250, eshift = 250)
+
+    measured <- time_op(gextract("v_avg", fix$small_chr1, iterator = 50))
+    expect_perf_baseline(measured, "vtrack avg+window", baseline_ms = 18)
+})
+
+test_that("gextract vtrack with LSE sliding window stays fast", {
+    # LSE is the function Tamar uses for motif scoring. Worth its own test
+    # because the LSE state machine in GenomeTrackFixedBin maintains a sliding
+    # log-sum-exp across bins and is touched by several perf-audit changes.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 1)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+    on.exit(try(gvtrack.rm("v_lse"), silent = TRUE), add = TRUE)
+
+    gvtrack.create("v_lse", fix$dense_tracks[1], func = "lse")
+    gvtrack.iterator("v_lse", sshift = -100, eshift = 100)
+
+    measured <- time_op(gextract("v_lse", fix$small_chr1, iterator = 50))
+    expect_perf_baseline(measured, "vtrack lse+window", baseline_ms = 18)
+})
+
+test_that("gscreen on many dense tracks stays fast", {
+    # gscreen is the second hottest entry point after gextract for Tamar's
+    # workloads. Same setup-cost characteristic as gextract — the validation
+    # loops go through the same per-track path.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 30)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+
+    expr <- paste(fix$dense_tracks, collapse = " > 0 & ")
+    expr <- paste(expr, "> 0")
+
+    measured <- time_op(gscreen(expr, intervals = fix$small_chr1, iterator = 50))
+    expect_perf_baseline(measured, "gscreen many-dense", baseline_ms = 109)
+})
+
+test_that("gsummary on dense full chr1 stays fast", {
+    # Reduction path — single-function fast-path territory in
+    # GenomeTrackFixedBin. The audit added a "mode 3" single-function fast
+    # path; this test would catch a regression there.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 1)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+
+    measured <- time_op(gsummary(fix$dense_tracks[1], intervals = fix$full_chr1))
+    expect_perf_baseline(measured, "gsummary dense full-chr", baseline_ms = 268)
+})
+
+test_that("gquantiles on dense full chr1 stays fast", {
+    # Streaming-percentile path (StreamPercentiler) — the audit templated its
+    # comparator for inlining. Different code path than the reducer/agg paths.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 1)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+
+    measured <- time_op(gquantiles(fix$dense_tracks[1], percentiles = c(0.1, 0.5, 0.9), intervals = fix$full_chr1))
+    expect_perf_baseline(measured, "gquantiles dense full-chr", baseline_ms = 429)
+})
+
+test_that("2D gextract on rect track full chr1xchr1 stays fast", {
+    # 2D path is independent of the 1D hot paths above. The perf audit
+    # touched StatQuadTree (uint8_t instead of bool) — that would show up here.
+    skip_unless_perf()
+    rect_tracks <- gtrack.ls("test\\.rects$")
+    if (length(rect_tracks) == 0) skip("no rects track in test_db")
+
+    iv2d <- gintervals.2d("chr1", 0, 1e7, "chr1", 0, 1e7)
+
+    measured <- time_op(gextract(rect_tracks[1], intervals = iv2d, iterator = c(1e5, 1e5)))
+    expect_perf_baseline(measured, "2D rect extract", baseline_ms = 21)
 })


### PR DESCRIPTION
## Summary

Adds a small framework (`tests/testthat/helper-perf.R`) and 8 new perf tests on top of the existing many-track-setup regression test, covering the operations that the C++ optimization audit (commit 1cbfa801, v5.6.11) plausibly affects.

### Framework

* `time_op()` — warmup + median-of-N elapsed timing
* `expect_perf_baseline(measured, label, baseline_ms)` asserts `measured < baseline_ms * 3`
* Pick `baseline_ms` as the **fastest** observed wall-clock for the operation across versions you care about. The 3× factor keeps noisy NFS hardware from false-firing while still catching genuine >3× slowdowns.

### Tests added

| Operation | Baseline (ms) | Code path it guards |
|---|---|---|
| many-dense setup | 112 | the v5.6.11–v5.6.16 regression — many tracks per call |
| gscreen many-dense | 109 | same setup-cost path as above |
| dense full-chr scan | 2005 | bin-scan inner loop in `GenomeTrackFixedBin::read_interval` |
| sparse full-chr | 20 | separate `GenomeTrackSparse` code path |
| vtrack avg+window | 18 | iterator-modifier / `BackendKey` path |
| vtrack lse+window | 18 | LSE state machine — Tamar's actual pattern |
| gsummary dense full-chr | 268 | single-function fast-path (audit's "mode 3") |
| gquantiles dense full-chr | 429 | `StreamPercentiler` path |
| 2D rect extract | 21 | `StatQuadTree` path |

Each baseline was measured as the **better of master tip (post-v5.6.17) and v5.6.7 (pre-perf-audit) on the same hardware**; in all 9 operations master matches or beats pre-audit, so the embedded number is the master median. The single `baseline_ms` is the threshold — no need to track historical and current numbers separately, the rule is just "fastest known".

Verified stable across 3 consecutive full runs.

### Opt-in

Same model as the existing test:

```
MISHA_PERF_TESTS=true R -e "devtools::test(filter='perf-regression')"
```

Skipped under the normal parallel `devtools::test()` because wall-clock under load is too noisy to be meaningful.

### Why this exists

We got bitten twice by perf regressions that correctness tests didn't catch (MAP_POPULATE eager paging, validation-loop `init_read` mmap thrash). And once by an audit "finding" that turned out to be a **false positive** — the suspect path wasn't even hit on the workload it claimed to slow down. The framework's docstring spells out the new rule: add a perf test only when both **(a)** it actually exercises the path and **(b)** you have measured a baseline on this hardware to anchor the threshold.

## Test plan

- [x] All 9 tests pass on master (3 consecutive runs)
- [x] Confirmed each test exercises the path it claims to (no false-positive style gaps)
- [x] Each baseline is the fastest observed across master tip and v5.6.7
- [x] No changes to the default test suite — opt-in only
- [ ] CI green