### PR TITLE
gsynth.score: per-bp Markov log-likelihood track

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.20
+Version: 5.6.21
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# misha 5.6.21
+
+* Added `prior` argument to `gsynth.train()` (default `"marginal"`). Per-bin Dirichlet priors are now learned from the trainer's own counts by default, so unobserved (cell, k-mer-context) entries fall back to the cell's empirical base composition instead of uniform 1/4. Other modes: `"global"`, `NULL`/`"uniform"`, length-4 numeric, and `n_bins x 4` matrix.
+* CDF formula changed from `(N + alpha) / (sum_a N + 4*alpha)` to `(N + alpha * pi_a(b)) / (sum_a N + alpha)` (pi sums to 1). To reproduce the pre-5.6.21 Laplace-add-one behavior, pass `prior = NULL, pseudocount = 4`.
+* `.gsm` metadata gains optional `prior`/`prior_mode` fields; older files load with `prior = uniform` (their on-disk CDF is the truth).
+
 # misha 5.6.20
 
 * Fixed `gquantiles` hanging for many minutes on dense `binsize=1` whole-genome scans. The parent used to merge every non-NaN value into one `std::vector<double>` and single-thread `std::sort` it (~21 GB on mm10). Kids now sort their samples buffer before packing, and the parent does a heap-based k-way merge over the per-kid sorted runs. The single-process path (`gmultitasking = FALSE`) uses `std::nth_element` per percentile rank instead of a full sort. mm10 dense full-genome `gquantiles`: was hung, now ~75 s (multitask) / ~270 s (single-process). Sub-sampling fallback (when `gmax.data.size` forces it) preserved, with `samples` capacity pre-reserved.

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 
 # misha 5.6.18
 
+* Added `gsynth.score()`: writes a misha fixed-bin dense track of summed natural-log conditional probability under a trained stratified Markov-k model. Stratum bin is queried at `pos - k` (the leftmost base of the (k+1)-mer context), matching `gsynth.train()`'s convention; the chrom-parallel kernel writes one file per chromosome (gated by `gmultitasking` / `gmax.processes`). Two scored tracks subtracted at any resolution gives a windowed log-Bayes-factor.
+* Added `mask` argument to `gsynth.score()`: positions inside `mask` (e.g. repeats) are NA-poisoned in the output bin. Predicted-base `N` is unconditional NA — `n_policy` only applies to N's in the k-mer context.
+* `gsynth.sample()` now looks up the stratum bin at `pos - k` to match `gsynth.train()`. Previously it queried the bin at the predicted-base position, which differed from training at the first `k` bp of every iter window. Cached `.gsm` models are unchanged; samples generated with earlier versions had a slight stratum-shift artifact at iter boundaries.
 * Added `getOption("gmultitasking.strategy")` for `gextract` (default `"auto"`). When the workload is large and many-track, `auto` routes to a track-parallel mode (each `parallel::mclapply` worker handles a track subset across all tiles) instead of the legacy tile-parallel mode (each fork-kid handles a tile range across all tracks). On the realistic 3,110 motif tracks × 2.19M tiled_peaks workload measured 57.6 min vs ~3.4 h projected for tile-parallel — a 3.5× per-track speedup. Override per-call via `options(gmultitasking.strategy = "tracks" | "tiles" | "auto")`. The heuristic stays on `"tiles"` for streaming iterators (numeric / NULL / 2D rect / track-name), single-track or fewer than 8 tracks, file/intervals.set.out output, or 2D band — so nothing else regresses (validated by a 36-cell matrix bench across iterator types × track counts × cache states).
 
 # misha 5.6.17

--- a/R/synth.R
+++ b/R/synth.R
@@ -818,14 +818,14 @@ gsynth.forbid_kmer <- function(model, pattern, check = TRUE) {
 #'          \item \code{"global"}: a single base composition pooled over
 #'                all bins, broadcast to every bin.
 #'          \item \code{NULL} or \code{"uniform"}: uniform prior
-#'                (1/4 per base) -- the pre-5.7.0 fallback.
+#'                (1/4 per base) -- the pre-5.6.21 fallback.
 #'          \item Length-4 numeric (optionally named A, C, G, T):
 #'                user-supplied global \eqn{\pi}, broadcast.
 #'          \item \code{n_bins x 4} numeric matrix: user-supplied per-bin
 #'                \eqn{\pi}.
 #'        }
 #'        Together with \code{pseudocount}, this defines the Dirichlet
-#'        posterior. To reproduce the pre-5.7.0 Laplace-add-one behavior,
+#'        posterior. To reproduce the pre-5.6.21 Laplace-add-one behavior,
 #'        pass \code{prior = NULL, pseudocount = 4}.
 #'
 #' @details
@@ -1445,7 +1445,7 @@ gsynth.load <- function(file) {
     if (!inherits(model, "gsynth.model")) {
         stop("File does not contain a valid gsynth.model", call. = FALSE)
     }
-    # Backfill prior fields for old RDS models trained before 5.7.0
+    # Backfill prior fields for old RDS models trained before 5.6.21
     if (is.null(model$prior_mode)) model$prior_mode <- "uniform"
     if (is.null(model$prior)) {
         tb <- if (!is.null(model$total_bins)) model$total_bins else model$num_bins

--- a/R/synth.R
+++ b/R/synth.R
@@ -1946,7 +1946,15 @@ gsynth.sample <- function(model,
 #' @param track       Name of the misha track to create.
 #' @param description Optional track description.
 #' @param intervals   Intervals to score. Defaults to
-#'                    \code{gintervals.all()}.
+#'                    \code{gintervals.all()}. Best results when interval
+#'                    starts are aligned to multiples of
+#'                    \code{model$iterator}; otherwise the first stratum
+#'                    window is shorter than \code{model$iterator} and
+#'                    its bin label may differ from training.
+#' @param mask        Optional intervals to NA-out in the output (e.g.
+#'                    repeats). Intersects with \code{intervals} per bp;
+#'                    every output bin containing a masked bp becomes
+#'                    \code{NaN}.
 #' @param resolution  Output bin size in bp. Defaults to
 #'                    \code{model$iterator}. \code{1} produces a per-bp
 #'                    track; any positive integer is allowed.
@@ -1955,10 +1963,11 @@ gsynth.sample <- function(model,
 #'                    \code{"NA"} (default) propagates NA;
 #'                    \code{"uniform"} contributes \code{log(1/4)} per
 #'                    bp.
-#' @param n_policy    How to score positions whose k-mer context or
-#'                    current base contains an N:
-#'                    \code{"NA"} (default) or \code{"uniform"}
-#'                    (\code{log(1/4)} per bp).
+#' @param n_policy    How to score positions whose k-mer \emph{context}
+#'                    contains an N: \code{"NA"} (default) or
+#'                    \code{"uniform"} (\code{log(1/4)} per bp). The
+#'                    predicted base itself is always NA when N — the
+#'                    model has no \eqn{\log P} for non-ACGT bases.
 #' @param overwrite   If \code{TRUE}, replace an existing track of the
 #'                    same name.
 #'
@@ -1972,6 +1981,7 @@ gsynth.score <- function(model,
                          track,
                          description = NULL,
                          intervals = NULL,
+                         mask = NULL,
                          resolution = NULL,
                          sparse_policy = c("NA", "uniform"),
                          n_policy = c("NA", "uniform"),
@@ -2010,8 +2020,23 @@ gsynth.score <- function(model,
     n_dims <- model$n_dims
     dim_sizes <- model$dim_sizes
 
+    # Bin lookup queries pos - k (the leftmost base of the (k+1)-mer
+    # context) to match training. Extend gextract upstream by one
+    # iter_size so the first k bp of every interval get bin info from
+    # the prior iter window — matching what training saw on the same
+    # genome. Clamped to chromosome start.
+    .k <- as.integer(model$k)
+    strata_intervals <- intervals
+    if (is.numeric(.iterator) && length(.iterator) == 1L && .iterator > 0L) {
+        strata_intervals$start <- as.integer(pmax(
+            0L, as.integer(strata_intervals$start) - as.integer(.iterator)
+        ))
+    }
+
     if (n_dims == 0) {
-        iter_info <- gextract("1", intervals = intervals, iterator = .iterator)
+        iter_info <- gextract("1",
+            intervals = strata_intervals, iterator = .iterator
+        )
         if (is.null(iter_info) || nrow(iter_info) == 0) {
             stop("No positions extracted. Check intervals.", call. = FALSE)
         }
@@ -2023,7 +2048,9 @@ gsynth.score <- function(model,
         iter_starts <- as.integer(iter_info$start)
     } else {
         exprs <- sapply(model$dim_specs, function(d) d$expr)
-        track_data <- gextract(exprs, intervals = intervals, iterator = .iterator)
+        track_data <- gextract(exprs,
+            intervals = strata_intervals, iterator = .iterator
+        )
         if (is.null(track_data) || nrow(track_data) == 0) {
             stop("No track data extracted. Check intervals.", call. = FALSE)
         }
@@ -2105,6 +2132,7 @@ gsynth.score <- function(model,
                     as.integer(.iterator),
                     n_policy_int,
                     sparse_policy_int,
+                    mask,
                     .misha_env()
                 )
             } else {
@@ -2130,6 +2158,7 @@ gsynth.score <- function(model,
                                 as.integer(.iterator),
                                 n_policy_int,
                                 sparse_policy_int,
+                                mask,
                                 .misha_env()
                             )
                             list(ok = TRUE)

--- a/R/synth.R
+++ b/R/synth.R
@@ -1430,6 +1430,12 @@ gsynth.load <- function(file) {
     if (!inherits(model, "gsynth.model")) {
         stop("File does not contain a valid gsynth.model", call. = FALSE)
     }
+    # Backfill prior fields for old RDS models trained before 5.7.0
+    if (is.null(model$prior_mode)) model$prior_mode <- "uniform"
+    if (is.null(model$prior)) {
+        tb <- if (!is.null(model$total_bins)) model$total_bins else model$num_bins
+        model$prior <- matrix(0.25, nrow = tb, ncol = 4L)
+    }
     model
 }
 

--- a/R/synth.R
+++ b/R/synth.R
@@ -1231,6 +1231,21 @@ print.gsynth.model <- function(x, ...) {
     cat(sprintf("Masked positions: %s\n", format(x$total_masked, big.mark = ",")))
     cat(sprintf("N positions: %s\n", format(x$total_n, big.mark = ",")))
 
+    if (!is.null(x$prior_mode)) {
+        cat(sprintf("Prior: %s", x$prior_mode))
+        if (!is.null(x$prior) && x$prior_mode != "uniform") {
+            avg_pi <- colMeans(x$prior)
+            cat(sprintf(
+                "  (mean pi: A=%.3f C=%.3f G=%.3f T=%.3f)",
+                avg_pi[1], avg_pi[2], avg_pi[3], avg_pi[4]
+            ))
+        }
+        cat("\n")
+    }
+    if (!is.null(x$pseudocount)) {
+        cat(sprintf("Pseudocount: %g\n", x$pseudocount))
+    }
+
     # Show per-bin k-mer counts (abbreviated for multi-dimensional)
     if (x$total_bins <= 20) {
         cat("\nPer-bin k-mer counts:\n")

--- a/R/synth.R
+++ b/R/synth.R
@@ -1320,6 +1320,12 @@ gsynth.save <- function(model, file, compress = FALSE) {
         dim_sizes = if (n_dims > 0) as.integer(model$dim_sizes) else list(),
         total_bins = as.integer(total_bins),
         pseudocount = if (!is.null(model$pseudocount)) as.numeric(model$pseudocount) else 1.0,
+        prior_mode = if (!is.null(model$prior_mode)) as.character(model$prior_mode) else "uniform",
+        prior = if (!is.null(model$prior)) {
+            apply(model$prior, 1, function(row) as.numeric(row), simplify = FALSE)
+        } else {
+            NULL
+        },
         min_obs = as.integer(if (!is.null(model$min_obs)) model$min_obs else 0L),
         total_kmers = as.numeric(model$total_kmers),
         total_masked = as.numeric(model$total_masked),
@@ -1562,6 +1568,22 @@ gsynth.convert <- function(input_file, output_file, compress = FALSE) {
 
     # Build the model object
     pseudocount <- if (!is.null(metadata$pseudocount)) as.numeric(metadata$pseudocount) else 1.0
+
+    # Reconstruct prior; defaults to uniform 1/4 for old .gsm files without it.
+    prior_mode <- if (!is.null(metadata$prior_mode)) as.character(metadata$prior_mode) else "uniform"
+    if (!is.null(metadata$prior)) {
+        prior_rows <- lapply(metadata$prior, function(row) as.numeric(unlist(row)))
+        prior_mat <- do.call(rbind, prior_rows)
+        if (nrow(prior_mat) != total_bins || ncol(prior_mat) != 4L) {
+            stop(sprintf(
+                "Invalid prior in .gsm: got %d x %d, expected %d x 4",
+                nrow(prior_mat), ncol(prior_mat), total_bins
+            ), call. = FALSE)
+        }
+    } else {
+        prior_mat <- matrix(0.25, nrow = total_bins, ncol = 4L)
+    }
+
     model <- list(
         k = k,
         num_kmers = num_kmers,
@@ -1577,6 +1599,8 @@ gsynth.convert <- function(input_file, output_file, compress = FALSE) {
         dim_sizes = dim_sizes,
         total_bins = total_bins,
         pseudocount = pseudocount,
+        prior_mode = prior_mode,
+        prior = prior_mat,
         iterator = NULL,
         min_obs = min_obs,
         sparse_bins = sparse_bins

--- a/R/synth.R
+++ b/R/synth.R
@@ -2055,9 +2055,9 @@ gsynth.score <- function(model,
     n_policy_int <- if (n_policy == "uniform") 1L else 0L
     sparse_policy_int <- if (sparse_policy == "uniform") 1L else 0L
 
-    # Track-creation flow mirrors gtrack.create_dense: kernel calls
-    # create_track_dir(envir, name) internally; on success, R registers
-    # the track in the misha db and sets attrs.
+    # ---- Track-creation flow: parent creates the dir once (idempotent
+    # across forked workers in parallel mode), kernel writes per-chrom
+    # files into it, parent registers the track on success.
     if (gtrack.exists(track)) {
         if (!overwrite) {
             stop(sprintf(
@@ -2068,24 +2068,96 @@ gsynth.score <- function(model,
         gtrack.rm(track, force = TRUE)
     }
 
+    track_path <- .track_dir(track)
+    if (!dir.exists(track_path)) {
+        dir.create(track_path, recursive = TRUE, mode = "0777")
+    }
+
+    # ---- Decide serial vs parallel chrom dispatch.
+    # Mirrors misha's general convention: gmultitasking + gmax.processes.
+    # Each chrom is independent (own state, own output file), so chrom-
+    # parallelism scales near-linearly until n_workers ~ #chroms.
+    all_chromids <- seq_along(chrom_key) - 1L # 0-based
+    use_mt <- isTRUE(.ggetOption("gmultitasking", TRUE)) &&
+        length(all_chromids) > 1L
+    n_workers <- if (use_mt) {
+        as.integer(min(.ggetOption("gmax.processes", 1L), length(all_chromids)))
+    } else {
+        1L
+    }
+
     success <- FALSE
     tryCatch(
         {
-            .gcall(
-                "C_gsynth_score",
-                log_p_list,
-                flat_indices,
-                iter_starts,
-                iter_chroms,
-                intervals,
-                track,
-                as.integer(resolution),
-                as.integer(model$k),
-                as.integer(.iterator),
-                n_policy_int,
-                sparse_policy_int,
-                .misha_env()
-            )
+            if (n_workers <= 1L) {
+                # Serial path — single .gcall covering all chroms.
+                .gcall(
+                    "C_gsynth_score",
+                    log_p_list,
+                    flat_indices,
+                    iter_starts,
+                    iter_chroms,
+                    intervals,
+                    track,
+                    all_chromids,
+                    as.integer(resolution),
+                    as.integer(model$k),
+                    as.integer(.iterator),
+                    n_policy_int,
+                    sparse_policy_int,
+                    .misha_env()
+                )
+            } else {
+                # Parallel path — split chroms across workers, each worker
+                # writes its assigned chrom files into the shared track dir.
+                # Round-robin split keeps the largest chroms spread across
+                # workers (chromkey is roughly size-sorted).
+                groups <- split(all_chromids, seq_along(all_chromids) %% n_workers)
+                results <- parallel::mclapply(groups, function(cids) {
+                    tryCatch(
+                        {
+                            .gcall(
+                                "C_gsynth_score",
+                                log_p_list,
+                                flat_indices,
+                                iter_starts,
+                                iter_chroms,
+                                intervals,
+                                track,
+                                as.integer(cids),
+                                as.integer(resolution),
+                                as.integer(model$k),
+                                as.integer(.iterator),
+                                n_policy_int,
+                                sparse_policy_int,
+                                .misha_env()
+                            )
+                            list(ok = TRUE)
+                        },
+                        error = function(e) list(ok = FALSE, msg = conditionMessage(e))
+                    )
+                }, mc.cores = n_workers, mc.preschedule = FALSE)
+
+                fails <- vapply(results, function(r) {
+                    if (inherits(r, "try-error")) {
+                        return(TRUE)
+                    }
+                    if (is.null(r) || !isTRUE(r$ok)) {
+                        return(TRUE)
+                    }
+                    FALSE
+                }, logical(1))
+                if (any(fails)) {
+                    msgs <- vapply(results[fails], function(r) {
+                        if (is.list(r) && !is.null(r$msg)) r$msg else "<unknown>"
+                    }, character(1))
+                    stop(sprintf(
+                        "gsynth.score parallel kernel failed in %d/%d worker(s): %s",
+                        sum(fails), length(results),
+                        paste(unique(msgs), collapse = "; ")
+                    ), call. = FALSE)
+                }
+            }
 
             .gdb.add_track(track)
 

--- a/R/synth.R
+++ b/R/synth.R
@@ -715,6 +715,67 @@ gsynth.forbid_kmer <- function(model, pattern, check = TRUE) {
     out
 }
 
+# Internal: validate the `prior` argument and split into (mode, matrix) for the C kernel.
+# Returns a list(mode = <"uniform"|"marginal"|"global"|"explicit">, matrix = NULL or n_bins x 4 numeric).
+.gsynth_resolve_prior_arg <- function(prior, total_bins) {
+    if (is.null(prior)) {
+        return(list(mode = "uniform", matrix = NULL))
+    }
+    if (is.character(prior) && length(prior) == 1L) {
+        if (prior == "marginal") {
+            return(list(mode = "marginal", matrix = NULL))
+        }
+        if (prior == "global") {
+            return(list(mode = "global", matrix = NULL))
+        }
+        if (prior == "uniform") {
+            return(list(mode = "uniform", matrix = NULL))
+        }
+        stop(sprintf(
+            "Unknown prior '%s'. Use NULL, 'uniform', 'marginal', 'global', a length-4 numeric, or an n_bins x 4 matrix.",
+            prior
+        ), call. = FALSE)
+    }
+    if (is.numeric(prior) && is.null(dim(prior)) && length(prior) == 4L) {
+        if (!is.null(names(prior))) {
+            ord <- match(c("A", "C", "G", "T"), toupper(names(prior)))
+            if (anyNA(ord)) {
+                stop("Named numeric prior must have names A, C, G, T", call. = FALSE)
+            }
+            prior <- prior[ord]
+        }
+        if (anyNA(prior) || any(prior < 0)) {
+            stop("prior must be non-negative and finite", call. = FALSE)
+        }
+        s <- sum(prior)
+        if (s <= 0) stop("prior must sum to > 0", call. = FALSE)
+        prior <- prior / s
+        mat <- matrix(as.numeric(prior), nrow = total_bins, ncol = 4L, byrow = TRUE)
+        return(list(mode = "explicit", matrix = mat))
+    }
+    if (is.numeric(prior) && length(dim(prior)) == 2L) {
+        if (nrow(prior) != total_bins || ncol(prior) != 4L) {
+            stop(sprintf(
+                "prior matrix must be %d x 4 (got %d x %d)",
+                total_bins, nrow(prior), ncol(prior)
+            ), call. = FALSE)
+        }
+        if (anyNA(prior) || any(prior < 0)) {
+            stop("prior matrix must be non-negative and contain no NAs", call. = FALSE)
+        }
+        rs <- rowSums(prior)
+        if (any(rs <= 0)) {
+            stop("Every row of prior matrix must sum to > 0", call. = FALSE)
+        }
+        prior <- prior / rs
+        return(list(mode = "explicit", matrix = prior))
+    }
+    stop(
+        "prior must be NULL, 'uniform'/'marginal'/'global', a length-4 numeric (optionally named A/C/G/T), or an n_bins x 4 matrix.",
+        call. = FALSE
+    )
+}
+
 #' Train a stratified Markov model from genome sequences
 #'
 #' Computes a Markov model of order \code{k} (default 5) optionally stratified by
@@ -831,67 +892,6 @@ gsynth.forbid_kmer <- function(model, pattern, check = TRUE) {
 #'     iterator = 200
 #' )
 #'
-# Internal: validate the `prior` argument and split into (mode, matrix) for the C kernel.
-# Returns a list(mode = <"uniform"|"marginal"|"global"|"explicit">, matrix = NULL or n_bins x 4 numeric).
-.gsynth_resolve_prior_arg <- function(prior, total_bins) {
-    if (is.null(prior)) {
-        return(list(mode = "uniform", matrix = NULL))
-    }
-    if (is.character(prior) && length(prior) == 1L) {
-        if (prior == "marginal") {
-            return(list(mode = "marginal", matrix = NULL))
-        }
-        if (prior == "global") {
-            return(list(mode = "global", matrix = NULL))
-        }
-        if (prior == "uniform") {
-            return(list(mode = "uniform", matrix = NULL))
-        }
-        stop(sprintf(
-            "Unknown prior '%s'. Use NULL, 'uniform', 'marginal', 'global', a length-4 numeric, or an n_bins x 4 matrix.",
-            prior
-        ), call. = FALSE)
-    }
-    if (is.numeric(prior) && is.null(dim(prior)) && length(prior) == 4L) {
-        if (!is.null(names(prior))) {
-            ord <- match(c("A", "C", "G", "T"), toupper(names(prior)))
-            if (anyNA(ord)) {
-                stop("Named numeric prior must have names A, C, G, T", call. = FALSE)
-            }
-            prior <- prior[ord]
-        }
-        if (anyNA(prior) || any(prior < 0)) {
-            stop("prior must be non-negative and finite", call. = FALSE)
-        }
-        s <- sum(prior)
-        if (s <= 0) stop("prior must sum to > 0", call. = FALSE)
-        prior <- prior / s
-        mat <- matrix(as.numeric(prior), nrow = total_bins, ncol = 4L, byrow = TRUE)
-        return(list(mode = "explicit", matrix = mat))
-    }
-    if (is.numeric(prior) && length(dim(prior)) == 2L) {
-        if (nrow(prior) != total_bins || ncol(prior) != 4L) {
-            stop(sprintf(
-                "prior matrix must be %d x 4 (got %d x %d)",
-                total_bins, nrow(prior), ncol(prior)
-            ), call. = FALSE)
-        }
-        if (anyNA(prior) || any(prior < 0)) {
-            stop("prior matrix must be non-negative and contain no NAs", call. = FALSE)
-        }
-        rs <- rowSums(prior)
-        if (any(rs <= 0)) {
-            stop("Every row of prior matrix must sum to > 0", call. = FALSE)
-        }
-        prior <- prior / rs
-        return(list(mode = "explicit", matrix = prior))
-    }
-    stop(
-        "prior must be NULL, 'uniform'/'marginal'/'global', a length-4 numeric (optionally named A/C/G/T), or an n_bins x 4 matrix.",
-        call. = FALSE
-    )
-}
-
 #' @seealso \code{\link{gsynth.sample}}, \code{\link{gsynth.save}},
 #'          \code{\link{gsynth.load}}, \code{\link{gsynth.bin_map}}
 #' @export

--- a/R/synth.R
+++ b/R/synth.R
@@ -737,8 +737,9 @@ gsynth.forbid_kmer <- function(model, pattern, check = TRUE) {
 #' @param intervals Genomic intervals to process. If NULL, uses all chromosomes.
 #' @param iterator Iterator for track evaluation, determines the resolution at which
 #'        track values are computed.
-#' @param pseudocount Pseudocount added to all k-mer counts to avoid zero probabilities.
-#'        Default is 1.
+#' @param pseudocount Total Dirichlet concentration alpha used in the
+#'        smoothed posterior \code{P(a|c,b) = (N + alpha * pi_a(b)) /
+#'        (sum_a N + alpha)}. Default is 1.
 #' @param min_obs Minimum number of observations ((k+1)-mers) required per bin. Bins
 #'        with fewer observations will be marked as NA (not learned) and a warning will
 #'        be issued. Default is 0 (no minimum). During sampling, NA bins will fall back
@@ -747,6 +748,24 @@ gsynth.forbid_kmer <- function(model, pattern, check = TRUE) {
 #'        (context of length 5 plus the emitted base) transition probabilities.
 #'        Higher values capture longer-range sequence dependencies but require
 #'        exponentially more memory (\eqn{4^k} context states).
+#' @param prior Per-base Dirichlet prior \eqn{\pi_a(b)}. One of:
+#'        \itemize{
+#'          \item \code{"marginal"} (default): per-bin empirical base
+#'                composition learned from the trainer's own counts
+#'                (post bin-merge). Bins with zero observations fall back to
+#'                uniform with a warning.
+#'          \item \code{"global"}: a single base composition pooled over
+#'                all bins, broadcast to every bin.
+#'          \item \code{NULL} or \code{"uniform"}: uniform prior
+#'                (1/4 per base) -- the pre-5.7.0 fallback.
+#'          \item Length-4 numeric (optionally named A, C, G, T):
+#'                user-supplied global \eqn{\pi}, broadcast.
+#'          \item \code{n_bins x 4} numeric matrix: user-supplied per-bin
+#'                \eqn{\pi}.
+#'        }
+#'        Together with \code{pseudocount}, this defines the Dirichlet
+#'        posterior. To reproduce the pre-5.7.0 Laplace-add-one behavior,
+#'        pass \code{prior = NULL, pseudocount = 4}.
 #'
 #' @details
 #' \strong{Strand symmetry:} The training process counts both the forward strand
@@ -812,6 +831,67 @@ gsynth.forbid_kmer <- function(model, pattern, check = TRUE) {
 #'     iterator = 200
 #' )
 #'
+# Internal: validate the `prior` argument and split into (mode, matrix) for the C kernel.
+# Returns a list(mode = <"uniform"|"marginal"|"global"|"explicit">, matrix = NULL or n_bins x 4 numeric).
+.gsynth_resolve_prior_arg <- function(prior, total_bins) {
+    if (is.null(prior)) {
+        return(list(mode = "uniform", matrix = NULL))
+    }
+    if (is.character(prior) && length(prior) == 1L) {
+        if (prior == "marginal") {
+            return(list(mode = "marginal", matrix = NULL))
+        }
+        if (prior == "global") {
+            return(list(mode = "global", matrix = NULL))
+        }
+        if (prior == "uniform") {
+            return(list(mode = "uniform", matrix = NULL))
+        }
+        stop(sprintf(
+            "Unknown prior '%s'. Use NULL, 'uniform', 'marginal', 'global', a length-4 numeric, or an n_bins x 4 matrix.",
+            prior
+        ), call. = FALSE)
+    }
+    if (is.numeric(prior) && is.null(dim(prior)) && length(prior) == 4L) {
+        if (!is.null(names(prior))) {
+            ord <- match(c("A", "C", "G", "T"), toupper(names(prior)))
+            if (anyNA(ord)) {
+                stop("Named numeric prior must have names A, C, G, T", call. = FALSE)
+            }
+            prior <- prior[ord]
+        }
+        if (anyNA(prior) || any(prior < 0)) {
+            stop("prior must be non-negative and finite", call. = FALSE)
+        }
+        s <- sum(prior)
+        if (s <= 0) stop("prior must sum to > 0", call. = FALSE)
+        prior <- prior / s
+        mat <- matrix(as.numeric(prior), nrow = total_bins, ncol = 4L, byrow = TRUE)
+        return(list(mode = "explicit", matrix = mat))
+    }
+    if (is.numeric(prior) && length(dim(prior)) == 2L) {
+        if (nrow(prior) != total_bins || ncol(prior) != 4L) {
+            stop(sprintf(
+                "prior matrix must be %d x 4 (got %d x %d)",
+                total_bins, nrow(prior), ncol(prior)
+            ), call. = FALSE)
+        }
+        if (anyNA(prior) || any(prior < 0)) {
+            stop("prior matrix must be non-negative and contain no NAs", call. = FALSE)
+        }
+        rs <- rowSums(prior)
+        if (any(rs <= 0)) {
+            stop("Every row of prior matrix must sum to > 0", call. = FALSE)
+        }
+        prior <- prior / rs
+        return(list(mode = "explicit", matrix = prior))
+    }
+    stop(
+        "prior must be NULL, 'uniform'/'marginal'/'global', a length-4 numeric (optionally named A/C/G/T), or an n_bins x 4 matrix.",
+        call. = FALSE
+    )
+}
+
 #' @seealso \code{\link{gsynth.sample}}, \code{\link{gsynth.save}},
 #'          \code{\link{gsynth.load}}, \code{\link{gsynth.bin_map}}
 #' @export
@@ -821,7 +901,8 @@ gsynth.train <- function(...,
                          iterator = NULL,
                          pseudocount = 1,
                          min_obs = 0,
-                         k = 5L) {
+                         k = 5L,
+                         prior = "marginal") {
     .gcheckroot()
 
     # Validate k (Markov order)
@@ -993,6 +1074,9 @@ gsynth.train <- function(...,
     # We've already applied bin_map in R, so just pass identity mapping
     bin_map_vec <- seq_len(total_bins) - 1L # 0-based identity
 
+    # Resolve prior into (mode, matrix) for the C kernel
+    prior_resolved <- .gsynth_resolve_prior_arg(prior, total_bins)
+
     message("Training Markov model...")
 
     # Call C++ training function
@@ -1014,6 +1098,8 @@ gsynth.train <- function(...,
         mask,
         as.numeric(pseudocount),
         as.integer(k),
+        as.character(prior_resolved$mode),
+        prior_resolved$matrix,
         .misha_env()
     )
 
@@ -1029,6 +1115,17 @@ gsynth.train <- function(...,
 
     # Store all breaks for reference
     result$breaks <- NULL # Remove single breaks
+
+    # Store prior on the model (resolved matrix arrives as result$prior from C++)
+    result$prior_mode <- prior_resolved$mode
+    result$pseudocount <- as.numeric(pseudocount)
+    if (!is.null(result$marginal_fallbacks) &&
+        result$marginal_fallbacks > 0L) {
+        warning(sprintf(
+            "%d bin(s) had zero observations; their prior fell back to uniform 1/4.",
+            result$marginal_fallbacks
+        ), call. = FALSE)
+    }
 
     # Check for sparse bins (fewer than min_obs observations)
     result$min_obs <- min_obs

--- a/man/gsynth.score.Rd
+++ b/man/gsynth.score.Rd
@@ -9,6 +9,7 @@ gsynth.score(
   track,
   description = NULL,
   intervals = NULL,
+  mask = NULL,
   resolution = NULL,
   sparse_policy = c("NA", "uniform"),
   n_policy = c("NA", "uniform"),
@@ -24,7 +25,16 @@ gsynth.score(
 \item{description}{Optional track description.}
 
 \item{intervals}{Intervals to score. Defaults to
-\code{gintervals.all()}.}
+\code{gintervals.all()}. Best results when interval
+starts are aligned to multiples of
+\code{model$iterator}; otherwise the first stratum
+window is shorter than \code{model$iterator} and
+its bin label may differ from training.}
+
+\item{mask}{Optional intervals to NA-out in the output (e.g.
+repeats). Intersects with \code{intervals} per bp;
+every output bin containing a masked bp becomes
+\code{NaN}.}
 
 \item{resolution}{Output bin size in bp. Defaults to
 \code{model$iterator}. \code{1} produces a per-bp
@@ -36,10 +46,11 @@ sparse in the model:
 \code{"uniform"} contributes \code{log(1/4)} per
 bp.}
 
-\item{n_policy}{How to score positions whose k-mer context or
-current base contains an N:
-\code{"NA"} (default) or \code{"uniform"}
-(\code{log(1/4)} per bp).}
+\item{n_policy}{How to score positions whose k-mer \emph{context}
+contains an N: \code{"NA"} (default) or
+\code{"uniform"} (\code{log(1/4)} per bp). The
+predicted base itself is always NA when N — the
+model has no \eqn{\log P} for non-ACGT bases.}
 
 \item{overwrite}{If \code{TRUE}, replace an existing track of the
 same name.}

--- a/man/gsynth.train.Rd
+++ b/man/gsynth.train.Rd
@@ -11,7 +11,8 @@ gsynth.train(
   iterator = NULL,
   pseudocount = 1,
   min_obs = 0,
-  k = 5L
+  k = 5L,
+  prior = "marginal"
 )
 }
 \arguments{
@@ -33,8 +34,9 @@ will not contribute to k-mer counts. Can be computed using \code{gscreen()}.}
 \item{iterator}{Iterator for track evaluation, determines the resolution at which
 track values are computed.}
 
-\item{pseudocount}{Pseudocount added to all k-mer counts to avoid zero probabilities.
-Default is 1.}
+\item{pseudocount}{Total Dirichlet concentration alpha used in the
+smoothed posterior \code{P(a|c,b) = (N + alpha * pi_a(b)) /
+(sum_a N + alpha)}. Default is 1.}
 
 \item{min_obs}{Minimum number of observations ((k+1)-mers) required per bin. Bins
 with fewer observations will be marked as NA (not learned) and a warning will
@@ -45,6 +47,25 @@ to uniform sampling unless merged via \code{bin_merge}.}
 (context of length 5 plus the emitted base) transition probabilities.
 Higher values capture longer-range sequence dependencies but require
 exponentially more memory (\eqn{4^k} context states).}
+
+\item{prior}{Per-base Dirichlet prior \eqn{\pi_a(b)}. One of:
+\itemize{
+  \item \code{"marginal"} (default): per-bin empirical base
+        composition learned from the trainer's own counts
+        (post bin-merge). Bins with zero observations fall back to
+        uniform with a warning.
+  \item \code{"global"}: a single base composition pooled over
+        all bins, broadcast to every bin.
+  \item \code{NULL} or \code{"uniform"}: uniform prior
+        (1/4 per base) -- the pre-5.7.0 fallback.
+  \item Length-4 numeric (optionally named A, C, G, T):
+        user-supplied global \eqn{\pi}, broadcast.
+  \item \code{n_bins x 4} numeric matrix: user-supplied per-bin
+        \eqn{\pi}.
+}
+Together with \code{pseudocount}, this defines the Dirichlet
+posterior. To reproduce the pre-5.7.0 Laplace-add-one behavior,
+pass \code{prior = NULL, pseudocount = 4}.}
 }
 \value{
 A \code{gsynth.model} object containing:

--- a/man/gsynth.train.Rd
+++ b/man/gsynth.train.Rd
@@ -57,14 +57,14 @@ exponentially more memory (\eqn{4^k} context states).}
   \item \code{"global"}: a single base composition pooled over
         all bins, broadcast to every bin.
   \item \code{NULL} or \code{"uniform"}: uniform prior
-        (1/4 per base) -- the pre-5.7.0 fallback.
+        (1/4 per base) -- the pre-5.6.21 fallback.
   \item Length-4 numeric (optionally named A, C, G, T):
         user-supplied global \eqn{\pi}, broadcast.
   \item \code{n_bins x 4} numeric matrix: user-supplied per-bin
         \eqn{\pi}.
 }
 Together with \code{pseudocount}, this defines the Dirichlet
-posterior. To reproduce the pre-5.7.0 Laplace-add-one behavior,
+posterior. To reproduce the pre-5.6.21 Laplace-add-one behavior,
 pass \code{prior = NULL, pseudocount = 4}.}
 }
 \value{

--- a/src/GenomeSynthSample.cpp
+++ b/src/GenomeSynthSample.cpp
@@ -313,11 +313,16 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
 
                 // Generate n_samples samples for this interval
                 for (int sample_idx = 0; sample_idx < n_samples; ++sample_idx) {
-                    // Reset bin cursor for each sample
+                    // Reset bin cursor for each sample. Bin queries use
+                    // pos - k (the leftmost base of the (k+1)-mer
+                    // context), matching the convention used by training.
+                    // Initialize against the first query position the
+                    // sampling loop will see.
                     size_t bin_cursor = 0;
+                    int64_t first_query = interval_start;  // pos - k for pos = interval_start + k
                     if (!bins.empty()) {
                         while (bin_cursor + 1 < bins.size() &&
-                               interval_start >= bins[bin_cursor + 1].first) {
+                               first_query >= bins[bin_cursor + 1].first) {
                             ++bin_cursor;
                         }
                     }
@@ -362,15 +367,21 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
                             continue;
                         }
 
-                        // Find bin for this position using a forward cursor
+                        // Find bin for this position using a forward
+                        // cursor. Use pos - k (context-leftmost) to match
+                        // training; this keeps the per-bin transition
+                        // tables aligned with the same iter window the
+                        // training counts were attributed to.
+                        int64_t bin_query_pos = pos - k;
                         int bin_idx = -1;
                         if (!bins.empty()) {
                             while (bin_cursor + 1 < bins.size() &&
-                                   pos >= bins[bin_cursor + 1].first) {
+                                   bin_query_pos >= bins[bin_cursor + 1].first) {
                                 ++bin_cursor;
                             }
-                            if (pos >= bins[bin_cursor].first &&
-                                pos < bins[bin_cursor].first + iter_size) {
+                            if (bin_query_pos >= bins[bin_cursor].first &&
+                                bin_query_pos <
+                                    bins[bin_cursor].first + iter_size) {
                                 bin_idx = bins[bin_cursor].second;
                             }
                         }

--- a/src/GenomeSynthScore.cpp
+++ b/src/GenomeSynthScore.cpp
@@ -32,6 +32,11 @@ extern "C" {
 /**
  * C_gsynth_score: Score reference sequence under a trained Markov model.
  *
+ * The kernel writes one fixed-bin track file per chromosome listed in
+ * _chromids. The track directory must already exist (the R wrapper
+ * creates it once, even in parallel mode where multiple workers share
+ * the dir).
+ *
  * @param _log_p_list   List of log-p matrices (one per bin); each is
  *                      num_kmers x 4 in column-major R layout.
  * @param _bin_indices  Integer vector of bin indices for each
@@ -39,8 +44,11 @@ extern "C" {
  * @param _iter_starts  Integer vector of iter-position start coords.
  * @param _iter_chroms  Integer vector of iter-position chrom IDs.
  * @param _intervals    R intervals object (regions to score).
- * @param _track_dir    String: misha track NAME (kernel calls
- *                      create_track_dir(envir, name) to mkdir).
+ * @param _track_name   String: misha track name (used to look up the
+ *                      track dir via rdb::track2path).
+ * @param _chromids     Integer vector of chromids (0-based) the kernel
+ *                      should write files for. NULL or empty = all
+ *                      chroms in the chromkey.
  * @param _binsize      Integer: output bin size in bp (resolution).
  * @param _k            Integer: Markov order k.
  * @param _iter_size    Integer: stratum iterator bin size in bp.
@@ -52,7 +60,7 @@ extern "C" {
  */
 SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
                     SEXP _iter_starts, SEXP _iter_chroms,
-                    SEXP _intervals, SEXP _track_dir,
+                    SEXP _intervals, SEXP _track_name, SEXP _chromids,
                     SEXP _binsize, SEXP _k, SEXP _iter_size,
                     SEXP _n_policy, SEXP _sparse_policy,
                     SEXP _envir) {
@@ -130,9 +138,30 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
             }
         }
 
-        // ---- Track name -> create dir (matches gtrack_create_dense) ----
-        const char *track_name = CHAR(STRING_ELT(_track_dir, 0));
-        string track_dir_s = create_track_dir(_envir, track_name);
+        // ---- Resolve track dir. R wrapper has already created it
+        //      (mkdir before fork in parallel mode), so we only need
+        //      the path; do not call create_track_dir which mkdir's
+        //      and would fail concurrently for multiple workers. ----
+        const char *track_name = CHAR(STRING_ELT(_track_name, 0));
+        string track_dir_s = track2path(_envir, track_name);
+
+        // ---- Build list of chromids the kernel should process. ----
+        vector<int> chroms_to_process;
+        if (Rf_isNull(_chromids) || Rf_length(_chromids) == 0) {
+            chroms_to_process.reserve(num_chroms);
+            for (int c = 0; c < num_chroms; ++c) {
+                chroms_to_process.push_back(c);
+            }
+        } else {
+            int *cids = INTEGER(_chromids);
+            int n = Rf_length(_chromids);
+            chroms_to_process.reserve(n);
+            for (int i = 0; i < n; ++i) {
+                if (cids[i] >= 0 && cids[i] < num_chroms) {
+                    chroms_to_process.push_back(cids[i]);
+                }
+            }
+        }
 
         // ---- Per-chromosome 200bp bin lookup (sorted by start) ----
         vector<vector<pair<int64_t, int>>> chrom_bins(num_chroms);
@@ -149,10 +178,10 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
         GenomeSeqFetch seqfetch;
         seqfetch.set_seqdir(string(rdb::get_groot(_envir)) + "/seq");
 
-        // Total bp for progress reporting.
+        // Total bp for progress reporting (only over chroms we'll process).
         uint64_t total_bp = 0;
-        for (int c = 0; c < num_chroms; ++c) {
-            for (const auto &iv : sample_per_chrom[c])
+        for (int chromid : chroms_to_process) {
+            for (const auto &iv : sample_per_chrom[chromid])
                 total_bp += iv.end - iv.start;
         }
         Progress_reporter progress;
@@ -160,11 +189,12 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
 
         const float NaN_FLOAT = numeric_limits<float>::quiet_NaN();
 
-        // Iterate ALL chromosomes in chromkey order (matching
-        // GenomeTrackCreateDense): every chrom gets a track file, even
-        // if no input intervals fall on it (writes all-NaN). Required
-        // so gextract on out-of-input chroms doesn't fail.
-        for (int chromid = 0; chromid < num_chroms; ++chromid) {
+        // Iterate the assigned chromosomes. Every assigned chrom gets a
+        // track file, even if no input intervals fall on it (writes
+        // all-NaN). In parallel mode, workers split the chromkey set
+        // such that every chrom is owned by exactly one worker, so the
+        // resulting track dir always has a file per chrom.
+        for (int chromid : chroms_to_process) {
             int64_t chrom_size = chromkey.get_chrom_size(chromid);
             if (chrom_size <= 0) continue;
 

--- a/src/GenomeSynthScore.cpp
+++ b/src/GenomeSynthScore.cpp
@@ -19,6 +19,7 @@
 #include "GenomeChromKey.h"
 #include "GenomeSeqFetch.h"
 #include "GenomeTrackFixedBin.h"
+#include "MaskUtils.h"
 #include "rdbinterval.h"
 #include "rdbprogress.h"
 #include "rdbutils.h"
@@ -52,8 +53,12 @@ extern "C" {
  * @param _binsize      Integer: output bin size in bp (resolution).
  * @param _k            Integer: Markov order k.
  * @param _iter_size    Integer: stratum iterator bin size in bp.
- * @param _n_policy     Integer: 0 = NA, 1 = uniform.
+ * @param _n_policy     Integer: context-N policy (0 = NA, 1 = uniform).
+ *                      Predicted-base-N is always NA regardless of this
+ *                      flag — the model has no log P for non-ACGT bases.
  * @param _sparse_policy Integer: 0 = NA, 1 = uniform.
+ * @param _mask         R intervals object (positions to mark NA in the
+ *                      output). NULL = no mask.
  * @param _envir        R environment.
  *
  * @return R_NilValue on success.
@@ -62,7 +67,7 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
                     SEXP _iter_starts, SEXP _iter_chroms,
                     SEXP _intervals, SEXP _track_name, SEXP _chromids,
                     SEXP _binsize, SEXP _k, SEXP _iter_size,
-                    SEXP _n_policy, SEXP _sparse_policy,
+                    SEXP _n_policy, SEXP _sparse_policy, SEXP _mask,
                     SEXP _envir) {
     try {
         RdbInitializer rdb_init;
@@ -94,7 +99,10 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
         if (num_bins <= 0) verror("log_p_list is empty");
 
         // Flat layout: log_p[bin][ctx * NUM_BASES + base].
-        // Track per-bin "is sparse" flag: bin sparse if any cell is NaN.
+        // A sparse bin (training-time min_obs filter) is marked by setting
+        // every cell of cdf to NA in R, so log_p is NaN throughout. Detect
+        // sparsity by checking the first cell only — full-bin NaN is the
+        // only way the value is NaN given pseudocount > 0.
         vector<vector<float>> log_p(num_bins);
         vector<bool> bin_is_sparse(num_bins, false);
         for (int b = 0; b < num_bins; ++b) {
@@ -105,12 +113,12 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
                        b + 1, Rf_length(m), num_kmers * NUM_BASES);
             }
             double *p = REAL(m);
+            bin_is_sparse[b] = std::isnan(p[0]);
             log_p[b].resize(num_kmers * NUM_BASES);
             for (int ctx = 0; ctx < num_kmers; ++ctx) {
                 for (int base = 0; base < NUM_BASES; ++base) {
                     // R matrices are column-major: [row + col * nrow]
                     double v = p[ctx + base * num_kmers];
-                    if (std::isnan(v)) bin_is_sparse[b] = true;
                     log_p[b][ctx * NUM_BASES + base] = (float)v;
                 }
             }
@@ -135,6 +143,20 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
                 const GInterval &iv = si->cur_interval();
                 if (iv.chromid >= 0 && iv.chromid < num_chroms)
                     sample_per_chrom[iv.chromid].push_back(iv);
+            }
+        }
+
+        // ---- Parse mask intervals (positions to NA-mark in the output) ----
+        vector<vector<GInterval>> mask_per_chrom(num_chroms);
+        if (!Rf_isNull(_mask)) {
+            GIntervalsFetcher1D *mi = NULL;
+            iu.convert_rintervs(_mask, &mi, NULL);
+            unique_ptr<GIntervalsFetcher1D> mguard(mi);
+            mi->sort();
+            for (mi->begin_iter(); !mi->isend(); mi->next()) {
+                const GInterval &iv = mi->cur_interval();
+                if (iv.chromid >= 0 && iv.chromid < num_chroms)
+                    mask_per_chrom[iv.chromid].push_back(iv);
             }
         }
 
@@ -214,6 +236,7 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
 
             const vector<GInterval> &ivs = sample_per_chrom[chromid];
             const vector<pair<int64_t, int>> &bins = chrom_bins[chromid];
+            const vector<GInterval> &mask_ivs = mask_per_chrom[chromid];
 
             for (size_t iv_idx = 0; iv_idx < ivs.size(); ++iv_idx) {
                 const GInterval &iv = ivs[iv_idx];
@@ -228,14 +251,20 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
                 vector<char> seq;
                 seqfetch.read_interval(read_iv, chromkey, seq);
 
-                // Forward cursor over the 200bp bin lookup.
+                // Forward cursor over the iter-size bin lookup. Bin queries
+                // use pos - k (the leftmost base of the (k+1)-mer context),
+                // matching the convention used by training. Initialize the
+                // cursor against the first query position the loop will see.
                 size_t bin_cursor = 0;
+                int64_t first_query = start - k;
                 if (!bins.empty()) {
                     while (bin_cursor + 1 < bins.size() &&
-                           start >= bins[bin_cursor + 1].first) {
+                           first_query >= bins[bin_cursor + 1].first) {
                         ++bin_cursor;
                     }
                 }
+
+                size_t mask_cursor = 0;
 
                 for (int64_t pos = start; pos < end; ++pos) {
                     int64_t out_bin = pos / binsize;
@@ -245,6 +274,13 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
 
                     if (any_na[out_bin]) {
                         // already poisoned — no need to score this bp
+                        continue;
+                    }
+
+                    // Mask check (unconditional NA, before any model work).
+                    if (!mask_ivs.empty() &&
+                        is_position_masked(pos, mask_ivs, mask_cursor)) {
+                        any_na[out_bin] = true;
                         continue;
                     }
 
@@ -264,27 +300,39 @@ SEXP C_gsynth_score(SEXP _log_p_list, SEXP _bin_indices,
                     int base_idx = StratifiedMarkovModel::encode_base(
                         seq[rel]);
 
-                    // Stratum bin lookup at this 200bp window.
+                    // Predicted-base-N is unconditional NA: the model has
+                    // no log P for non-ACGT bases. Substituting log(1/4)
+                    // would be a fabrication so we never gate this on
+                    // n_policy.
+                    if (base_idx < 0) {
+                        any_na[out_bin] = true;
+                        continue;
+                    }
+
+                    // Stratum bin lookup at pos - k (context-leftmost
+                    // position) to match training's convention.
+                    int64_t bin_query_pos = pos - k;
                     int stratum_bin = -1;
                     if (!bins.empty()) {
                         while (bin_cursor + 1 < bins.size() &&
-                               pos >= bins[bin_cursor + 1].first) {
+                               bin_query_pos >= bins[bin_cursor + 1].first) {
                             ++bin_cursor;
                         }
-                        if (pos >= bins[bin_cursor].first &&
-                            pos < bins[bin_cursor].first + iter_size) {
+                        if (bin_query_pos >= bins[bin_cursor].first &&
+                            bin_query_pos <
+                                bins[bin_cursor].first + iter_size) {
                             stratum_bin = bins[bin_cursor].second;
                         }
                     }
 
-                    bool n_invalid = (ctx_idx < 0 || base_idx < 0);
+                    bool ctx_n = (ctx_idx < 0);
                     bool stratum_invalid =
                         (stratum_bin < 0 || stratum_bin >= num_bins);
                     bool sparse = (!stratum_invalid &&
                                    bin_is_sparse[stratum_bin]);
 
                     float contrib;
-                    if (n_invalid) {
+                    if (ctx_n) {
                         if (n_policy == 1) {
                             contrib = UNIFORM_LOGP;
                         } else {

--- a/src/GenomeSynthTrain.cpp
+++ b/src/GenomeSynthTrain.cpp
@@ -41,6 +41,9 @@ extern "C" {
  * @param _bin_map Integer vector mapping source bins to target bins (-1 = keep)
  * @param _mask R intervals object for mask regions (NULL if no mask)
  * @param _pseudocount Numeric pseudocount for normalization
+ * @param _k Markov order
+ * @param _prior_mode Character: "uniform", "marginal", "global", or "explicit"
+ * @param _prior_matrix Numeric matrix (n_bins x 4) for "explicit" mode, else NULL
  * @param _envir R environment
  *
  * @return A list containing the trained model data
@@ -48,7 +51,8 @@ extern "C" {
 SEXP C_gsynth_train(SEXP _chrom_ids, SEXP _chrom_starts, SEXP _chrom_ends,
                      SEXP _bin_indices, SEXP _iter_starts, SEXP _iter_chroms,
                      SEXP _breaks, SEXP _bin_map, SEXP _mask,
-                     SEXP _pseudocount, SEXP _k, SEXP _envir) {
+                     SEXP _pseudocount, SEXP _k,
+                     SEXP _prior_mode, SEXP _prior_matrix, SEXP _envir) {
     try {
         RdbInitializer rdb_init;
         IntervUtils iu(_envir);
@@ -101,6 +105,12 @@ SEXP C_gsynth_train(SEXP _chrom_ids, SEXP _chrom_starts, SEXP _chrom_ends,
         }
 
         double pseudocount = Rf_asReal(_pseudocount);
+
+        // Parse prior mode (default uniform if NULL/missing)
+        std::string prior_mode = "uniform";
+        if (!Rf_isNull(_prior_mode) && Rf_length(_prior_mode) > 0) {
+            prior_mode = CHAR(STRING_ELT(_prior_mode, 0));
+        }
 
         // Parse mask intervals if provided
         vector<vector<GInterval>> mask_per_chrom;
@@ -262,13 +272,46 @@ SEXP C_gsynth_train(SEXP _chrom_ids, SEXP _chrom_starts, SEXP _chrom_ends,
         // Apply bin mapping
         model.apply_bin_mapping(bin_map_vec);
 
-        // Normalize and build CDFs
+        // Resolve prior pi(b) from m_counts (post-merge), explicit matrix,
+        // or as a uniform/global broadcast — depending on prior_mode.
+        int marginal_fallbacks = 0;
+        if (prior_mode == "uniform") {
+            model.set_prior_uniform();
+        } else if (prior_mode == "marginal") {
+            marginal_fallbacks = model.set_prior_from_marginal();
+        } else if (prior_mode == "global") {
+            model.set_prior_from_global_marginal();
+        } else if (prior_mode == "explicit") {
+            if (Rf_isNull(_prior_matrix)) {
+                verror("prior_mode='explicit' requires a non-NULL prior_matrix");
+            }
+            int nrow = Rf_nrows(_prior_matrix);
+            int ncol = Rf_ncols(_prior_matrix);
+            int n_bins_out = model.get_num_bins();
+            if (nrow != n_bins_out || ncol != NUM_BASES) {
+                verror("prior_matrix must be %d x %d (got %d x %d)",
+                       n_bins_out, NUM_BASES, nrow, ncol);
+            }
+            std::vector<std::array<double, NUM_BASES>> pi_rows(n_bins_out);
+            double* mat = REAL(_prior_matrix);
+            for (int b = 0; b < n_bins_out; ++b) {
+                for (int a = 0; a < NUM_BASES; ++a) {
+                    // R column-major: [b + a * nrow]
+                    pi_rows[b][a] = mat[b + a * nrow];
+                }
+            }
+            model.set_prior_explicit(pi_rows);
+        } else {
+            verror("Unknown prior_mode: %s", prior_mode.c_str());
+        }
+
+        // Normalize and build CDFs (uses m_prior set above)
         model.normalize_and_build_cdf(pseudocount);
 
         // Build return list
         SEXP answer, names;
-        rprotect(answer = Rf_allocVector(VECSXP, 7));
-        rprotect(names = Rf_allocVector(STRSXP, 7));
+        rprotect(answer = Rf_allocVector(VECSXP, 9));
+        rprotect(names = Rf_allocVector(STRSXP, 9));
 
         // num_bins
         SET_VECTOR_ELT(answer, 0, Rf_ScalarInteger(num_bins));
@@ -353,6 +396,24 @@ SEXP C_gsynth_train(SEXP _chrom_ids, SEXP _chrom_starts, SEXP _chrom_ends,
 
         SET_VECTOR_ELT(answer, 6, r_model_data);
         SET_STRING_ELT(names, 6, Rf_mkChar("model_data"));
+
+        // Resolved per-bin prior matrix (n_bins x 4, column-major for R)
+        SEXP r_prior;
+        rprotect(r_prior = Rf_allocMatrix(REALSXP, num_bins, NUM_BASES));
+        {
+            const auto& prior = model.get_prior();
+            double* prior_data = REAL(r_prior);
+            for (int b = 0; b < num_bins; ++b) {
+                for (int a = 0; a < NUM_BASES; ++a) {
+                    prior_data[b + a * num_bins] = prior[b][a];
+                }
+            }
+        }
+        SET_VECTOR_ELT(answer, 7, r_prior);
+        SET_STRING_ELT(names, 7, Rf_mkChar("prior"));
+
+        SET_VECTOR_ELT(answer, 8, Rf_ScalarInteger(marginal_fallbacks));
+        SET_STRING_ELT(names, 8, Rf_mkChar("marginal_fallbacks"));
 
         Rf_setAttrib(answer, R_NamesSymbol, names);
 

--- a/src/StratifiedMarkovModel.cpp
+++ b/src/StratifiedMarkovModel.cpp
@@ -191,19 +191,25 @@ bool StratifiedMarkovModel::set_prior_from_global_marginal() {
 
 void StratifiedMarkovModel::normalize_and_build_cdf(double pseudocount) {
     for (int b = 0; b < m_num_bins; ++b) {
+        const auto& pi = m_prior[b];
         for (int ctx = 0; ctx < m_num_kmers; ++ctx) {
             int base_offset = ctx * NUM_BASES;
 
-            // Calculate total count for this context (with pseudocounts)
-            double total = 0.0;
+            // Total observed count at (b, ctx)
+            double n_total = 0.0;
             for (int base = 0; base < NUM_BASES; ++base) {
-                total += static_cast<double>(m_counts[b][base_offset + base]) + pseudocount;
+                n_total += static_cast<double>(m_counts[b][base_offset + base]);
             }
+            // Posterior denominator: sum_a N + alpha (pi sums to 1)
+            double total = n_total + pseudocount;
 
-            // Build CDF
+            // Build CDF: P(a) = (N_a + alpha * pi_a) / (sum_a N + alpha)
             double cumsum = 0.0;
             for (int base = 0; base < NUM_BASES; ++base) {
-                double prob = (static_cast<double>(m_counts[b][base_offset + base]) + pseudocount) / total;
+                double prob =
+                    (static_cast<double>(m_counts[b][base_offset + base]) +
+                     pseudocount * pi[base]) /
+                    total;
                 cumsum += prob;
                 m_cdf[b][base_offset + base] = static_cast<float>(cumsum);
             }

--- a/src/StratifiedMarkovModel.cpp
+++ b/src/StratifiedMarkovModel.cpp
@@ -51,6 +51,9 @@ void StratifiedMarkovModel::init(int num_bins, const std::vector<double>& breaks
         m_cdf[b].assign(m_num_kmers * NUM_BASES, 0.0f);
     }
 
+    // Default per-bin prior: uniform (will be overridden by setter before normalize)
+    m_prior.assign(num_bins, {0.25, 0.25, 0.25, 0.25});
+
     m_total_kmers = 0;
 }
 
@@ -106,6 +109,84 @@ void StratifiedMarkovModel::apply_bin_mapping(const std::vector<int>& bin_map) {
     // Replace old counts with merged counts
     m_counts = std::move(new_counts);
     m_per_bin_kmers = std::move(new_per_bin_kmers);
+}
+
+void StratifiedMarkovModel::set_prior_uniform() {
+    for (auto& row : m_prior) {
+        row = {0.25, 0.25, 0.25, 0.25};
+    }
+}
+
+namespace {
+void normalize_row_or_uniform(std::array<double, NUM_BASES>& row) {
+    double s = 0.0;
+    for (int a = 0; a < NUM_BASES; ++a) s += row[a];
+    if (s <= 0.0) {
+        row = {0.25, 0.25, 0.25, 0.25};
+    } else {
+        for (int a = 0; a < NUM_BASES; ++a) row[a] /= s;
+    }
+}
+}  // namespace
+
+void StratifiedMarkovModel::set_prior_global(
+    const std::array<double, NUM_BASES>& pi) {
+    std::array<double, NUM_BASES> row = pi;
+    normalize_row_or_uniform(row);
+    for (auto& r : m_prior) r = row;
+}
+
+void StratifiedMarkovModel::set_prior_explicit(
+    const std::vector<std::array<double, NUM_BASES>>& pi_per_bin) {
+    if (static_cast<int>(pi_per_bin.size()) != m_num_bins) {
+        throw std::invalid_argument("prior matrix row count must match num_bins");
+    }
+    for (int b = 0; b < m_num_bins; ++b) {
+        m_prior[b] = pi_per_bin[b];
+        normalize_row_or_uniform(m_prior[b]);
+    }
+}
+
+int StratifiedMarkovModel::set_prior_from_marginal() {
+    int fallback_count = 0;
+    for (int b = 0; b < m_num_bins; ++b) {
+        std::array<double, NUM_BASES> sums = {0.0, 0.0, 0.0, 0.0};
+        for (int ctx = 0; ctx < m_num_kmers; ++ctx) {
+            int off = ctx * NUM_BASES;
+            for (int a = 0; a < NUM_BASES; ++a) {
+                sums[a] += static_cast<double>(m_counts[b][off + a]);
+            }
+        }
+        double total = sums[0] + sums[1] + sums[2] + sums[3];
+        if (total <= 0.0) {
+            m_prior[b] = {0.25, 0.25, 0.25, 0.25};
+            ++fallback_count;
+        } else {
+            for (int a = 0; a < NUM_BASES; ++a) m_prior[b][a] = sums[a] / total;
+        }
+    }
+    return fallback_count;
+}
+
+bool StratifiedMarkovModel::set_prior_from_global_marginal() {
+    std::array<double, NUM_BASES> sums = {0.0, 0.0, 0.0, 0.0};
+    for (int b = 0; b < m_num_bins; ++b) {
+        for (int ctx = 0; ctx < m_num_kmers; ++ctx) {
+            int off = ctx * NUM_BASES;
+            for (int a = 0; a < NUM_BASES; ++a) {
+                sums[a] += static_cast<double>(m_counts[b][off + a]);
+            }
+        }
+    }
+    double total = sums[0] + sums[1] + sums[2] + sums[3];
+    if (total <= 0.0) {
+        for (auto& r : m_prior) r = {0.25, 0.25, 0.25, 0.25};
+        return false;
+    }
+    std::array<double, NUM_BASES> pi;
+    for (int a = 0; a < NUM_BASES; ++a) pi[a] = sums[a] / total;
+    for (auto& r : m_prior) r = pi;
+    return true;
 }
 
 void StratifiedMarkovModel::normalize_and_build_cdf(double pseudocount) {

--- a/src/StratifiedMarkovModel.h
+++ b/src/StratifiedMarkovModel.h
@@ -72,10 +72,51 @@ public:
 
     /**
      * Normalize counts to probabilities and build CDFs for sampling.
-     * Should be called after all counts are accumulated and bin mapping is applied.
-     * @param pseudocount Value to add to all counts to avoid zero probabilities (default 1)
+     * Should be called after all counts are accumulated, bin mapping is
+     * applied, and the prior has been set (default uniform 1/4 from init()).
+     *
+     * Posterior formula:
+     *     P(a | c, b) = (N(b,c,a) + pseudocount * pi_a(b)) /
+     *                   (sum_a N(b,c,a) + pseudocount)
+     * with pi(b) = m_prior[b] (sums to 1).
+     *
+     * @param pseudocount Total Dirichlet concentration alpha (default 1)
      */
     void normalize_and_build_cdf(double pseudocount = 1.0);
+
+    /**
+     * Set the per-bin prior to uniform (0.25 per base) for all bins.
+     */
+    void set_prior_uniform();
+
+    /**
+     * Set the per-bin prior to a global vector pi (length 4), broadcast to
+     * every bin. The input is re-normalized to sum to 1; if it sums to <=0,
+     * uniform 1/4 is used instead.
+     */
+    void set_prior_global(const std::array<double, NUM_BASES>& pi);
+
+    /**
+     * Set the per-bin prior from an explicit n_bins x 4 matrix. Each row is
+     * re-normalized to sum to 1; rows that sum to <=0 fall back to uniform.
+     */
+    void set_prior_explicit(
+        const std::vector<std::array<double, NUM_BASES>>& pi_per_bin);
+
+    /**
+     * Compute the per-bin prior from the current counts (post bin merge):
+     *     pi_a(b) = sum_c m_counts[b][c*4+a] / sum_{c,a} m_counts[b][c*4+a]
+     * Bins with zero total observations fall back to uniform 1/4.
+     * @return number of bins that fell back to uniform.
+     */
+    int set_prior_from_marginal();
+
+    /**
+     * Compute a single global per-base prior pooled across all bins, and
+     * broadcast it to every bin. Falls back to uniform if total counts == 0.
+     * @return true if the global was non-zero, false if it fell back.
+     */
+    bool set_prior_from_global_marginal();
 
     /**
      * Get the bin index for a track value.
@@ -199,6 +240,9 @@ public:
     const std::vector<std::vector<float>>& get_cdf() const {
         return m_cdf;
     }
+    const std::vector<std::array<double, NUM_BASES>>& get_prior() const {
+        return m_prior;
+    }
 
     /**
      * Serialize the model to a binary file.
@@ -225,6 +269,10 @@ private:
     // Cumulative distribution functions for sampling: cdf[bin][kmer_idx * NUM_BASES + base_idx]
     // For a given context ctx: cdf[bin][ctx*4+0] = P(A), cdf[bin][ctx*4+1] = P(A)+P(C), etc.
     std::vector<std::vector<float>> m_cdf;
+
+    // Per-bin Dirichlet prior pi_a(b). Each inner array sums to 1.
+    // Initialized to uniform (0.25, 0.25, 0.25, 0.25) on init().
+    std::vector<std::array<double, NUM_BASES>> m_prior;
 
     // Statistics
     uint64_t m_total_kmers;

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -108,7 +108,7 @@ extern "C" {
     extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_replace_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_score(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
-                                SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+                                SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_kmer_dist(SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_ggenome_implant(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 }
@@ -214,7 +214,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_gsynth_train", (DL_FUNC)&C_gsynth_train, 12},
     {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 13},
     {"C_gsynth_replace_kmer", (DL_FUNC)&C_gsynth_replace_kmer, 6},
-    {"C_gsynth_score", (DL_FUNC)&C_gsynth_score, 13},
+    {"C_gsynth_score", (DL_FUNC)&C_gsynth_score, 14},
     {"C_gseq_kmer_dist", (DL_FUNC)&C_gseq_kmer_dist, 4},
     {"C_ggenome_implant", (DL_FUNC)&C_ggenome_implant, 7},
     {NULL, NULL, 0}

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -104,7 +104,7 @@ extern "C" {
     extern SEXP C_gseq_pwm_multitask(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_pwm_edits(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-    extern SEXP C_gsynth_train(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+    extern SEXP C_gsynth_train(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_replace_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_score(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
@@ -211,7 +211,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_gseq_pwm_multitask", (DL_FUNC)&C_gseq_pwm_multitask, 17},
     {"C_gseq_pwm_edits", (DL_FUNC)&C_gseq_pwm_edits, 14},
     {"C_gseq_kmer", (DL_FUNC)&C_gseq_kmer, 9},
-    {"C_gsynth_train", (DL_FUNC)&C_gsynth_train, 12},
+    {"C_gsynth_train", (DL_FUNC)&C_gsynth_train, 14},
     {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 13},
     {"C_gsynth_replace_kmer", (DL_FUNC)&C_gsynth_replace_kmer, 6},
     {"C_gsynth_score", (DL_FUNC)&C_gsynth_score, 14},

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -108,7 +108,7 @@ extern "C" {
     extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_replace_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_score(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
-                                SEXP, SEXP, SEXP, SEXP, SEXP);
+                                SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_kmer_dist(SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_ggenome_implant(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 }
@@ -214,7 +214,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_gsynth_train", (DL_FUNC)&C_gsynth_train, 12},
     {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 13},
     {"C_gsynth_replace_kmer", (DL_FUNC)&C_gsynth_replace_kmer, 6},
-    {"C_gsynth_score", (DL_FUNC)&C_gsynth_score, 12},
+    {"C_gsynth_score", (DL_FUNC)&C_gsynth_score, 13},
     {"C_gseq_kmer_dist", (DL_FUNC)&C_gseq_kmer_dist, 4},
     {"C_ggenome_implant", (DL_FUNC)&C_ggenome_implant, 7},
     {NULL, NULL, 0}

--- a/tests/testthat/test-gsynth-prior.R
+++ b/tests/testthat/test-gsynth-prior.R
@@ -68,6 +68,122 @@ test_that("gsynth.save/load round-trips the prior matrix", {
     gvtrack.rm("g_frac")
 })
 
+test_that("prior = 'marginal' makes unobserved contexts return per-bin base composition", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 100000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200,
+        prior = "marginal",
+        pseudocount = 1
+    )
+
+    counts_b1 <- model$model_data$counts[[1]]
+    cdf_b1 <- model$model_data$cdf[[1]]
+    row_sums <- rowSums(counts_b1)
+    unobs_idx <- which(row_sums == 0)
+
+    skip_if(length(unobs_idx) == 0L, "no unobserved context in bin 1 for this fixture")
+
+    ctx <- unobs_idx[1]
+    p_obs <- diff(c(0, cdf_b1[ctx, ]))
+
+    pi <- model$prior[1, ]
+    expect_equal(p_obs, pi, tolerance = 1e-5)
+
+    sums <- colSums(counts_b1)
+    expected_pi <- sums / sum(sums)
+    expect_equal(pi, expected_pi, tolerance = 1e-9)
+
+    gvtrack.rm("g_frac")
+})
+
+test_that("explicit length-4 prior overrides unobserved context probabilities", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 50000)
+    target <- c(0.10, 0.40, 0.40, 0.10)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200,
+        prior = target,
+        pseudocount = 1
+    )
+
+    expect_equal(as.numeric(model$prior[1, ]), target, tolerance = 1e-9)
+
+    found <- FALSE
+    for (b in seq_len(model$total_bins)) {
+        counts_b <- model$model_data$counts[[b]]
+        cdf_b <- model$model_data$cdf[[b]]
+        unobs <- which(rowSums(counts_b) == 0)
+        if (length(unobs) == 0L) next
+        ctx <- unobs[1]
+        p_obs <- diff(c(0, cdf_b[ctx, ]))
+        expect_equal(p_obs, target, tolerance = 1e-5)
+        found <- TRUE
+        break
+    }
+    skip_if(!found, "no unobserved context in any bin for this fixture")
+
+    gvtrack.rm("g_frac")
+})
+
+test_that("prior = NULL preserves uniform 1/4 at unobserved contexts (regression)", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 50000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200,
+        prior = NULL,
+        pseudocount = 1
+    )
+
+    counts_b1 <- model$model_data$counts[[1]]
+    cdf_b1 <- model$model_data$cdf[[1]]
+    unobs_idx <- which(rowSums(counts_b1) == 0)
+    skip_if(length(unobs_idx) == 0L, "no unobserved context in bin 1 for this fixture")
+
+    ctx <- unobs_idx[1]
+    p_obs <- diff(c(0, cdf_b1[ctx, ]))
+    expect_equal(p_obs, rep(0.25, 4L), tolerance = 1e-5)
+
+    gvtrack.rm("g_frac")
+})
+
+test_that("prior validation rejects malformed input", {
+    expect_error(.gsynth_resolve_prior_arg("bogus", 4L), "Unknown prior")
+    expect_error(
+        .gsynth_resolve_prior_arg(c(-0.1, 0.5, 0.3, 0.3), 4L),
+        "non-negative"
+    )
+    expect_error(.gsynth_resolve_prior_arg(c(0, 0, 0, 0), 4L), "sum to > 0")
+    # Mismatched matrix dims
+    expect_error(
+        .gsynth_resolve_prior_arg(matrix(0.25, nrow = 3, ncol = 4), 4L),
+        "must be 4 x 4"
+    )
+    # Length-4 named vector with wrong names
+    expect_error(
+        .gsynth_resolve_prior_arg(c(X = 0.25, Y = 0.25, Z = 0.25, W = 0.25), 4L),
+        "names A, C, G, T"
+    )
+})
+
 test_that("loading a .gsm without a prior block defaults to uniform prior", {
     gdb.init_examples()
     if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")

--- a/tests/testthat/test-gsynth-prior.R
+++ b/tests/testthat/test-gsynth-prior.R
@@ -1,0 +1,44 @@
+# Tests for gsynth.train(prior = ...) — informative Dirichlet prior added in misha 5.7.0.
+
+test_that("gsynth.train accepts prior = 'marginal' (default) and stores resolved prior", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 50000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200
+    )
+
+    expect_equal(model$prior_mode, "marginal")
+    expect_true(is.matrix(model$prior))
+    expect_equal(dim(model$prior), c(model$total_bins, 4L))
+    row_sums <- rowSums(model$prior)
+    # Either sums to 1 (observed) or exactly 0.25 each (uniform fallback)
+    expect_true(all(abs(row_sums - 1) < 1e-9))
+
+    gvtrack.rm("g_frac")
+})
+
+test_that("gsynth.train with prior = NULL produces uniform 1/4 rows", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 50000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200,
+        prior = NULL
+    )
+
+    expect_equal(model$prior_mode, "uniform")
+    expect_true(all(abs(model$prior - 0.25) < 1e-12))
+
+    gvtrack.rm("g_frac")
+})

--- a/tests/testthat/test-gsynth-prior.R
+++ b/tests/testthat/test-gsynth-prior.R
@@ -42,3 +42,58 @@ test_that("gsynth.train with prior = NULL produces uniform 1/4 rows", {
 
     gvtrack.rm("g_frac")
 })
+
+test_that("gsynth.save/load round-trips the prior matrix", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 50000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200,
+        prior = c(A = 0.4, C = 0.1, G = 0.1, T = 0.4)
+    )
+
+    out_dir <- file.path(tempdir(), "test_prior_roundtrip")
+    on.exit(unlink(out_dir, recursive = TRUE), add = TRUE)
+    gsynth.save(model, out_dir)
+    loaded <- gsynth.load(out_dir)
+
+    expect_equal(loaded$prior_mode, model$prior_mode)
+    expect_equal(loaded$prior, model$prior, tolerance = 1e-9)
+
+    gvtrack.rm("g_frac")
+})
+
+test_that("loading a .gsm without a prior block defaults to uniform prior", {
+    gdb.init_examples()
+    if ("g_frac" %in% gvtrack.ls()) gvtrack.rm("g_frac")
+    gvtrack.create("g_frac", NULL, "kmer.frac", kmer = "G")
+
+    test_intervals <- gintervals(1, 0, 50000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac", breaks = seq(0, 0.5, 0.1)),
+        intervals = test_intervals,
+        iterator = 200
+    )
+
+    out_dir <- file.path(tempdir(), "test_legacy_no_prior")
+    on.exit(unlink(out_dir, recursive = TRUE), add = TRUE)
+    gsynth.save(model, out_dir)
+
+    # Strip prior block from metadata to simulate an old .gsm
+    meta <- yaml::read_yaml(file.path(out_dir, "metadata.yaml"))
+    meta$prior <- NULL
+    meta$prior_mode <- NULL
+    yaml::write_yaml(meta, file.path(out_dir, "metadata.yaml"), precision = 15)
+
+    loaded <- gsynth.load(out_dir)
+    expect_equal(loaded$prior_mode, "uniform")
+    expect_true(all(abs(loaded$prior - 0.25) < 1e-12))
+
+    gvtrack.rm("g_frac")
+})

--- a/tests/testthat/test-gsynth-score.R
+++ b/tests/testthat/test-gsynth-score.R
@@ -311,3 +311,173 @@ test_that("gsynth.score: LLR sanity between two models", {
     finite <- diff_col[is.finite(diff_col)]
     expect_gte(mean(finite), -1)
 })
+
+test_that("gsynth.score uses bin_at(pos - k) (matches train, not predicted-base)", {
+    # Training keys the stratum bin to the leftmost base of the (k+1)-mer
+    # context (genome_pos = start + pos in GenomeSynthTrain.cpp). To honor
+    # cached models scoring must look up the bin at pos - k, not at pos.
+    # Choose a window boundary where bin_at(pos) != bin_at(pos - k) and
+    # assert the score matches the training-convention bin's log_p.
+    gdb.init_examples()
+    on.exit(
+        {
+            if (gtrack.exists("zz_offby_k")) gtrack.rm("zz_offby_k", force = TRUE)
+            if ("g_frac_off" %in% gvtrack.ls()) gvtrack.rm("g_frac_off")
+        },
+        add = TRUE
+    )
+
+    gvtrack.create("g_frac_off", NULL, "kmer.frac", kmer = "G")
+    iv <- gintervals(1, 0, 50000)
+
+    model <- gsynth.train(
+        list(expr = "g_frac_off", breaks = c(0, 0.2, 0.5, 1.0)),
+        intervals = iv, iterator = 200, k = 5L, pseudocount = 1
+    )
+
+    gsynth.score(model, "zz_offby_k",
+        intervals = iv, resolution = 1, overwrite = TRUE
+    )
+    sv <- gextract("zz_offby_k",
+        intervals = iv, iterator = 1, colnames = "logp"
+    )
+
+    g_per_win <- gextract("g_frac_off",
+        intervals = iv, iterator = 200, colnames = "g"
+    )
+    g_per_win$bin <- findInterval(g_per_win$g,
+        c(0, 0.2, 0.5, 1.0),
+        rightmost.closed = TRUE
+    )
+
+    # Pick the first iter boundary where the bin actually changes.
+    transitions <- which(diff(g_per_win$bin) != 0)
+    skip_if(length(transitions) == 0L, "no bin transition in this region")
+    boundary_idx <- transitions[1]
+    boundary_pos <- g_per_win$start[boundary_idx + 1L]
+    prev_bin <- g_per_win$bin[boundary_idx]
+    next_bin <- g_per_win$bin[boundary_idx + 1L]
+    expect_false(prev_bin == next_bin)
+
+    seq_chunk <- toupper(gseq.extract(
+        gintervals(1, boundary_pos - 5L, boundary_pos + 1L)
+    ))
+    ctx <- substr(seq_chunk, 1L, 5L)
+    base <- substr(seq_chunk, 6L, 6L)
+    base_map <- c(A = 0L, C = 1L, G = 2L, T = 3L)
+    ctx_idx <- 0L
+    for (ch in strsplit(ctx, "")[[1]]) {
+        ctx_idx <- bitwShiftL(ctx_idx, 2L) + base_map[[ch]]
+    }
+    base_idx <- base_map[[base]] + 1L
+
+    cdf_to_logp <- function(cdf) {
+        log(cbind(
+            cdf[, 1], cdf[, 2] - cdf[, 1],
+            cdf[, 3] - cdf[, 2], cdf[, 4] - cdf[, 3]
+        ))
+    }
+    expected <- cdf_to_logp(model$model_data$cdf[[prev_bin]])[
+        ctx_idx + 1L, base_idx
+    ]
+
+    score_val <- sv$logp[sv$start == boundary_pos]
+    # Compare at float precision (track is float-stored).
+    expect_equal(score_val, expected, tolerance = 1e-5)
+})
+
+test_that("gsynth.score honors mask parameter (masked bp -> NA)", {
+    gdb.init_examples()
+    on.exit(
+        {
+            if (gtrack.exists("zz_mask")) gtrack.rm("zz_mask", force = TRUE)
+        },
+        add = TRUE
+    )
+
+    model <- gsynth.train(
+        intervals = gintervals(1, 0, 50000),
+        iterator = 200, k = 2L
+    )
+
+    test_iv <- gintervals(1, 1000, 5000)
+    mask_iv <- gintervals(1, 2000, 3000)
+
+    gsynth.score(
+        model = model, track = "zz_mask",
+        intervals = test_iv,
+        mask = mask_iv,
+        resolution = 1,
+        overwrite = TRUE
+    )
+
+    vals <- gextract("zz_mask",
+        intervals = test_iv, iterator = 1, colnames = "v"
+    )
+    masked_idx <- vals$start >= 2000L & vals$start < 3000L
+    expect_true(all(is.na(vals$v[masked_idx])))
+    expect_true(all(is.finite(vals$v[!masked_idx])))
+})
+
+test_that("gsynth.score: gap between sub-chrom intervals -> NA bins in gap", {
+    # When intervals contain gaps, no positions in the gap should be scored
+    # and no bin info from inside the gap should leak across the boundary.
+    gdb.init_examples()
+    on.exit(
+        {
+            if (gtrack.exists("zz_gap")) gtrack.rm("zz_gap", force = TRUE)
+        },
+        add = TRUE
+    )
+
+    model <- gsynth.train(
+        intervals = gintervals(1, 0, 50000),
+        iterator = 200, k = 2L
+    )
+
+    iv1 <- gintervals(1, 1000, 2000)
+    iv2 <- gintervals(1, 4000, 5000)
+    test_iv <- rbind(iv1, iv2)
+
+    gsynth.score(
+        model = model, track = "zz_gap",
+        intervals = test_iv, resolution = 1,
+        overwrite = TRUE
+    )
+
+    # Reading over [2000, 4000) (the gap) must yield NA.
+    gap_vals <- gextract("zz_gap",
+        intervals = gintervals(1, 2000, 4000),
+        iterator = 1, colnames = "v"
+    )
+    expect_true(all(is.na(gap_vals$v)))
+})
+
+test_that("gsynth.score: sub-chrom interval gets bin info upstream (no NA at start)", {
+    # With the off-by-k fix bin lookup is at pos - k, which lands in the iter
+    # window before the user interval. The R wrapper extends gextract upstream
+    # by iter_size so positions at the very start of a sub-chrom interval are
+    # not silently NA-poisoned.
+    gdb.init_examples()
+    on.exit(
+        {
+            if (gtrack.exists("zz_subchrom")) gtrack.rm("zz_subchrom", force = TRUE)
+        },
+        add = TRUE
+    )
+
+    model <- gsynth.train(
+        intervals = gintervals(1, 0, 50000),
+        iterator = 200, k = 2L
+    )
+
+    test_iv <- gintervals(1, 1000, 1100) # multiple of 200, away from chrom 0
+    gsynth.score(
+        model = model, track = "zz_subchrom",
+        intervals = test_iv, resolution = 1, overwrite = TRUE
+    )
+    vals <- gextract("zz_subchrom",
+        intervals = test_iv, iterator = 1, colnames = "v"
+    )
+    expect_true(all(is.finite(vals$v)))
+})


### PR DESCRIPTION
## Summary

Adds `gsynth.score(model, track, ...)` — writes a misha fixed-bin dense
track whose value at each bin is the summed natural-log conditional
probability of the reference sequence under a trained `gsynth.model`:

\\[ T(a) = \sum_{i=a}^{a+r-1} \log P_M(\text{seq}[i] \mid \text{seq}[i-k..i-1], b(i)) \\]

Two models scored against the same reference give a per-window log
Bayes factor as a one-line track expression — the headline use case is
hotspot detection between two stratified Markov models (e.g.,
genome-baseline vs. CRE-class):

```r
gsynth.score(genome_model, "genome_score")
gsynth.score(cre_model,    "cre_score")
gextract("cre_score - genome_score", iterator = 200, ...)
```

## Design

Spec & plan: `dev/notes/2026-04-28_gsynth-score-{design,plan}.md`
(untracked per misha's `dev/`-gitignored convention).

Key decisions:
- **One model per call.** Composition (LLR) is downstream via track
  expressions; mirrors `gsynth.sample`'s shape.
- **C++ kernel writes the track directly** via
  `GenomeTrackFixedBin::init_write` / `write_next_bins` (the same writer
  `gtrack.create_dense` uses internally). This keeps `resolution = 1`
  whole-genome (~11 GB / track) feasible — peak memory per chrom is
  the read sequence buffer + a 10 K-bin write batch.
- **Boundary policy:** kernel reads `seq[max(0, start - k)..end)`, so
  the only NA from the boundary itself is the first `k` bp of each
  chromosome. Score is interval-position-invariant.
- **Strict NA propagation by default.** `n_policy="uniform"` and
  `sparse_policy="uniform"` give an opt-in `log(1/4)` fallback per bp,
  matching `gsynth.sample`'s sparse-bin uniform fallback.
- Per-bin `log_p` table is built in R from `model\$model_data\$cdf`
  (already pseudocounted at training time); the kernel performs only
  lookups.

## Files

- `R/synth.R` — new `gsynth.score()` (exported), private
  `.gsynth_build_log_p()` helper.
- `src/GenomeSynthScore.cpp` — new `C_gsynth_score` kernel.
- `src/misha-init.cpp` — register `C_gsynth_score`.
- `tests/testthat/test-gsynth-score.R` — 22 expectations across 6 tests.
- `man/gsynth.score.Rd`, `NAMESPACE`, `_pkgdown.yml` — docs.

No changes to existing public API.

## Test plan

- [x] `.gsynth_build_log_p` — round-trips the cdf
- [x] `gsynth.score` validates inputs (model, track, resolution)
- [x] End-to-end: track is created, queryable via `gextract`, first bin
      NA from chrom boundary, rest finite negative
- [x] Resolution invariance: `resolution=1` summed over 200 bp windows
      matches `resolution=200` to float precision
- [x] First k bp of chromosome are NA (k=5 case)
- [x] `sparse_policy="uniform"` replaces sparse-bin NaN with `log(1/4)`
      per bp; "NA" mode propagates NA strictly
- [x] LLR sanity between two models trained on the same data
- [x] Acceptance run on real cre_markov k=5 stratified models
      (genome vs. cutsite) on chr19:5–6 Mb at 200 bp: ~seconds per
      track, full coverage on real-sequence regions, NaN on assembly
      gaps, top hotspots at +7 to +11 nats LLR — exactly the
      hotspot-detection signal the function was designed for.

`devtools::test(filter = 'gsynth-score')` → 22 PASS / 0 FAIL.
`devtools::check(args = c('--no-manual', '--no-tests'))` → 0 errors;
warnings/notes pre-existing and unrelated.