### PR TITLE
fix: release per-track FILE* to avoid EMFILE on many-track gextract

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # misha 5.6.17
 
+* Fixed `gextract` over thousands of tracks failing with "Too many open files" (EMFILE). `GenomeTrackSparse` and `GenomeTrackFixedBin` (dense) were holding one open `FILE*` per track for the lifetime of the call, so workloads over hundreds–thousands of motif tracks blew past the default 1024 soft `RLIMIT_NOFILE`. The `BufferedFile` handle is now released once it is no longer needed (sparse: after data is loaded into memory; dense: after `mmap` is set up — reads go through the mapped region). Subsequent chromosome transitions reopen via the same paths. Negligible perf cost.
 * Fixed dense-track `gextract` regression introduced in v5.6.11 where calls over many tracks (e.g. ~50 motif tracks) became 10–20× slower. Two compounding causes:
   - `MmapFile` used `MAP_POPULATE`, eagerly paging in every mapped track at every chromosome transition (already covered by `MADV_SEQUENTIAL`).
   - The two track-validation loops in `create_expr_iterator` and `TrackExpressionVars::init` were calling `GenomeTrackFixedBin::init_read()` once per chromosome per track, paying open + mmap + madvise + close + munmap each time, even though they only needed the bin size and file size. Replaced with a metadata-only path that stat()s for size and reads bin_size only once per track. Net effect on Tamar's 51-motif workload: 22s → 0.4s.

--- a/src/GenomeTrackFixedBin.cpp
+++ b/src/GenomeTrackFixedBin.cpp
@@ -1235,6 +1235,16 @@ void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int 
 			m_mmap_path.clear();
 		}
 	}
+
+	// When the mmap path is active, m_bfile is dead weight — read_next_bin
+	// and read_bins_bulk both branch through m_mmap_data instead. Close it
+	// so per-track FILE*s do not pile up across thousands of motif tracks
+	// and overflow RLIMIT_NOFILE. Header re-reads on chrom transitions
+	// just reopen via the smart-handle / per-chrom path above.
+	if (m_mmap_data) {
+		m_bfile.close();
+		m_dat_open = false;
+	}
 }
 
 void GenomeTrackFixedBin::init_write(const char *filename, unsigned bin_size, int chromid)

--- a/src/GenomeTrackSparse.cpp
+++ b/src/GenomeTrackSparse.cpp
@@ -228,6 +228,13 @@ void GenomeTrackSparse::read_file_into_mem()
 
 	m_icur_interval = m_intervals.begin();
 	m_loaded = true;
+
+	// All chrom data is now in m_intervals/m_vals; the file handle is no
+	// longer needed. Close it so per-track FILE*s do not pile up across N
+	// motif tracks and overflow RLIMIT_NOFILE. The next chromosome
+	// transition reopens via the smart-handle path in init_read.
+	m_bfile.close();
+	m_dat_open = false;
 }
 
 void GenomeTrackSparse::read_interval(const GInterval &interval)


### PR DESCRIPTION
## Summary

- **Root cause.** `GenomeTrack::m_bfile` (`BufferedFile`) was held open per track instance for the lifetime of a `gextract` call. With thousands of motif tracks (Tamar's case: 3,110 dense per-chrom tracks) the open-FD count overflows the default `RLIMIT_NOFILE` soft limit (1024 on most Linux distros) and `fopen` fails with `EMFILE` → `Error: Too many open files`.
- **Fix.** Release the `BufferedFile` as soon as it is no longer needed:
  - `GenomeTrackSparse::read_file_into_mem()` — close after the chrom data is fully copied into `m_intervals`/`m_vals`.
  - `GenomeTrackFixedBin::init_read()` — close when the `mmap` path is active (the case for any successful read of a non-empty dense track). `read_next_bin` / `read_bins_bulk` both branch through the mapped region in that case, so `m_bfile` is dead weight.
- **CRAN-clean.** No `.onLoad` rlimit raise, no process-wide side effects. Subsequent chrom transitions just reopen via the existing per-chrom / smart-handle paths.

## Verification

- Stress test under `prlimit --nofile=256` over 200 sparse tracks: open-FD count stayed at 11 throughout the `gextract` call (would have been 200+ before the fix). Two consecutive `gextract` calls also stayed at 11 — no leak.
- Full test suite: `[ FAIL 0 | WARN 9 | SKIP 24 | PASS 18061 ]`.
- Opt-in perf regression suite (`MISHA_PERF_TESTS=true`): all 9 baselines pass — including the many-dense-setup, dense full-chr scan, and sparse full-chr tests. Negligible elapsed-time impact.

## Test plan

- [x] Existing test suite passes (parallel)
- [x] Perf regression baselines unchanged
- [x] Manual FD-stress test: 200-track gextract under `prlimit --nofile=256`, FD count remains at baseline
- [ ] CI macOS + Linux conda build green