### PR TITLE
feat(intervals): accept "+"/"-" character strand input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.21
+Version: 5.6.22
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.22
+
+* Intervals' `strand` column now accepts character (`"+"`, `"-"`, `"."`, `"*"`, `""`) or factor input in addition to numeric `1`/`-1`/`0`. Strings are normalized to the numeric convention at the R→C++ boundary; output stays numeric.
+
 # misha 5.6.21
 
 * Added `prior` argument to `gsynth.train()` (default `"marginal"`). Per-bin Dirichlet priors are now learned from the trainer's own counts by default, so unobserved (cell, k-mer-context) entries fall back to the cell's empirical base composition instead of uniform 1/4. Other modes: `"global"`, `NULL`/`"uniform"`, length-4 numeric, and `n_bins x 4` matrix.

--- a/R/intervals-core.R
+++ b/R/intervals-core.R
@@ -29,13 +29,27 @@
     }
 
     if (!is.null(strands)) {
-        if (!is.numeric(intervals$strand)) {
-            stop("Invalid strand values", call. = FALSE)
+        if (is.factor(intervals$strand)) {
+            intervals$strand <- as.character(intervals$strand)
         }
-
-        err.intervs <- intervals[intervals$strand != as.integer(intervals$strand) | intervals$strand < -1 | intervals$strand > 1, ]
-        if (nrow(err.intervs) > 0) {
-            stop(sprintf("Invalid strand value %g of interval (%s, %g, %g)", err.intervs$strand[1], err.intervs$chrom[1], err.intervs$start[1], err.intervs$end[1]))
+        if (is.character(intervals$strand)) {
+            mapped <- rep(NA_integer_, length(intervals$strand))
+            mapped[intervals$strand == "+"] <- 1L
+            mapped[intervals$strand == "-"] <- -1L
+            mapped[intervals$strand == "." | intervals$strand == "*" | intervals$strand == ""] <- 0L
+            bad <- is.na(mapped)
+            if (any(bad)) {
+                i <- which(bad)[1]
+                stop(sprintf("Invalid strand value \"%s\" of interval (%s, %g, %g)", intervals$strand[i], intervals$chrom[i], intervals$start[i], intervals$end[i]), call. = FALSE)
+            }
+            intervals$strand <- as.numeric(mapped)
+        } else if (!is.numeric(intervals$strand)) {
+            stop("Invalid strand values", call. = FALSE)
+        } else {
+            err.intervs <- intervals[intervals$strand != as.integer(intervals$strand) | intervals$strand < -1 | intervals$strand > 1, ]
+            if (nrow(err.intervs) > 0) {
+                stop(sprintf("Invalid strand value %g of interval (%s, %g, %g)", err.intervs$strand[1], err.intervs$chrom[1], err.intervs$start[1], err.intervs$end[1]))
+            }
         }
     }
 
@@ -78,13 +92,16 @@
 #'
 #' If 'strands' argument is not 'NULL' an additional column "strand" is added
 #' to the intervals. The possible values of a strand can be '1' (plus strand),
-#' '-1' (minus strand) or '0' (unknown).
+#' '-1' (minus strand) or '0' (unknown). Character values "+", "-", ".", "*"
+#' and "" (or factors with these levels) are also accepted and converted
+#' internally to '1', '-1' and '0' respectively.
 #'
 #' @param chroms chromosomes - an array of strings with or without "chr"
 #' prefixes or an array of integers (like: '1' for "chr1")
 #' @param starts an array of start coordinates
 #' @param ends an array of end coordinates. If '-1' chromosome size is assumed.
-#' @param strands 'NULL' or an array consisting of '-1', '0' or '1' values
+#' @param strands 'NULL', a numeric vector of '-1', '0' or '1' values, or a
+#' character/factor vector with values "+", "-", ".", "*" or ""
 #' @return A data frame representing the intervals.
 #' @seealso \code{\link{gintervals.2d}}, \code{\link{gintervals.force_range}}
 #' @keywords ~intervals

--- a/man/gintervals.Rd
+++ b/man/gintervals.Rd
@@ -14,7 +14,8 @@ prefixes or an array of integers (like: '1' for "chr1")}
 
 \item{ends}{an array of end coordinates. If '-1' chromosome size is assumed.}
 
-\item{strands}{'NULL' or an array consisting of '-1', '0' or '1' values}
+\item{strands}{'NULL', a numeric vector of '-1', '0' or '1' values, or a
+character/factor vector with values "+", "-", ".", "*" or ""}
 }
 \value{
 A data frame representing the intervals.
@@ -34,7 +35,9 @@ must be added after the three obligatory ones.
 
 If 'strands' argument is not 'NULL' an additional column "strand" is added
 to the intervals. The possible values of a strand can be '1' (plus strand),
-'-1' (minus strand) or '0' (unknown).
+'-1' (minus strand) or '0' (unknown). Character values "+", "-", ".", "*"
+and "" (or factors with these levels) are also accepted and converted
+internally to '1', '-1' and '0' respectively.
 }
 \examples{
 \dontshow{

--- a/src/GInterval.cpp
+++ b/src/GInterval.cpp
@@ -113,3 +113,16 @@ char GInterval::char2strand(char c)
 	return 0;
 }
 
+char GInterval::str2strand(const char *s)
+{
+	if (s == NULL || s[0] == '\0')
+		return 0;
+	if (s[1] == '\0') {
+		if (s[0] == '+') return 1;
+		if (s[0] == '-') return -1;
+		if (s[0] == '.' || s[0] == '*') return 0;
+	}
+	TGLError<GInterval>(BAD_STRAND, "Bad strand value \"%s\" (expected \"+\", \"-\", \".\", \"*\" or \"\")", s);
+	return 0;
+}
+

--- a/src/GInterval.h
+++ b/src/GInterval.h
@@ -72,6 +72,9 @@ struct GInterval : public Segment {
 
 	static char char2strand(char c);
 
+	// Parse a strand string: "+" -> 1, "-" -> -1, "."/"*"/"" -> 0. Errors on anything else.
+	static char str2strand(const char *s);
+
 	char *debug_str(const GenomeChromKey &chromkey) const {
 		static char str[200];
 		snprintf(str, sizeof(str), "(%s, %" PRId64 ", %" PRId64 ")", chromkey.id2chrom(chromid).c_str(), start, end);

--- a/src/IntervalConverter.cpp
+++ b/src/IntervalConverter.cpp
@@ -63,7 +63,8 @@ unsigned IntervalConverter::get_rintervs_type_mask(SEXP rintervals, const char *
 
 		for (int i = 0; i < Rf_length(rintervals); i++) {
 			if (!strcmp(CHAR(STRING_ELT(colnames, i)), "strand")) {
-				if (Rf_length(VECTOR_ELT(rintervals, i)) != Rf_length(VECTOR_ELT(rintervals, GInterval::CHROM)))
+				strands = VECTOR_ELT(rintervals, i);
+				if (Rf_length(strands) != Rf_length(VECTOR_ELT(rintervals, GInterval::CHROM)))
 					verror("%sNumber of rows in column %s differs than the number of rows in column strand", error_msg_prefix, GInterval::COL_NAMES[GInterval::CHROM]);
 				break;
 			}
@@ -74,7 +75,8 @@ unsigned IntervalConverter::get_rintervs_type_mask(SEXP rintervals, const char *
 				verror("%sNumber of rows in column %s differs than the number of rows in column %s", error_msg_prefix, GInterval::COL_NAMES[i - 1], GInterval::COL_NAMES[i]);
 		}
 
-		if ((!Rf_isReal(starts) && !Rf_isInteger(starts)) || (!Rf_isReal(ends) && !Rf_isInteger(ends)) || (strands != R_NilValue && !Rf_isReal(strands) && !Rf_isInteger(strands)))
+		if ((!Rf_isReal(starts) && !Rf_isInteger(starts)) || (!Rf_isReal(ends) && !Rf_isInteger(ends)) ||
+			(strands != R_NilValue && !Rf_isReal(strands) && !Rf_isInteger(strands) && !Rf_isString(strands) && !Rf_isFactor(strands)))
 			verror("%sInvalid format of intervals argument", error_msg_prefix);
 
 	} else if (type == rdb::IntervUtils::INTERVS2D) {
@@ -308,6 +310,12 @@ SEXP IntervalConverter::convert_rintervs(SEXP rintervals, GIntervals *intervals,
 			}
 		}
 
+		SEXP strand_levels = R_NilValue;
+		bool strands_is_string = strands != R_NilValue && Rf_isString(strands);
+		bool strands_is_factor = strands != R_NilValue && Rf_isFactor(strands);
+		if (strands_is_factor)
+			strand_levels = Rf_getAttrib(strands, R_LevelsSymbol);
+
 		for (unsigned i = 0; i < num_intervals; i++) {
 			if ((Rf_isFactor(chroms) && INTEGER(chroms)[i] < 0) ||
 				(Rf_isReal(starts) && std::isnan(REAL(starts)[i])) || (Rf_isReal(ends) && std::isnan(REAL(ends)[i])) ||
@@ -328,8 +336,21 @@ SEXP IntervalConverter::convert_rintervs(SEXP rintervals, GIntervals *intervals,
 			int64_t end = (int64_t)(Rf_isReal(ends) ? REAL(ends)[i] : INTEGER(ends)[i]);
 			char strand = 0;
 
-			if (strands != R_NilValue)
-				strand = (char)(Rf_isReal(strands) ? REAL(strands)[i] : INTEGER(strands)[i]);
+			if (strands != R_NilValue) {
+				if (strands_is_string) {
+					SEXP elt = STRING_ELT(strands, i);
+					if (elt == NA_STRING)
+						verror("%sInvalid strand value (NA) at index %d", error_msg_prefix, i + 1);
+					strand = GInterval::str2strand(CHAR(elt));
+				} else if (strands_is_factor) {
+					int level_idx = INTEGER(strands)[i];
+					if (level_idx == NA_INTEGER)
+						verror("%sInvalid strand value (NA) at index %d", error_msg_prefix, i + 1);
+					strand = GInterval::str2strand(CHAR(STRING_ELT(strand_levels, level_idx - 1)));
+				} else {
+					strand = (char)(Rf_isReal(strands) ? REAL(strands)[i] : INTEGER(strands)[i]);
+				}
+			}
 
 			GInterval interval(chromid, start, end, strand, (void *)(intptr_t)i);
 

--- a/tests/testthat/test-character-strand.R
+++ b/tests/testthat/test-character-strand.R
@@ -1,0 +1,70 @@
+create_isolated_test_db()
+
+test_that("gintervals accepts +/- character strand", {
+    num <- gintervals(c(1, 1, 1), c(0, 100, 200), c(50, 150, 250), c(1, -1, 0))
+    chr <- gintervals(c(1, 1, 1), c(0, 100, 200), c(50, 150, 250), c("+", "-", "."))
+    expect_equal(num, chr)
+})
+
+test_that("gintervals accepts factor strand", {
+    num <- gintervals(c(1, 1, 1), c(0, 100, 200), c(50, 150, 250), c(1, -1, 0))
+    fac <- gintervals(
+        c(1, 1, 1), c(0, 100, 200), c(50, 150, 250),
+        factor(c("+", "-", "."), levels = c("+", "-", ".", "*"))
+    )
+    expect_equal(num, fac)
+})
+
+test_that("gintervals accepts unknown-strand variants .,*,'' as 0", {
+    res <- gintervals(c(1, 1, 1), c(0, 100, 200), c(50, 150, 250), c(".", "*", ""))
+    expect_equal(res$strand, c(0, 0, 0))
+})
+
+test_that("gintervals rejects garbage strand strings", {
+    expect_error(
+        gintervals(c(1, 1), c(0, 100), c(50, 150), c("+", "foo")),
+        "Invalid strand value"
+    )
+})
+
+test_that("gintervals rejects strand integer outside {-1,0,1}", {
+    expect_error(
+        gintervals(c(1, 1), c(0, 100), c(50, 150), c(1, 2)),
+        "Invalid strand value"
+    )
+})
+
+test_that("data.frame with character strand flows through C++ converter", {
+    df_num <- data.frame(
+        chrom = "chr1", start = c(0L, 1000L, 2000L), end = c(500L, 1500L, 2500L),
+        strand = c(1, -1, 0)
+    )
+    df_chr <- df_num
+    df_chr$strand <- c("+", "-", ".")
+
+    # gintervals.canonic flows through convert_rintervs in C++; both inputs must
+    # produce identical output once the strand column has been normalized.
+    out_num <- gintervals.canonic(df_num)
+    out_chr <- gintervals.canonic(df_chr)
+    expect_equal(out_num, out_chr)
+})
+
+test_that("gintervals.neighbors accepts character strand", {
+    intervs1 <- data.frame(
+        chrom = "chr1", start = c(1000L, 5000L), end = c(1100L, 5100L),
+        strand = c("+", "-"), stringsAsFactors = FALSE
+    )
+    intervs2 <- data.frame(
+        chrom = "chr1", start = c(2000L, 4000L), end = c(2100L, 4100L),
+        strand = c("+", "-"), stringsAsFactors = FALSE
+    )
+    expect_silent(suppressWarnings(gintervals.neighbors(intervs1, intervs2, 1)))
+})
+
+test_that("data.frame with character strand reports invalid value via C++", {
+    df <- data.frame(
+        chrom = "chr1", start = c(0L, 1000L), end = c(500L, 1500L),
+        strand = c("+", "wat"), stringsAsFactors = FALSE
+    )
+    expect_error(gintervals.canonic(df), "Bad strand")
+})


### PR DESCRIPTION
## Summary

- Intervals' `strand` column now accepts character (`"+"`, `"-"`, `"."`, `"*"`, `""`) or factor input in addition to the existing numeric `1`/`-1`/`0` convention.
- Coercion happens at the R→C++ boundary in `IntervalConverter::convert_rintervs` (string and factor branches use the new `GInterval::str2strand` helper). Output of misha functions continues to return numeric strand — this is input-only tolerance, no changes to on-disk format or downstream contracts.
- `R/intervals-core.R::.gintervals()` accepts character/factor strands and normalizes them to numeric before the rest of the pipeline; garbage strings produce a clear error.
- Drive-by: `get_rintervs_type_mask` had a dead-code bug where `strands` was declared but never assigned, so the strand-type guard never fired. It is now wired up properly and broadened to allow `STRSXP`/factor.

## Test plan

- [x] `R -e 'devtools::test(filter = "character-strand")'` — 8/8 pass
- [x] Wider parallel sweep across `intervals|character-strand|directional|gscreen|gextract1` — all green
- [x] `pkgbuild::clean_dll(); pkgbuild::compile_dll()` — clean build, no new warnings
- [ ] CI green