### PR TITLE
feat(gtrack.copy): cross-db copy with format and chrom-order remap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # misha 5.6.23
 
+* `gtrack.copy()` gained a `db` argument to copy tracks across databases,
+  and `overwrite` to replace existing destinations. Format conversion
+  (per-chromosome ↔ indexed) and chromosome-order remap are handled
+  automatically. Multi-track input is also supported.
 * Improved error messages: "start exceeds or equals to end" now mentions misha's 0-based half-open convention and the GFF/VCF 1-based hint; "chromosome does not exist" lists known chromosomes and points to `CHROM_ALIAS`.
 * C++ converter now emits an R warning ("N intervals had start == end and were extended by 1bp") when zero-length intervals from a loaded file are auto-bumped — previously this happened silently.
 * Added `gintervals.import_bed()`, `gintervals.import_gff()`, `gintervals.import_vcf()` for direct import from common interval file formats. All three normalize chromosome names via the existing `CHROM_ALIAS` mechanism (so `chr1` ↔ `1` works), apply misha's 0-based half-open convention (subtracting 1 from start for the 1-based GFF/GTF/VCF inputs), and preserve common metadata columns (`name`/`score`/`strand` for BED; `type`/`source`/`score`/`attrs` for GFF; `id`/`ref`/`alt`/`qual`/`filter`/`info` for VCF).

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,10 @@
 
 # misha 5.6.23
 
+* `gtrack.copy()` gained a `db` argument to copy tracks across databases,
+  and `overwrite` to replace existing destinations. Format conversion
+  (per-chromosome ↔ indexed) and chromosome-order remap are handled
+  automatically. Multi-track input is also supported.
 * Improved error messages: "start exceeds or equals to end" now mentions misha's 0-based half-open convention and the GFF/VCF 1-based hint; "chromosome does not exist" lists known chromosomes and points to `CHROM_ALIAS`.
 * C++ converter now emits an R warning ("N intervals had start == end and were extended by 1bp") when zero-length intervals from a loaded file are auto-bumped — previously this happened silently.
 * Added `gintervals.import_bed()`, `gintervals.import_gff()`, `gintervals.import_vcf()` for direct import from common interval file formats. All three normalize chromosome names via the existing `CHROM_ALIAS` mechanism (so `chr1` ↔ `1` works), apply misha's 0-based half-open convention (subtracting 1 from start for the 1-based GFF/GTF/VCF inputs), and preserve common metadata columns (`name`/`score`/`strand` for BED; `type`/`source`/`score`/`attrs` for GFF; `id`/`ref`/`alt`/`qual`/`filter`/`info` for VCF).

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -650,7 +650,7 @@ gdb.mark_cache_dirty <- function() {
 # Names of files that live inside a track directory but are not per-chromosome
 # data: the indexed-format pair, attribute/var sidecars, and the meta file used
 # by big interval sets. Keep in sync with src/ when adding new sidecar files.
-.TRACK_INTERNAL_FILES <- c("track.idx", "track.dat", ".attrs", ".vars", ".meta")
+.TRACK_INTERNAL_FILES <- c("track.idx", "track.dat", ".attributes", "vars", ".meta")
 
 # Check whether a database at the given path is in indexed format.
 # Unlike .gdb.is_indexed(), does not depend on the loaded GROOT.

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -661,15 +661,18 @@ gdb.mark_cache_dirty <- function() {
         file.exists(file.path(seq_dir, "genome.seq"))
 }
 
-# Read chromosome names (in declaration order) from a db's chrom_sizes.txt.
+# Read chromosome names verbatim from chrom_sizes.txt (no "chr" prefix
+# normalization), in declaration order. Callers that need normalization
+# must apply it themselves.
 .gdb.chrom_names_at <- function(groot) {
     cs <- file.path(groot, "chrom_sizes.txt")
     if (!file.exists(cs)) {
         stop(sprintf("chrom_sizes.txt missing in %s", groot), call. = FALSE)
     }
-    df <- utils::read.table(cs,
-        header = FALSE, stringsAsFactors = FALSE,
-        col.names = c("chrom", "size")
+    df <- utils::read.table(
+        cs,
+        header = FALSE, sep = "\t",
+        stringsAsFactors = FALSE, col.names = c("chrom", "size")
     )
-    as.character(df$chrom)
+    df$chrom
 }

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -677,7 +677,9 @@ gdb.mark_cache_dirty <- function() {
     df <- utils::read.table(
         cs,
         header = FALSE, sep = "\t",
-        stringsAsFactors = FALSE, col.names = c("chrom", "size")
+        stringsAsFactors = FALSE,
+        colClasses = c("character", "integer"),
+        col.names = c("chrom", "size")
     )
     df$chrom
 }

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -647,6 +647,11 @@ gdb.mark_cache_dirty <- function() {
     invisible(.gdb.cache_mark_dirty())
 }
 
+# Names of files that live inside a track directory but are not per-chromosome
+# data: the indexed-format pair, attribute/var sidecars, and the meta file used
+# by big interval sets. Keep in sync with src/ when adding new sidecar files.
+.TRACK_INTERNAL_FILES <- c("track.idx", "track.dat", ".attrs", ".vars", ".meta")
+
 # Check whether a database at the given path is in indexed format.
 # Unlike .gdb.is_indexed(), does not depend on the loaded GROOT.
 .gdb.is_indexed_at <- function(groot) {

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -646,3 +646,30 @@ gdb.mark_cache_dirty <- function() {
     .gcheckroot()
     invisible(.gdb.cache_mark_dirty())
 }
+
+# Check whether a database at the given path is in indexed format.
+# Unlike .gdb.is_indexed(), does not depend on the loaded GROOT.
+.gdb.is_indexed_at <- function(groot) {
+    if (is.null(groot) || !nzchar(groot)) {
+        return(FALSE)
+    }
+    seq_dir <- file.path(groot, "seq")
+    if (!dir.exists(seq_dir)) {
+        return(FALSE)
+    }
+    file.exists(file.path(seq_dir, "genome.idx")) &&
+        file.exists(file.path(seq_dir, "genome.seq"))
+}
+
+# Read chromosome names (in declaration order) from a db's chrom_sizes.txt.
+.gdb.chrom_names_at <- function(groot) {
+    cs <- file.path(groot, "chrom_sizes.txt")
+    if (!file.exists(cs)) {
+        stop(sprintf("chrom_sizes.txt missing in %s", groot), call. = FALSE)
+    }
+    df <- utils::read.table(cs,
+        header = FALSE, stringsAsFactors = FALSE,
+        col.names = c("chrom", "size")
+    )
+    as.character(df$chrom)
+}

--- a/R/db-index.R
+++ b/R/db-index.R
@@ -991,6 +991,15 @@ gtrack.convert_to_indexed <- function(track = NULL) {
     invisible(0)
 }
 
+.gtrack.split_indexed_to_per_chrom <- function(track_dir, chrom_names, remove_indexed = TRUE) {
+    .gcall(
+        "gtrack_split_indexed_to_per_chrom",
+        track_dir, as.character(chrom_names), isTRUE(remove_indexed),
+        .misha_env()
+    )
+    invisible()
+}
+
 #' Convert 1D interval set to indexed format
 #'
 #' Converts a per-chromosome interval set to indexed format

--- a/R/db-index.R
+++ b/R/db-index.R
@@ -1003,6 +1003,18 @@ gtrack.convert_to_indexed <- function(track = NULL) {
     invisible()
 }
 
+.gtrack.pack_per_chrom_to_indexed <- function(track_dir, chrom_names, track_type) {
+    if (!dir.exists(track_dir)) {
+        stop(sprintf("Track directory does not exist: %s", track_dir), call. = FALSE)
+    }
+    .gcall(
+        "gtrack_pack_per_chrom_to_indexed",
+        track_dir, as.character(chrom_names), as.character(track_type),
+        .misha_env()
+    )
+    invisible()
+}
+
 #' Convert 1D interval set to indexed format
 #'
 #' Converts a per-chromosome interval set to indexed format

--- a/R/db-index.R
+++ b/R/db-index.R
@@ -992,6 +992,9 @@ gtrack.convert_to_indexed <- function(track = NULL) {
 }
 
 .gtrack.split_indexed_to_per_chrom <- function(track_dir, chrom_names, remove_indexed = TRUE) {
+    if (!dir.exists(track_dir)) {
+        stop(sprintf("Track directory does not exist: %s", track_dir), call. = FALSE)
+    }
     .gcall(
         "gtrack_split_indexed_to_per_chrom",
         track_dir, as.character(chrom_names), isTRUE(remove_indexed),

--- a/R/track-management.R
+++ b/R/track-management.R
@@ -396,6 +396,11 @@ gtrack.mv <- function(src = NULL, dest = NULL) {
 #' Chromosomes that exist in the source database but not in the destination
 #' are dropped with a warning.
 #'
+#' @details
+#' For 2D tracks (rectangles, points), cross-database copy requires identical
+#' chromosome order in source and destination. Format conversion (per-chromosome
+#' to indexed) is supported only when the destination is the active database.
+#'
 #' @param src source track name(s). Either a single name or a character
 #'   vector of names.
 #' @param dest destination name. If \code{src} is a single name, this is the
@@ -575,7 +580,17 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
         if (!file.copy(src_dir, dest_dir, copy.mode = TRUE)) {
             stop(sprintf("Failed to copy %s to %s", srcname, destname), call. = FALSE)
         }
-        .gdb.add_track(destname, dest_db)
+        groot <- get("GROOT", envir = .misha)
+        gdatasets <- get("GDATASETS", envir = .misha)
+        if (is.null(gdatasets)) gdatasets <- character(0)
+        if (dest_db %in% c(groot, gdatasets)) {
+            .gdb.add_track(destname, dest_db)
+        } else {
+            # Cross-db copy to an unloaded path: skip in-memory registration to
+            # avoid state leakage; mark the dest db's cache dirty so a later
+            # gsetroot/gdataset.load will pick up the new track on rescan.
+            .gdb.cache_mark_dirty(dest_db)
+        }
         return(destname)
     }
 
@@ -586,7 +601,18 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
     if (!dir.create(dest_dir, showWarnings = FALSE) && !dir.exists(dest_dir)) {
         stop(sprintf("Failed to create %s", dest_dir), call. = FALSE)
     }
-    .gdb.add_track(destname, dest_db)
+    groot <- get("GROOT", envir = .misha)
+    gdatasets <- get("GDATASETS", envir = .misha)
+    if (is.null(gdatasets)) gdatasets <- character(0)
+    dest_db_loaded <- dest_db %in% c(groot, gdatasets)
+    if (dest_db_loaded) {
+        .gdb.add_track(destname, dest_db)
+    } else {
+        # Cross-db copy to an unloaded path: skip in-memory registration to
+        # avoid state leakage; mark the dest db's cache dirty so a later
+        # gsetroot/gdataset.load will pick up the new track on rescan.
+        .gdb.cache_mark_dirty(dest_db)
+    }
     tryCatch(
         .gtrack.copy.pipeline(
             src_dir, dest_dir, src_chroms, dest_chroms,
@@ -598,7 +624,9 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
             # Order matters: .gdb.rm_track only updates caches when the trackdir
             # is gone, so unlink first.
             unlink(dest_dir, recursive = TRUE)
-            .gdb.rm_track(destname, db = dest_db)
+            if (dest_db_loaded) {
+                .gdb.rm_track(destname, db = dest_db)
+            }
             stop(e)
         }
     )

--- a/R/track-management.R
+++ b/R/track-management.R
@@ -493,10 +493,23 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
     gdatasets <- get("GDATASETS", envir = .misha)
     if (is.null(gdatasets)) gdatasets <- character(0)
     if (!(db %in% c(groot, gdatasets))) {
-        stop(sprintf(
-            "Destination db %s is not the current GROOT and not a loaded dataset; load it with gdataset.load() first.",
-            db
-        ), call. = FALSE)
+        # Cross-genome destinations cannot be loaded via gdataset.load() (which
+        # enforces matching chrom_sizes.txt). For gtrack.copy we only require
+        # the destination to look like a valid misha db: chrom_sizes.txt and
+        # tracks/ must exist. Other invariants (chrom names, indexed format)
+        # are picked up by the pipeline.
+        if (!file.exists(file.path(db, "chrom_sizes.txt"))) {
+            stop(sprintf(
+                "Destination db %s does not contain a chrom_sizes.txt file.",
+                db
+            ), call. = FALSE)
+        }
+        if (!dir.exists(file.path(db, "tracks"))) {
+            stop(sprintf(
+                "Destination db %s does not contain a tracks/ directory.",
+                db
+            ), call. = FALSE)
+        }
     }
     db
 }
@@ -671,6 +684,24 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
         ), call. = FALSE)
     }
 
+    # Canonicalize remaining per-chrom filenames to dest's preferred form.
+    # After the drop pass, surviving files may be named by src's convention
+    # (e.g. "chr1") while dest expects another (e.g. "1"). Rename so the
+    # pack helper or downstream readers find them.
+    remaining <- setdiff(list.files(dest_dir, full.names = FALSE), internal)
+    for (f in remaining) {
+        canonical <- .gtrack.copy.match_chrom_alias(f, dest_chroms)
+        if (!is.null(canonical) && canonical != f) {
+            ok <- file.rename(file.path(dest_dir, f), file.path(dest_dir, canonical))
+            if (!ok) {
+                stop(sprintf(
+                    "Failed to rename %s -> %s in %s",
+                    f, canonical, dest_dir
+                ), call. = FALSE)
+            }
+        }
+    }
+
     if (dest_indexed) {
         if (track_type %in% c("dense", "sparse", "array")) {
             .gtrack.pack_per_chrom_to_indexed(dest_dir, dest_chroms, track_type)
@@ -699,6 +730,28 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
             stop(sprintf("Failed to copy %s into %s", item, dest_dir), call. = FALSE)
         }
     }
+}
+
+# Given a per-chrom filename and the destination's chrom list, return the
+# destination chrom name that this file represents (tolerating chr-prefix
+# variation). Returns NULL if no match.
+.gtrack.copy.match_chrom_alias <- function(filename, dest_chroms) {
+    if (filename %in% dest_chroms) {
+        return(filename)
+    }
+    # Try toggling the "chr" prefix
+    if (startsWith(filename, "chr")) {
+        stripped <- substring(filename, 4)
+        if (stripped %in% dest_chroms) {
+            return(stripped)
+        }
+    } else {
+        prefixed <- paste0("chr", filename)
+        if (prefixed %in% dest_chroms) {
+            return(prefixed)
+        }
+    }
+    NULL
 }
 
 # Temporarily switch GWD to the given db's tracks/ for the duration of fn().

--- a/R/track-management.R
+++ b/R/track-management.R
@@ -429,18 +429,25 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
 
     # Resolve src names: support both unquoted single name (back-compat) and
     # character vectors.
-    if (is.character(src) && length(src) > 1) {
-        srcnames <- src
-    } else if (is.character(src)) {
+    if (is.character(src)) {
         srcnames <- src
     } else {
         srcnames <- do.call(.gexpr2str, list(substitute(src)), envir = parent.frame())
+    }
+
+    if (length(srcnames) == 0) {
+        return(invisible(character(0)))
     }
 
     if (is.null(dest)) {
         destnames <- srcnames
     } else if (length(srcnames) == 1) {
         destnames <- if (is.character(dest)) {
+            if (length(dest) != 1) {
+                stop("When copying a single track, 'dest' must be a single name or NULL.",
+                    call. = FALSE
+                )
+            }
             dest
         } else {
             do.call(.gexpr2str, list(substitute(dest)), envir = parent.frame())
@@ -451,7 +458,8 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
                 call. = FALSE
             )
         }
-        destnames <- paste(dest, srcnames, sep = ".")
+        prefix <- sub("\\.+$", "", dest)
+        destnames <- paste(prefix, srcnames, sep = ".")
     }
 
     dest_db <- .gtrack.copy.resolve_dest_db(db)
@@ -556,11 +564,29 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
         return(destname)
     }
 
-    .gtrack.copy.pipeline(
-        src_dir, dest_dir, src_chroms, dest_chroms,
-        src_indexed, dest_indexed, info$type, destname, dest_db
-    )
+    # Register destination first so convert-to-indexed (called inside pipeline)
+    # can find it in GTRACKS. .gdb.add_track only registers if the trackdir
+    # already exists, so create it now -- .gtrack.copy.raw_dir tolerates a
+    # pre-existing empty dest_dir.
+    if (!dir.create(dest_dir, showWarnings = FALSE) && !dir.exists(dest_dir)) {
+        stop(sprintf("Failed to create %s", dest_dir), call. = FALSE)
+    }
     .gdb.add_track(destname, dest_db)
+    tryCatch(
+        .gtrack.copy.pipeline(
+            src_dir, dest_dir, src_chroms, dest_chroms,
+            src_indexed, dest_indexed, info$type, destname, dest_db
+        ),
+        error = function(e) {
+            # Roll back the registration if the pipeline failed; the dest dir may
+            # still exist but is in an inconsistent state -- best-effort cleanup.
+            # Order matters: .gdb.rm_track only updates caches when the trackdir
+            # is gone, so unlink first.
+            unlink(dest_dir, recursive = TRUE)
+            .gdb.rm_track(destname, db = dest_db)
+            stop(e)
+        }
+    )
     destname
 }
 
@@ -613,7 +639,7 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
             paste0("chr", dest_chroms)
         )
     ))
-    internal <- c("track.idx", "track.dat", ".attrs", ".vars", ".meta")
+    internal <- .TRACK_INTERNAL_FILES
     candidates_for_drop <- setdiff(files_in_dir, internal)
     dropped <- candidates_for_drop[!(candidates_for_drop %in% dest_with_variants)]
     if (length(dropped) > 0) {
@@ -622,6 +648,18 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
             destname, paste(dropped, collapse = ", ")
         ), call. = FALSE)
         for (f in dropped) unlink(file.path(dest_dir, f))
+    }
+
+    remaining_per_chrom_files <- setdiff(
+        list.files(dest_dir, full.names = FALSE),
+        internal
+    )
+    if (length(candidates_for_drop) > 0 && length(remaining_per_chrom_files) == 0) {
+        unlink(dest_dir, recursive = TRUE)
+        stop(sprintf(
+            "gtrack.copy(%s): no chromosomes from source database are present in destination; refusing to create empty track.",
+            destname
+        ), call. = FALSE)
     }
 
     if (dest_indexed) {

--- a/R/track-management.R
+++ b/R/track-management.R
@@ -527,23 +527,25 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
         stop(sprintf("Source and destination are the same track: %s", srcname), call. = FALSE)
     }
 
-    # Check destination existence
-    existing_db <- .gtrack_db_path(destname)
-    if (!is.null(existing_db) && identical(existing_db, dest_db)) {
+    src_dir <- .track_dir(srcname)
+    dest_dir <- file.path(dest_db, "tracks", paste0(gsub("\\.", "/", destname), ".track"))
+    dest_parent <- dirname(dest_dir)
+    if (!dir.exists(dest_parent)) {
+        dir.create(dest_parent, recursive = TRUE, showWarnings = FALSE)
+    }
+
+    # Use the filesystem as the source of truth for "destination already exists".
+    # An in-memory cache check is fragile when dest_db is not in GDATASETS.
+    if (dir.exists(dest_dir)) {
         if (!overwrite) {
             stop(sprintf(
                 "Track %s already exists in %s; use overwrite=TRUE to replace.",
                 destname, dest_db
             ), call. = FALSE)
         }
-        gtrack.rm(destname, force = TRUE, db = dest_db)
-    }
-
-    src_dir <- .track_dir(srcname)
-    dest_dir <- file.path(dest_db, "tracks", paste0(gsub("\\.", "/", destname), ".track"))
-    dest_parent <- dirname(dest_dir)
-    if (!dir.exists(dest_parent)) {
-        dir.create(dest_parent, recursive = TRUE, showWarnings = FALSE)
+        # Bypass gtrack.rm (which insists db is loaded) and clean up directly.
+        unlink(dest_dir, recursive = TRUE)
+        .gdb.rm_track(destname, trackdir = dest_dir, db = dest_db)
     }
 
     src_indexed <- file.exists(file.path(src_dir, "track.idx"))

--- a/R/track-management.R
+++ b/R/track-management.R
@@ -615,6 +615,15 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
         }
         .gtrack.copy.raw_dir(src_dir, dest_dir)
         if (dest_indexed && !src_indexed) {
+            # gtrack.2d.convert_to_indexed reads GROOT directly in C++, so it
+            # only works when dest_db is the active database. Cross-db 2D
+            # conversion is a follow-up.
+            if (dest_db != get("GROOT", envir = .misha)) {
+                stop(sprintf(
+                    "Cross-db copy of 2D track %s with format conversion to a non-active dataset is not yet supported.",
+                    destname
+                ), call. = FALSE)
+            }
             .with_db_context(dest_db, function() {
                 gtrack.2d.convert_to_indexed(destname, remove.old = TRUE)
             })
@@ -663,7 +672,17 @@ gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
     }
 
     if (dest_indexed) {
-        .with_db_context(dest_db, function() gtrack.convert_to_indexed(destname))
+        if (track_type %in% c("dense", "sparse", "array")) {
+            .gtrack.pack_per_chrom_to_indexed(dest_dir, dest_chroms, track_type)
+        } else {
+            # 2D types: fall back to the existing path. The 2D code currently has the
+            # same GROOT-coupling caveat as the 1D path; for now require dest_db == GROOT
+            # for 2D indexed conversion.
+            stop(sprintf(
+                "Cross-db copy of 2D track %s with format conversion to a non-active dataset is not yet supported.",
+                destname
+            ), call. = FALSE)
+        }
     }
     invisible()
 }

--- a/R/track-management.R
+++ b/R/track-management.R
@@ -387,19 +387,28 @@ gtrack.mv <- function(src = NULL, dest = NULL) {
     invisible()
 }
 
-#' Copies a track
+#' Copies one or more tracks
 #'
-#' Creates a copy of an existing track.
+#' Creates a copy of an existing track, optionally to a different database.
+#' Transparently handles format mismatches (per-chromosome vs indexed) and
+#' chromosome-order differences between source and destination databases.
 #'
-#' This function creates a copy of a track. The new track is created in the
-#' current working directory (.misha$GWD), which may be in a different database than
-#' the source track when multiple databases are connected.
+#' Chromosomes that exist in the source database but not in the destination
+#' are dropped with a warning.
 #'
-#' @param src source track name
-#' @param dest destination track name
-#' @return None.
-#' @seealso \code{\link{gtrack.mv}}, \code{\link{gtrack.rm}},
-#' \code{\link{gtrack.exists}}, \code{\link{gtrack.ls}}
+#' @param src source track name(s). Either a single name or a character
+#'   vector of names.
+#' @param dest destination name. If \code{src} is a single name, this is the
+#'   destination track name (defaults to \code{src}). If \code{src} is a
+#'   vector, \code{dest} is treated as a namespace prefix (e.g. \code{"ns"}
+#'   produces \code{"ns.track1"}, \code{"ns.track2"}, ...). NULL keeps each
+#'   track's name.
+#' @param db destination database root. Must be the current \code{GROOT} or a
+#'   member of \code{GDATASETS}. NULL means the current working directory db.
+#' @param overwrite if TRUE, replace an existing destination track.
+#'
+#' @return invisibly, the character vector of created track names.
+#' @seealso \code{\link{gtrack.mv}}, \code{\link{gtrack.rm}}
 #' @keywords ~track
 #' @examples
 #' \dontshow{
@@ -412,76 +421,240 @@ gtrack.mv <- function(src = NULL, dest = NULL) {
 #' gtrack.rm("dense_track_copy", force = TRUE)
 #'
 #' @export gtrack.copy
-gtrack.copy <- function(src = NULL, dest = NULL) {
-    if (is.null(substitute(src)) || is.null(substitute(dest))) {
-        stop("Usage: gtrack.copy(src, dest)", call. = FALSE)
+gtrack.copy <- function(src = NULL, dest = NULL, db = NULL, overwrite = FALSE) {
+    if (is.null(substitute(src))) {
+        stop("Usage: gtrack.copy(src, dest = NULL, db = NULL, overwrite = FALSE)", call. = FALSE)
     }
     .gcheckroot()
 
-    srcname <- do.call(.gexpr2str, list(substitute(src)), envir = parent.frame())
-    destname <- do.call(.gexpr2str, list(substitute(dest)), envir = parent.frame())
-
-    if (srcname == destname) {
-        stop("Source and destination track names are the same", call. = FALSE)
+    # Resolve src names: support both unquoted single name (back-compat) and
+    # character vectors.
+    if (is.character(src) && length(src) > 1) {
+        srcnames <- src
+    } else if (is.character(src)) {
+        srcnames <- src
+    } else {
+        srcnames <- do.call(.gexpr2str, list(substitute(src)), envir = parent.frame())
     }
 
-    # Check source exists
+    if (is.null(dest)) {
+        destnames <- srcnames
+    } else if (length(srcnames) == 1) {
+        destnames <- if (is.character(dest)) {
+            dest
+        } else {
+            do.call(.gexpr2str, list(substitute(dest)), envir = parent.frame())
+        }
+    } else {
+        if (!is.character(dest) || length(dest) != 1) {
+            stop("When copying multiple tracks, 'dest' must be a single namespace prefix or NULL.",
+                call. = FALSE
+            )
+        }
+        destnames <- paste(dest, srcnames, sep = ".")
+    }
+
+    dest_db <- .gtrack.copy.resolve_dest_db(db)
+    .gcheck_write_permission(file.path(dest_db, "tracks"), "copy track to")
+
+    created <- character(0)
+    for (i in seq_along(srcnames)) {
+        created <- c(created, .gtrack.copy.one(srcnames[i], destnames[i], dest_db, overwrite))
+    }
+
+    invisible(created)
+}
+
+# Resolve the destination db path. NULL -> the db that owns the current GWD.
+# Otherwise validate that the explicit path is loaded.
+.gtrack.copy.resolve_dest_db <- function(db) {
+    if (is.null(db)) {
+        gwd <- get("GWD", envir = .misha)
+        groot <- get("GROOT", envir = .misha)
+        gdatasets <- get("GDATASETS", envir = .misha)
+        if (is.null(gdatasets)) gdatasets <- character(0)
+        for (g in c(groot, gdatasets)) {
+            if (.gpath_is_within(gwd, file.path(g, "tracks"))) {
+                return(g)
+            }
+        }
+        return(groot)
+    }
+    db <- normalizePath(db, mustWork = TRUE)
+    groot <- get("GROOT", envir = .misha)
+    gdatasets <- get("GDATASETS", envir = .misha)
+    if (is.null(gdatasets)) gdatasets <- character(0)
+    if (!(db %in% c(groot, gdatasets))) {
+        stop(sprintf(
+            "Destination db %s is not the current GROOT and not a loaded dataset; load it with gdataset.load() first.",
+            db
+        ), call. = FALSE)
+    }
+    db
+}
+
+# Copy a single track. Returns the destination track name on success.
+.gtrack.copy.one <- function(srcname, destname, dest_db, overwrite) {
     if (!(srcname %in% get("GTRACKS", envir = .misha))) {
         stop(sprintf("Track %s does not exist", srcname), call. = FALSE)
     }
 
-    # Check destination doesn't exist
-    if (destname %in% get("GTRACKS", envir = .misha)) {
-        stop(sprintf("Track %s already exists", destname), call. = FALSE)
+    src_db <- .gtrack_db_path(srcname)
+    if (is.null(src_db)) src_db <- get("GROOT", envir = .misha)
+
+    if (srcname == destname && identical(src_db, dest_db)) {
+        stop(sprintf("Source and destination are the same track: %s", srcname), call. = FALSE)
+    }
+
+    # Check destination existence
+    existing_db <- .gtrack_db_path(destname)
+    if (!is.null(existing_db) && identical(existing_db, dest_db)) {
+        if (!overwrite) {
+            stop(sprintf(
+                "Track %s already exists in %s; use overwrite=TRUE to replace.",
+                destname, dest_db
+            ), call. = FALSE)
+        }
+        gtrack.rm(destname, force = TRUE, db = dest_db)
     }
 
     src_dir <- .track_dir(srcname)
-
-    # Destination is in current GWD (may be different database)
-    gwd <- get("GWD", envir = .misha)
-    dest_dir <- file.path(gwd, paste0(gsub("\\.", "/", destname), ".track"))
-
-    # Check write permission for destination
-    .gcheck_write_permission(gwd, "copy track to")
-
-    # Create destination parent directory if needed
+    dest_dir <- file.path(dest_db, "tracks", paste0(gsub("\\.", "/", destname), ".track"))
     dest_parent <- dirname(dest_dir)
     if (!dir.exists(dest_parent)) {
         dir.create(dest_parent, recursive = TRUE, showWarnings = FALSE)
     }
 
-    # Create destination directory
-    if (!dir.create(dest_dir, showWarnings = FALSE)) {
-        if (!dir.exists(dest_dir)) {
-            stop(sprintf("Failed to create destination directory for track %s", destname), call. = FALSE)
-        }
+    src_indexed <- file.exists(file.path(src_dir, "track.idx"))
+    dest_indexed <- .gdb.is_indexed_at(dest_db)
+    src_chroms <- .gdb.chrom_names_at(src_db)
+    dest_chroms <- .gdb.chrom_names_at(dest_db)
+
+    info <- gtrack.info(srcname)
+
+    # 2D track guard
+    if (info$type %in% c("rectangles", "points") &&
+        !identical(src_chroms, dest_chroms)) {
+        stop(sprintf(
+            "Cross-db copy of 2D track %s requires identical chromosome order in source and destination.",
+            srcname
+        ), call. = FALSE)
     }
 
-    # Copy contents of source track to destination
-    src_contents <- list.files(src_dir, full.names = TRUE, all.files = TRUE, no.. = TRUE)
-    for (item in src_contents) {
+    # Legacy single-file (1D) tracks: refuse if dest is indexed
+    if (info$type %in% c("dense", "sparse", "array") && !dir.exists(src_dir)) {
+        if (dest_indexed) {
+            stop(sprintf(
+                "Track %s is in legacy single-file format; convert with gtrack.convert(\"%s\") first.",
+                srcname, srcname
+            ), call. = FALSE)
+        }
+        if (!file.copy(src_dir, dest_dir, copy.mode = TRUE)) {
+            stop(sprintf("Failed to copy %s to %s", srcname, destname), call. = FALSE)
+        }
+        .gdb.add_track(destname, dest_db)
+        return(destname)
+    }
+
+    .gtrack.copy.pipeline(
+        src_dir, dest_dir, src_chroms, dest_chroms,
+        src_indexed, dest_indexed, info$type, destname, dest_db
+    )
+    .gdb.add_track(destname, dest_db)
+    destname
+}
+
+# The full per-track copy pipeline:
+#   copy dir -> [decode if src indexed] -> [drop unmapped chroms] -> [encode if dest indexed]
+.gtrack.copy.pipeline <- function(src_dir, dest_dir,
+                                  src_chroms, dest_chroms,
+                                  src_indexed, dest_indexed,
+                                  track_type, destname, dest_db) {
+    same_order <- identical(src_chroms, dest_chroms)
+
+    # Fast path: same format + same chrom order
+    if (same_order && (src_indexed == dest_indexed)) {
+        .gtrack.copy.raw_dir(src_dir, dest_dir)
+        return(invisible())
+    }
+
+    # 2D track: at this point we know either format or chrom order differs.
+    # If chrom orders differ, we already errored in .gtrack.copy.one.
+    if (track_type %in% c("rectangles", "points")) {
+        if (src_indexed && !dest_indexed) {
+            stop(sprintf(
+                "Cross-db copy of indexed 2D track %s into a per-chromosome database is not yet supported.",
+                destname
+            ), call. = FALSE)
+        }
+        .gtrack.copy.raw_dir(src_dir, dest_dir)
+        if (dest_indexed && !src_indexed) {
+            .with_db_context(dest_db, function() {
+                gtrack.2d.convert_to_indexed(destname, remove.old = TRUE)
+            })
+        }
+        return(invisible())
+    }
+
+    # 1D pipeline
+    .gtrack.copy.raw_dir(src_dir, dest_dir)
+
+    if (src_indexed) {
+        .gtrack.split_indexed_to_per_chrom(dest_dir, src_chroms, remove_indexed = TRUE)
+    }
+
+    # Drop per-chrom files for chroms not in dest_chroms.
+    # Tolerate the chr-prefix variant the indexed-conversion code already tolerates
+    # (see src/GenomeTrackIndexedFormat.cpp:218-234).
+    files_in_dir <- list.files(dest_dir, full.names = FALSE)
+    dest_with_variants <- unique(c(
+        dest_chroms,
+        ifelse(startsWith(dest_chroms, "chr"), substr(dest_chroms, 4, nchar(dest_chroms)),
+            paste0("chr", dest_chroms)
+        )
+    ))
+    internal <- c("track.idx", "track.dat", ".attrs", ".vars", ".meta")
+    candidates_for_drop <- setdiff(files_in_dir, internal)
+    dropped <- candidates_for_drop[!(candidates_for_drop %in% dest_with_variants)]
+    if (length(dropped) > 0) {
+        warning(sprintf(
+            "gtrack.copy(%s): dropped chromosomes not present in destination: %s",
+            destname, paste(dropped, collapse = ", ")
+        ), call. = FALSE)
+        for (f in dropped) unlink(file.path(dest_dir, f))
+    }
+
+    if (dest_indexed) {
+        .with_db_context(dest_db, function() gtrack.convert_to_indexed(destname))
+    }
+    invisible()
+}
+
+# Raw file copy of an entire .track directory.
+.gtrack.copy.raw_dir <- function(src_dir, dest_dir) {
+    if (!dir.create(dest_dir, showWarnings = FALSE) && !dir.exists(dest_dir)) {
+        stop(sprintf("Failed to create %s", dest_dir), call. = FALSE)
+    }
+    contents <- list.files(src_dir, full.names = TRUE, all.files = TRUE, no.. = TRUE)
+    for (item in contents) {
         if (!file.copy(item, dest_dir, recursive = TRUE, copy.mode = TRUE)) {
             unlink(dest_dir, recursive = TRUE)
-            stop(sprintf("Failed to copy track %s to %s", srcname, destname), call. = FALSE)
+            stop(sprintf("Failed to copy %s into %s", item, dest_dir), call. = FALSE)
         }
     }
+}
 
-    # Update cache - determine which database the dest is in
-    dest_db <- NULL
-    groot <- get("GROOT", envir = .misha)
-    gdatasets <- get("GDATASETS", envir = .misha)
-    if (is.null(gdatasets)) gdatasets <- character(0)
-    groots <- c(groot, gdatasets)
-    for (g in groots) {
-        if (.gpath_is_within(gwd, file.path(g, "tracks"))) {
-            dest_db <- g
-            break
-        }
+# Temporarily switch GWD to the given db's tracks/ for the duration of fn().
+# Mirrors .with_track_context (R/db-cache.R:297) but for an explicit dest db path.
+.with_db_context <- function(dest_db, fn) {
+    correct_gwd <- file.path(dest_db, "tracks")
+    current_gwd <- get("GWD", envir = .misha)
+    if (correct_gwd == current_gwd) {
+        return(fn())
     }
-
-    .gdb.add_track(destname, dest_db)
-
-    invisible()
+    assign("GWD", correct_gwd, envir = .misha)
+    on.exit(assign("GWD", current_gwd, envir = .misha), add = TRUE)
+    fn()
 }
 
 #' Deletes a track

--- a/man/gtrack.copy.Rd
+++ b/man/gtrack.copy.Rd
@@ -2,25 +2,36 @@
 % Please edit documentation in R/track-management.R
 \name{gtrack.copy}
 \alias{gtrack.copy}
-\title{Copies a track}
+\title{Copies one or more tracks}
 \usage{
-gtrack.copy(src = NULL, dest = NULL)
+gtrack.copy(src = NULL, dest = NULL, db = NULL, overwrite = FALSE)
 }
 \arguments{
-\item{src}{source track name}
+\item{src}{source track name(s). Either a single name or a character
+vector of names.}
 
-\item{dest}{destination track name}
+\item{dest}{destination name. If \code{src} is a single name, this is the
+destination track name (defaults to \code{src}). If \code{src} is a
+vector, \code{dest} is treated as a namespace prefix (e.g. \code{"ns"}
+produces \code{"ns.track1"}, \code{"ns.track2"}, ...). NULL keeps each
+track's name.}
+
+\item{db}{destination database root. Must be the current \code{GROOT} or a
+member of \code{GDATASETS}. NULL means the current working directory db.}
+
+\item{overwrite}{if TRUE, replace an existing destination track.}
 }
 \value{
-None.
+invisibly, the character vector of created track names.
 }
 \description{
-Creates a copy of an existing track.
+Creates a copy of an existing track, optionally to a different database.
+Transparently handles format mismatches (per-chromosome vs indexed) and
+chromosome-order differences between source and destination databases.
 }
 \details{
-This function creates a copy of a track. The new track is created in the
-current working directory (.misha$GWD), which may be in a different database than
-the source track when multiple databases are connected.
+Chromosomes that exist in the source database but not in the destination
+are dropped with a warning.
 }
 \examples{
 \dontshow{
@@ -34,7 +45,6 @@ gtrack.rm("dense_track_copy", force = TRUE)
 
 }
 \seealso{
-\code{\link{gtrack.mv}}, \code{\link{gtrack.rm}},
-\code{\link{gtrack.exists}}, \code{\link{gtrack.ls}}
+\code{\link{gtrack.mv}}, \code{\link{gtrack.rm}}
 }
 \keyword{~track}

--- a/man/gtrack.copy.Rd
+++ b/man/gtrack.copy.Rd
@@ -32,6 +32,11 @@ chromosome-order differences between source and destination databases.
 \details{
 Chromosomes that exist in the source database but not in the destination
 are dropped with a warning.
+
+
+For 2D tracks (rectangles, points), cross-database copy requires identical
+chromosome order in source and destination. Format conversion (per-chromosome
+to indexed) is supported only when the destination is the active database.
 }
 \examples{
 \dontshow{

--- a/src/GenomeTrackIndexedFormat.cpp
+++ b/src/GenomeTrackIndexedFormat.cpp
@@ -28,14 +28,6 @@
 using namespace std;
 using namespace rdb;
 
-// Offset to checksum field in index header
-static const size_t IDX_HEADER_SIZE_TO_CHECKSUM =
-    8 +                    // Magic header
-    sizeof(uint32_t) +     // Version
-    sizeof(uint32_t) +     // Track type
-    sizeof(uint32_t) +     // Num contigs
-    sizeof(uint64_t);      // Flags
-
 // Helper function to write index header
 static void write_index_header(FILE *fp, MishaTrackType track_type, uint32_t num_contigs, uint64_t checksum) {
     // Magic header

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -13,6 +13,9 @@
 #include <string>
 #include <vector>
 
+// Note: do NOT #include <Rinternals.h> directly. It defines a length(x) macro
+// that collides with TrackContigEntry::length in TrackIndex.h. R's headers are
+// pulled in transitively via rdbutils.h.
 #include "TrackIndex.h"
 #include "TGLException.h"
 #include "rdbutils.h"

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -8,8 +8,6 @@
 #include <cstdio>
 #include <cstring>
 #include <errno.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #include <string>
 #include <vector>
@@ -61,7 +59,8 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
             if (entry.length == 0) continue;
             if (entry.chrom_id >= (uint32_t)n_chroms) {
                 fclose(dat_fp);
-                verror("track.idx references chrom_id %u but only %d chrom names supplied",
+                verror("track.idx references chrom_id %u but only %d chrom names supplied "
+                       "(internal mismatch or corrupt index)",
                        entry.chrom_id, n_chroms);
             }
 
@@ -97,6 +96,8 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
                 remaining -= got;
             }
 
+            // Per-file fsync + atomic rename: each per-chrom file is canonical db state;
+            // we accept N fsyncs (one per non-empty contig) for crash-safe individual files.
             fflush(out_fp);
             fsync(fileno(out_fp));
             fclose(out_fp);

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -75,6 +75,11 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
                 verror("Failed to create %s: %s", out_path_tmp.c_str(), strerror(errno));
             }
 
+            // Length=0 entries arise when the source had no per-chrom file at convert time.
+            // We still touch an output file (atomic via tmp+rename above) so that downstream
+            // per-chrom invariants hold, but we write zero bytes. In practice this is
+            // unreachable for tracks created via gtrack.create_*, which always writes a
+            // 4-byte format-signature header for every chromosome.
             if (entry.length > 0) {
                 if (fseeko(dat_fp, (off_t)entry.offset, SEEK_SET) != 0) {
                     fclose(out_fp); fclose(dat_fp);

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -16,6 +16,7 @@
 // that collides with TrackContigEntry::length in TrackIndex.h. R's headers are
 // pulled in transitively via rdbutils.h.
 #include "TrackIndex.h"
+#include "CRC64.h"
 #include "TGLException.h"
 #include "rdbutils.h"
 
@@ -56,7 +57,6 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
         vector<char> buffer(BUF);
 
         for (const TrackContigEntry &entry : idx.get_all_entries()) {
-            if (entry.length == 0) continue;
             if (entry.chrom_id >= (uint32_t)n_chroms) {
                 fclose(dat_fp);
                 verror("track.idx references chrom_id %u but only %d chrom names supplied "
@@ -74,30 +74,32 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
                 verror("Failed to create %s: %s", out_path_tmp.c_str(), strerror(errno));
             }
 
-            if (fseeko(dat_fp, (off_t)entry.offset, SEEK_SET) != 0) {
-                fclose(out_fp); fclose(dat_fp);
-                verror("Failed to seek to offset %llu in %s",
-                       (unsigned long long)entry.offset, dat_path.c_str());
-            }
+            if (entry.length > 0) {
+                if (fseeko(dat_fp, (off_t)entry.offset, SEEK_SET) != 0) {
+                    fclose(out_fp); fclose(dat_fp);
+                    verror("Failed to seek to offset %llu in %s",
+                           (unsigned long long)entry.offset, dat_path.c_str());
+                }
 
-            uint64_t remaining = entry.length;
-            while (remaining > 0) {
-                size_t to_read = (size_t)min((uint64_t)BUF, remaining);
-                size_t got = fread(buffer.data(), 1, to_read, dat_fp);
-                if (got != to_read) {
-                    fclose(out_fp); fclose(dat_fp);
-                    verror("Short read from %s at offset %llu",
-                           dat_path.c_str(), (unsigned long long)entry.offset);
+                uint64_t remaining = entry.length;
+                while (remaining > 0) {
+                    size_t to_read = (size_t)min((uint64_t)BUF, remaining);
+                    size_t got = fread(buffer.data(), 1, to_read, dat_fp);
+                    if (got != to_read) {
+                        fclose(out_fp); fclose(dat_fp);
+                        verror("Short read from %s at offset %llu",
+                               dat_path.c_str(), (unsigned long long)entry.offset);
+                    }
+                    if (fwrite(buffer.data(), 1, got, out_fp) != got) {
+                        fclose(out_fp); fclose(dat_fp);
+                        verror("Failed to write %s: %s", out_path_tmp.c_str(), strerror(errno));
+                    }
+                    remaining -= got;
                 }
-                if (fwrite(buffer.data(), 1, got, out_fp) != got) {
-                    fclose(out_fp); fclose(dat_fp);
-                    verror("Failed to write %s: %s", out_path_tmp.c_str(), strerror(errno));
-                }
-                remaining -= got;
             }
 
             // Per-file fsync + atomic rename: each per-chrom file is canonical db state;
-            // we accept N fsyncs (one per non-empty contig) for crash-safe individual files.
+            // we accept N fsyncs (one per contig) for crash-safe individual files.
             fflush(out_fp);
             fsync(fileno(out_fp));
             fclose(out_fp);
@@ -123,6 +125,170 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
         verror("%s", e.msg());
     } catch (const bad_alloc &) {
         for (const string &p : tmp_files_to_cleanup) unlink(p.c_str());
+        verror("Out of memory");
+    }
+    return R_NilValue;
+}
+
+// Pack per-chromosome files in track_dir into track.dat + track.idx.
+// Mirrors gtrack_convert_to_indexed_format but takes explicit args (track_dir,
+// chrom_names, track_type) so it works without GROOT/ALLGENOME context.
+SEXP gtrack_pack_per_chrom_to_indexed(SEXP _track_dir, SEXP _chrom_names, SEXP _track_type) {
+    string dat_path_tmp;
+    string idx_path_tmp;
+    try {
+        RdbInitializer rdb_init;
+
+        if (!Rf_isString(_track_dir) || Rf_length(_track_dir) != 1)
+            verror("track_dir must be a single string");
+        if (!Rf_isString(_chrom_names))
+            verror("chrom_names must be a character vector");
+        if (!Rf_isString(_track_type) || Rf_length(_track_type) != 1)
+            verror("track_type must be a single string ('dense', 'sparse', or 'array')");
+
+        const string track_dir = CHAR(STRING_ELT(_track_dir, 0));
+        const int n_chroms = Rf_length(_chrom_names);
+        vector<string> chrom_names(n_chroms);
+        for (int i = 0; i < n_chroms; ++i)
+            chrom_names[i] = CHAR(STRING_ELT(_chrom_names, i));
+
+        const string type_str = CHAR(STRING_ELT(_track_type, 0));
+        MishaTrackType track_type = MishaTrackType::DENSE;
+        if (type_str == "dense")       track_type = MishaTrackType::DENSE;
+        else if (type_str == "sparse") track_type = MishaTrackType::SPARSE;
+        else if (type_str == "array")  track_type = MishaTrackType::ARRAY;
+        else verror("Unsupported track_type '%s'; expected dense/sparse/array", type_str.c_str());
+
+        dat_path_tmp = track_dir + "/track.dat.tmp";
+        idx_path_tmp = track_dir + "/track.idx.tmp";
+        const string dat_path = track_dir + "/track.dat";
+        const string idx_path = track_dir + "/track.idx";
+
+        FILE *dat_fp = fopen(dat_path_tmp.c_str(), "wb");
+        if (!dat_fp)
+            verror("Failed to create %s: %s", dat_path_tmp.c_str(), strerror(errno));
+        FILE *idx_fp = fopen(idx_path_tmp.c_str(), "wb");
+        if (!idx_fp) {
+            fclose(dat_fp);
+            verror("Failed to create %s: %s", idx_path_tmp.c_str(), strerror(errno));
+        }
+
+        // Header (checksum=0 for now; updated at end). Layout matches
+        // GenomeTrackIndexedFormat.cpp::write_index_header.
+        const char magic[8] = {'M','I','S','H','A','T','D','X'};
+        const uint32_t version = 1;
+        const uint32_t track_type_raw = static_cast<uint32_t>(track_type);
+        const uint32_t num_contigs = (uint32_t)n_chroms;
+        const uint64_t flags = 0x01; // IS_LITTLE_ENDIAN
+        uint64_t checksum_placeholder = 0;
+        bool header_ok =
+            fwrite(magic, 1, 8, idx_fp) == 8 &&
+            fwrite(&version, sizeof(version), 1, idx_fp) == 1 &&
+            fwrite(&track_type_raw, sizeof(track_type_raw), 1, idx_fp) == 1 &&
+            fwrite(&num_contigs, sizeof(num_contigs), 1, idx_fp) == 1 &&
+            fwrite(&flags, sizeof(flags), 1, idx_fp) == 1 &&
+            fwrite(&checksum_placeholder, sizeof(checksum_placeholder), 1, idx_fp) == 1;
+        if (!header_ok) {
+            fclose(dat_fp); fclose(idx_fp);
+            verror("Failed to write index header");
+        }
+
+        vector<TrackContigEntry> entries;
+        vector<string> chr_files_to_remove;
+        uint64_t current_offset = 0;
+
+        const size_t BUF = 1 << 20;
+        vector<char> buffer(BUF);
+
+        for (int chromid = 0; chromid < n_chroms; ++chromid) {
+            const string chr_file = track_dir + "/" + chrom_names[chromid];
+
+            TrackContigEntry entry;
+            entry.chrom_id = (uint32_t)chromid;
+            entry.offset = current_offset;
+            entry.length = 0;
+            entry.reserved = 0;
+
+            FILE *src_fp = fopen(chr_file.c_str(), "rb");
+            if (src_fp) {
+                if (fseeko(src_fp, 0, SEEK_END) != 0) {
+                    fclose(src_fp); fclose(dat_fp); fclose(idx_fp);
+                    verror("Failed to size %s", chr_file.c_str());
+                }
+                const uint64_t file_size = (uint64_t)ftello(src_fp);
+                rewind(src_fp);
+
+                uint64_t remaining = file_size;
+                while (remaining > 0) {
+                    size_t to_read = (size_t)min((uint64_t)BUF, remaining);
+                    size_t got = fread(buffer.data(), 1, to_read, src_fp);
+                    if (got != to_read) {
+                        fclose(src_fp); fclose(dat_fp); fclose(idx_fp);
+                        verror("Short read from %s", chr_file.c_str());
+                    }
+                    if (fwrite(buffer.data(), 1, got, dat_fp) != got) {
+                        fclose(src_fp); fclose(dat_fp); fclose(idx_fp);
+                        verror("Failed to write track.dat");
+                    }
+                    remaining -= got;
+                }
+                fclose(src_fp);
+                entry.length = file_size;
+                current_offset += file_size;
+                chr_files_to_remove.push_back(chr_file);
+            }
+            // else: entry stays length=0, no per-chrom file present.
+
+            if (fwrite(&entry.chrom_id,  sizeof(entry.chrom_id),  1, idx_fp) != 1 ||
+                fwrite(&entry.offset,    sizeof(entry.offset),    1, idx_fp) != 1 ||
+                fwrite(&entry.length,    sizeof(entry.length),    1, idx_fp) != 1 ||
+                fwrite(&entry.reserved,  sizeof(entry.reserved),  1, idx_fp) != 1) {
+                fclose(dat_fp); fclose(idx_fp);
+                verror("Failed to write index entry for %s", chrom_names[chromid].c_str());
+            }
+            entries.push_back(entry);
+        }
+
+        // Compute and patch checksum
+        misha::CRC64 crc64;
+        uint64_t checksum = crc64.init_incremental();
+        for (const auto &e : entries) {
+            checksum = crc64.compute_incremental(checksum, (const unsigned char*)&e.chrom_id, sizeof(e.chrom_id));
+            checksum = crc64.compute_incremental(checksum, (const unsigned char*)&e.offset,   sizeof(e.offset));
+            checksum = crc64.compute_incremental(checksum, (const unsigned char*)&e.length,   sizeof(e.length));
+        }
+        checksum = crc64.finalize_incremental(checksum);
+
+        // Header layout: magic(8) + version(4) + tracktype(4) + numcontigs(4) + flags(8) = 28 bytes before checksum
+        if (fseek(idx_fp, 8 + 4 + 4 + 4 + 8, SEEK_SET) != 0) {
+            fclose(dat_fp); fclose(idx_fp);
+            verror("Failed to seek to checksum position");
+        }
+        if (fwrite(&checksum, sizeof(checksum), 1, idx_fp) != 1) {
+            fclose(dat_fp); fclose(idx_fp);
+            verror("Failed to update checksum");
+        }
+
+        fflush(dat_fp); fflush(idx_fp);
+        fsync(fileno(dat_fp)); fsync(fileno(idx_fp));
+        fclose(dat_fp); fclose(idx_fp);
+
+        if (rename(dat_path_tmp.c_str(), dat_path.c_str()) != 0)
+            verror("Failed to rename %s to %s: %s", dat_path_tmp.c_str(), dat_path.c_str(), strerror(errno));
+        if (rename(idx_path_tmp.c_str(), idx_path.c_str()) != 0)
+            verror("Failed to rename %s to %s: %s", idx_path_tmp.c_str(), idx_path.c_str(), strerror(errno));
+
+        // Remove old per-chrom files (always remove; this is a destructive pack)
+        for (const string &p : chr_files_to_remove) unlink(p.c_str());
+
+        return R_NilValue;
+    } catch (TGLException &e) {
+        unlink(dat_path_tmp.c_str());
+        unlink(idx_path_tmp.c_str());
+        verror("%s", e.msg());
+    } catch (const bad_alloc &) {
+        unlink(dat_path_tmp.c_str());
+        unlink(idx_path_tmp.c_str());
         verror("Out of memory");
     }
     return R_NilValue;

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstring>
 #include <errno.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <string>
 #include <vector>
@@ -259,8 +260,8 @@ SEXP gtrack_pack_per_chrom_to_indexed(SEXP _track_dir, SEXP _chrom_names, SEXP _
         }
         checksum = crc64.finalize_incremental(checksum);
 
-        // Header layout: magic(8) + version(4) + tracktype(4) + numcontigs(4) + flags(8) = 28 bytes before checksum
-        if (fseek(idx_fp, 8 + 4 + 4 + 4 + 8, SEEK_SET) != 0) {
+        // Seek to checksum field; layout documented in TrackIndex.h.
+        if (fseek(idx_fp, IDX_HEADER_SIZE_TO_CHECKSUM, SEEK_SET) != 0) {
             fclose(dat_fp); fclose(idx_fp);
             verror("Failed to seek to checksum position");
         }
@@ -277,6 +278,15 @@ SEXP gtrack_pack_per_chrom_to_indexed(SEXP _track_dir, SEXP _chrom_names, SEXP _
             verror("Failed to rename %s to %s: %s", dat_path_tmp.c_str(), dat_path.c_str(), strerror(errno));
         if (rename(idx_path_tmp.c_str(), idx_path.c_str()) != 0)
             verror("Failed to rename %s to %s: %s", idx_path_tmp.c_str(), idx_path.c_str(), strerror(errno));
+
+        // Validate track.dat size matches what we wrote, before destroying source files.
+        struct stat dat_stat;
+        if (stat(dat_path.c_str(), &dat_stat) != 0)
+            verror("Failed to stat %s after pack: %s", dat_path.c_str(), strerror(errno));
+        if ((uint64_t)dat_stat.st_size != current_offset)
+            verror("track.dat size mismatch after pack: expected %llu bytes, got %llu bytes",
+                   (unsigned long long)current_offset,
+                   (unsigned long long)dat_stat.st_size);
 
         // Remove old per-chrom files (always remove; this is a destructive pack)
         for (const string &p : chr_files_to_remove) unlink(p.c_str());

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -1,0 +1,44 @@
+// src/GenomeTrackSplitIndexed.cpp
+//
+// Splits a 1D indexed-format track (track.dat + track.idx) back into per-chromosome
+// files in the same directory, named by the supplied chrom names.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string>
+#include <vector>
+
+#include "TrackIndex.h"
+#include "TGLException.h"
+#include "rdbutils.h"
+
+using namespace std;
+using namespace rdb;
+
+extern "C" {
+
+SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP _remove_indexed) {
+    try {
+        RdbInitializer rdb_init;
+
+        if (!Rf_isString(_track_dir) || Rf_length(_track_dir) != 1)
+            verror("track_dir must be a single string");
+        if (!Rf_isString(_chrom_names))
+            verror("chrom_names must be a character vector");
+
+        // Stub: do nothing yet.
+        return R_NilValue;
+    } catch (TGLException &e) {
+        verror("%s", e.msg());
+    } catch (const bad_alloc &) {
+        verror("Out of memory");
+    }
+    return R_NilValue;
+}
+
+} // extern "C"

--- a/src/GenomeTrackSplitIndexed.cpp
+++ b/src/GenomeTrackSplitIndexed.cpp
@@ -3,6 +3,7 @@
 // Splits a 1D indexed-format track (track.dat + track.idx) back into per-chromosome
 // files in the same directory, named by the supplied chrom names.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -26,6 +27,7 @@ using namespace rdb;
 extern "C" {
 
 SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP _remove_indexed) {
+    vector<string> tmp_files_to_cleanup;
     try {
         RdbInitializer rdb_init;
 
@@ -34,11 +36,92 @@ SEXP gtrack_split_indexed_to_per_chrom(SEXP _track_dir, SEXP _chrom_names, SEXP 
         if (!Rf_isString(_chrom_names))
             verror("chrom_names must be a character vector");
 
-        // Stub: do nothing yet.
+        const string track_dir = CHAR(STRING_ELT(_track_dir, 0));
+        const int n_chroms = Rf_length(_chrom_names);
+        vector<string> chrom_names(n_chroms);
+        for (int i = 0; i < n_chroms; ++i)
+            chrom_names[i] = CHAR(STRING_ELT(_chrom_names, i));
+        const bool remove_indexed = Rf_asLogical(_remove_indexed) == TRUE;
+
+        const string idx_path = track_dir + "/track.idx";
+        const string dat_path = track_dir + "/track.dat";
+
+        TrackIndex idx;
+        if (!idx.load(idx_path))
+            verror("track.idx not found in %s", track_dir.c_str());
+
+        FILE *dat_fp = fopen(dat_path.c_str(), "rb");
+        if (!dat_fp)
+            verror("Failed to open %s: %s", dat_path.c_str(), strerror(errno));
+
+        const size_t BUF = 1 << 20; // 1 MiB
+        vector<char> buffer(BUF);
+
+        for (const TrackContigEntry &entry : idx.get_all_entries()) {
+            if (entry.length == 0) continue;
+            if (entry.chrom_id >= (uint32_t)n_chroms) {
+                fclose(dat_fp);
+                verror("track.idx references chrom_id %u but only %d chrom names supplied",
+                       entry.chrom_id, n_chroms);
+            }
+
+            const string out_path     = track_dir + "/" + chrom_names[entry.chrom_id];
+            const string out_path_tmp = out_path + ".tmp";
+            tmp_files_to_cleanup.push_back(out_path_tmp);
+
+            FILE *out_fp = fopen(out_path_tmp.c_str(), "wb");
+            if (!out_fp) {
+                fclose(dat_fp);
+                verror("Failed to create %s: %s", out_path_tmp.c_str(), strerror(errno));
+            }
+
+            if (fseeko(dat_fp, (off_t)entry.offset, SEEK_SET) != 0) {
+                fclose(out_fp); fclose(dat_fp);
+                verror("Failed to seek to offset %llu in %s",
+                       (unsigned long long)entry.offset, dat_path.c_str());
+            }
+
+            uint64_t remaining = entry.length;
+            while (remaining > 0) {
+                size_t to_read = (size_t)min((uint64_t)BUF, remaining);
+                size_t got = fread(buffer.data(), 1, to_read, dat_fp);
+                if (got != to_read) {
+                    fclose(out_fp); fclose(dat_fp);
+                    verror("Short read from %s at offset %llu",
+                           dat_path.c_str(), (unsigned long long)entry.offset);
+                }
+                if (fwrite(buffer.data(), 1, got, out_fp) != got) {
+                    fclose(out_fp); fclose(dat_fp);
+                    verror("Failed to write %s: %s", out_path_tmp.c_str(), strerror(errno));
+                }
+                remaining -= got;
+            }
+
+            fflush(out_fp);
+            fsync(fileno(out_fp));
+            fclose(out_fp);
+
+            if (rename(out_path_tmp.c_str(), out_path.c_str()) != 0) {
+                fclose(dat_fp);
+                verror("Failed to rename %s to %s: %s",
+                       out_path_tmp.c_str(), out_path.c_str(), strerror(errno));
+            }
+            tmp_files_to_cleanup.pop_back(); // succeeded
+        }
+
+        fclose(dat_fp);
+
+        if (remove_indexed) {
+            unlink(dat_path.c_str());
+            unlink(idx_path.c_str());
+        }
+
         return R_NilValue;
     } catch (TGLException &e) {
+        for (const string &p : tmp_files_to_cleanup) unlink(p.c_str());
         verror("%s", e.msg());
     } catch (const bad_alloc &) {
+        for (const string &p : tmp_files_to_cleanup) unlink(p.c_str());
         verror("Out of memory");
     }
     return R_NilValue;

--- a/src/TrackIndex.h
+++ b/src/TrackIndex.h
@@ -106,4 +106,8 @@ private:
     uint64_t compute_checksum(const vector<TrackContigEntry> &entries);
 };
 
+// Offset to the checksum field within the index header.
+// Header layout: magic(8) + version(4) + tracktype(4) + numcontigs(4) + flags(8) = 28 bytes.
+static constexpr size_t IDX_HEADER_SIZE_TO_CHECKSUM = 8 + 4 + 4 + 4 + 8;
+
 #endif /* TRACKINDEX_H_ */

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -67,6 +67,7 @@ extern "C" {
     extern SEXP gtrackcreate(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrack_convert_to_indexed_format(SEXP, SEXP, SEXP);
     extern SEXP gtrack_split_indexed_to_per_chrom(SEXP, SEXP, SEXP);
+    extern SEXP gtrack_pack_per_chrom_to_indexed(SEXP, SEXP, SEXP);
     extern SEXP gtrack2d_convert_to_indexed(SEXP, SEXP, SEXP);
     extern SEXP gtrack_create_empty_indexed(SEXP, SEXP);
     extern SEXP ginterv_convert(SEXP, SEXP, SEXP);
@@ -175,6 +176,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"gtrackcreate", (DL_FUNC)&gtrackcreate, 5},
     {"gtrack_convert_to_indexed_format", (DL_FUNC)&gtrack_convert_to_indexed_format, 3},
     {"gtrack_split_indexed_to_per_chrom", (DL_FUNC)&gtrack_split_indexed_to_per_chrom, 3},
+    {"gtrack_pack_per_chrom_to_indexed", (DL_FUNC)&gtrack_pack_per_chrom_to_indexed, 3},
     {"gtrack2d_convert_to_indexed", (DL_FUNC)&gtrack2d_convert_to_indexed, 3},
     {"gtrack_create_empty_indexed", (DL_FUNC)&gtrack_create_empty_indexed, 2},
     {"ginterv_convert", (DL_FUNC)&ginterv_convert, 3},

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -66,6 +66,7 @@ extern "C" {
     extern SEXP gtrack_create_track2d(SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrackcreate(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrack_convert_to_indexed_format(SEXP, SEXP, SEXP);
+    extern SEXP gtrack_split_indexed_to_per_chrom(SEXP, SEXP, SEXP);
     extern SEXP gtrack2d_convert_to_indexed(SEXP, SEXP, SEXP);
     extern SEXP gtrack_create_empty_indexed(SEXP, SEXP);
     extern SEXP ginterv_convert(SEXP, SEXP, SEXP);
@@ -173,6 +174,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"gtrack_create_track2d", (DL_FUNC)&gtrack_create_track2d, 4},
     {"gtrackcreate", (DL_FUNC)&gtrackcreate, 5},
     {"gtrack_convert_to_indexed_format", (DL_FUNC)&gtrack_convert_to_indexed_format, 3},
+    {"gtrack_split_indexed_to_per_chrom", (DL_FUNC)&gtrack_split_indexed_to_per_chrom, 3},
     {"gtrack2d_convert_to_indexed", (DL_FUNC)&gtrack2d_convert_to_indexed, 3},
     {"gtrack_create_empty_indexed", (DL_FUNC)&gtrack_create_empty_indexed, 2},
     {"ginterv_convert", (DL_FUNC)&ginterv_convert, 3},

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -18,3 +18,51 @@ test_that(".gdb.is_indexed_at returns TRUE for an indexed db", {
         expect_true(misha:::.gdb.is_indexed_at(normalizePath("idx_db")))
     })
 })
+
+test_that("split_indexed_to_per_chrom recreates per-chrom files identical to pre-conversion", {
+    withr::with_tempdir({
+        create_test_db("db_a")
+        gsetroot("db_a")
+        gtrack.create_sparse("t1", "test", gintervals(1, 0, 1000), 7)
+        # Snapshot per-chrom files before conversion
+        track_dir <- file.path(normalizePath("db_a"), "tracks", "t1.track")
+        before <- list.files(track_dir)
+        sizes_before <- file.info(file.path(track_dir, before))$size
+        names(sizes_before) <- before
+
+        gtrack.convert_to_indexed("t1")
+        expect_true(file.exists(file.path(track_dir, "track.idx")))
+
+        # Split back
+        chrom_names <- misha:::.gdb.chrom_names_at(normalizePath("db_a"))
+        misha:::.gtrack.split_indexed_to_per_chrom(track_dir, chrom_names, remove_indexed = TRUE)
+
+        expect_false(file.exists(file.path(track_dir, "track.idx")))
+        expect_false(file.exists(file.path(track_dir, "track.dat")))
+        # Every original per-chrom file is back, byte-for-byte (compare sizes here; full bytes covered in later test)
+        after <- list.files(track_dir)
+        expect_setequal(after, before)
+        sizes_after <- file.info(file.path(track_dir, after))$size
+        names(sizes_after) <- after
+        expect_equal(sizes_after[before], sizes_before[before])
+    })
+})
+
+test_that("split_indexed_to_per_chrom is byte-identical to pre-conversion", {
+    withr::with_tempdir({
+        create_test_db("db_b")
+        gsetroot("db_b")
+        intervs <- gintervals(1, 0, 5000)
+        gtrack.create_sparse("t2", "test", intervs, 42)
+        track_dir <- file.path(normalizePath("db_b"), "tracks", "t2.track")
+        files <- list.files(track_dir, full.names = FALSE)
+        before <- setNames(lapply(file.path(track_dir, files), readBin, what = "raw", n = 1e8), files)
+
+        gtrack.convert_to_indexed("t2")
+        chrom_names <- misha:::.gdb.chrom_names_at(normalizePath("db_b"))
+        misha:::.gtrack.split_indexed_to_per_chrom(track_dir, chrom_names, remove_indexed = TRUE)
+
+        after <- setNames(lapply(file.path(track_dir, files), readBin, what = "raw", n = 1e8), files)
+        expect_equal(after, before)
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -152,3 +152,20 @@ test_that("split_indexed_to_per_chrom errors on chromid out of range and preserv
         expect_length(list.files(track_dir, pattern = "\\.tmp$"), 0)
     })
 })
+
+test_that("gtrack.copy with db= lands the track in the named dataset", {
+    withr::with_tempdir({
+        create_test_db("workdb")
+        create_test_db("otherdb")
+        gsetroot("workdb")
+        gdataset.load(normalizePath("otherdb"))
+        gtrack.create_sparse("src_t", "src", gintervals(1, 0, 1000), 9)
+
+        gtrack.copy("src_t", "copied_t", db = normalizePath("otherdb"))
+
+        expect_true(gtrack.exists("copied_t"))
+        expect_equal(gtrack.dataset("copied_t"), normalizePath("otherdb"))
+        expect_equal(gtrack.dataset("src_t"), normalizePath("workdb"))
+        expect_equal(gextract("copied_t", gintervals(1, 0, 500))$copied_t[1], 9)
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -212,3 +212,27 @@ test_that("gtrack.copy: indexed src to per-chrom dest splits on the fly", {
         expect_equal(gextract("t_copy", gintervals(1, 0, 500))$t_copy[1], 22)
     })
 })
+
+test_that("gtrack.copy: per-chrom dense src to indexed dest converts on the fly", {
+    withr::with_tempdir({
+        create_test_db("perchrom_src_dense")
+        create_test_db("indexed_dest_dense")
+        gdb.init("indexed_dest_dense")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        gsetroot("perchrom_src_dense")
+        gdataset.load(normalizePath("indexed_dest_dense"))
+
+        # Dense track via gtrack.create with a fixed-bin iterator
+        intervs <- gintervals(1, 0, 1000)
+        gtrack.create("d", "dense", "1", iterator = 100)
+
+        gtrack.copy("d", "d_copy", db = normalizePath("indexed_dest_dense"))
+
+        dest_dir <- file.path(normalizePath("indexed_dest_dense"), "tracks", "d_copy.track")
+        expect_true(file.exists(file.path(dest_dir, "track.idx")))
+        expect_true(file.exists(file.path(dest_dir, "track.dat")))
+        # Values intact for dense track
+        result <- gextract("d_copy", gintervals(1, 0, 500), iterator = 100)
+        expect_true(all(result$d_copy == 1))
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -312,3 +312,66 @@ test_that("gtrack.copy: src 'chr1' -> dest '1' handles prefix variant via rename
         expect_equal(gextract("t_copy", gintervals("1", 0, 100))$t_copy[1], 7)
     })
 })
+
+test_that("gtrack.copy: vector src with prefix dest", {
+    withr::with_tempdir({
+        create_test_db("a")
+        create_test_db("b")
+        gsetroot("a")
+        gtrack.create_sparse("x", "x", gintervals(1, 0, 100), 1)
+        gtrack.create_sparse("y", "y", gintervals(1, 0, 100), 2)
+
+        out <- gtrack.copy(c("x", "y"), dest = "ns", db = normalizePath("b"))
+
+        expect_setequal(out, c("ns.x", "ns.y"))
+        gsetroot("b")
+        expect_true(gtrack.exists("ns.x"))
+        expect_true(gtrack.exists("ns.y"))
+        expect_equal(gextract("ns.x", gintervals(1, 0, 100))$ns.x[1], 1)
+        expect_equal(gextract("ns.y", gintervals(1, 0, 100))$ns.y[1], 2)
+    })
+})
+
+test_that("gtrack.copy: vector src with NULL dest keeps names", {
+    withr::with_tempdir({
+        create_test_db("a")
+        create_test_db("b")
+        gsetroot("a")
+        gtrack.create_sparse("x", "x", gintervals(1, 0, 100), 1)
+        gtrack.create_sparse("y", "y", gintervals(1, 0, 100), 2)
+
+        gtrack.copy(c("x", "y"), db = normalizePath("b"))
+
+        gsetroot("b")
+        expect_true(gtrack.exists("x"))
+        expect_true(gtrack.exists("y"))
+        expect_equal(gextract("x", gintervals(1, 0, 100))$x[1], 1)
+        expect_equal(gextract("y", gintervals(1, 0, 100))$y[1], 2)
+    })
+})
+
+test_that("gtrack.copy: overwrite=FALSE errors on existing dest, overwrite=TRUE replaces", {
+    withr::with_tempdir({
+        create_test_db("a")
+        create_test_db("b")
+        gsetroot("a")
+        gtrack.create_sparse("x", "x", gintervals(1, 0, 100), 1)
+
+        # First copy succeeds
+        gtrack.copy("x", "x_copy", db = normalizePath("b"))
+
+        # Second copy without overwrite errors
+        expect_error(
+            gtrack.copy("x", "x_copy", db = normalizePath("b")),
+            "already exists"
+        )
+
+        # Replace source with different value, then overwrite=TRUE
+        gtrack.rm("x", force = TRUE)
+        gtrack.create_sparse("x", "x", gintervals(1, 0, 100), 99)
+
+        gtrack.copy("x", "x_copy", db = normalizePath("b"), overwrite = TRUE)
+        gsetroot("b")
+        expect_equal(gextract("x_copy", gintervals(1, 0, 100))$x_copy[1], 99)
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -169,3 +169,46 @@ test_that("gtrack.copy with db= lands the track in the named dataset", {
         expect_equal(gextract("copied_t", gintervals(1, 0, 500))$copied_t[1], 9)
     })
 })
+
+test_that("gtrack.copy: per-chrom src to indexed dest converts on the fly", {
+    withr::with_tempdir({
+        create_test_db("perchrom_src")
+        create_test_db("indexed_dest")
+        gdb.init("indexed_dest")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        gsetroot("perchrom_src")
+        gdataset.load(normalizePath("indexed_dest"))
+        gtrack.create_sparse("t", "src", gintervals(1, 0, 1000), 11)
+
+        gtrack.copy("t", "t_copy", db = normalizePath("indexed_dest"))
+
+        # Destination should be in indexed format
+        dest_dir <- file.path(normalizePath("indexed_dest"), "tracks", "t_copy.track")
+        expect_true(file.exists(file.path(dest_dir, "track.idx")))
+        expect_true(file.exists(file.path(dest_dir, "track.dat")))
+        # Per-chrom files should be gone
+        expect_length(list.files(dest_dir, pattern = "^chr"), 0)
+        # Values intact
+        expect_equal(gextract("t_copy", gintervals(1, 0, 500))$t_copy[1], 11)
+    })
+})
+
+test_that("gtrack.copy: indexed src to per-chrom dest splits on the fly", {
+    withr::with_tempdir({
+        create_test_db("indexed_src")
+        create_test_db("perchrom_dest")
+        gdb.init("indexed_src")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        gtrack.create_sparse("t", "src", gintervals(1, 0, 1000), 22)
+        gsetroot("perchrom_dest")
+        gdataset.load(normalizePath("indexed_src"))
+
+        gtrack.copy("t", "t_copy", db = normalizePath("perchrom_dest"))
+
+        dest_dir <- file.path(normalizePath("perchrom_dest"), "tracks", "t_copy.track")
+        expect_false(file.exists(file.path(dest_dir, "track.idx")))
+        # Per-chrom files present (chr1 should exist; chr2 may not since data is only on chr1)
+        expect_true(any(c("chr1", "chr2") %in% list.files(dest_dir)))
+        expect_equal(gextract("t_copy", gintervals(1, 0, 500))$t_copy[1], 22)
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -1,0 +1,20 @@
+# tests/testthat/test-track-copy-crossdb.R
+test_that(".gdb.is_indexed_at and .gdb.chrom_names_at probe a db without loading it", {
+    withr::with_tempdir({
+        create_test_db("perchrom_db")
+        expect_false(misha:::.gdb.is_indexed_at(normalizePath("perchrom_db")))
+        expect_equal(
+            misha:::.gdb.chrom_names_at(normalizePath("perchrom_db")),
+            c("chr1", "chr2")
+        )
+    })
+})
+
+test_that(".gdb.is_indexed_at returns TRUE for an indexed db", {
+    withr::with_tempdir({
+        create_test_db("idx_db")
+        gdb.init("idx_db")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        expect_true(misha:::.gdb.is_indexed_at(normalizePath("idx_db")))
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -236,3 +236,79 @@ test_that("gtrack.copy: per-chrom dense src to indexed dest converts on the fly"
         expect_true(all(result$d_copy == 1))
     })
 })
+
+test_that("gtrack.copy drops chromosomes not present in destination, with a warning", {
+    withr::with_tempdir({
+        # src has chr1, chr2, chr3; dest has only chr1, chr2
+        create_test_db("src3", chrom_sizes = data.frame(
+            chrom = c("chr1", "chr2", "chr3"), size = c(10000, 10000, 10000)
+        ))
+        create_test_db("dest2", chrom_sizes = data.frame(
+            chrom = c("chr1", "chr2"), size = c(10000, 10000)
+        ))
+        gsetroot("src3")
+        gtrack.create_sparse(
+            "t", "src",
+            rbind(gintervals(1, 0, 100), gintervals(3, 0, 100)),
+            c(5, 5)
+        )
+
+        expect_warning(
+            gtrack.copy("t", "t_copy", db = normalizePath("dest2")),
+            "chr3"
+        )
+        gsetroot("dest2")
+        # Track exists; values for chr1 are 5, chr3 is gone (doesn't exist in dest)
+        expect_true(gtrack.exists("t_copy"))
+        expect_equal(gextract("t_copy", gintervals(1, 0, 100))$t_copy[1], 5)
+    })
+})
+
+test_that("gtrack.copy: indexed -> indexed with different chrom order remaps via two-stage pipeline", {
+    withr::with_tempdir({
+        # src order: chr1, chr2; dest order: chr2, chr1
+        create_test_db("src_idx", chrom_sizes = data.frame(
+            chrom = c("chr1", "chr2"), size = c(10000, 10000)
+        ))
+        create_test_db("dest_idx", chrom_sizes = data.frame(
+            chrom = c("chr2", "chr1"), size = c(10000, 10000)
+        ))
+        gdb.init("src_idx")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        gtrack.create_sparse(
+            "t", "src",
+            rbind(gintervals(1, 0, 100), gintervals(2, 0, 100)),
+            c(13, 13)
+        )
+        gdb.init("dest_idx")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        gsetroot("src_idx")
+
+        gtrack.copy("t", "t_copy", db = normalizePath("dest_idx"))
+
+        gsetroot("dest_idx")
+        expect_true(gtrack.exists("t_copy"))
+        expect_equal(gextract("t_copy", gintervals(1, 0, 100))$t_copy[1], 13)
+        expect_equal(gextract("t_copy", gintervals(2, 0, 100))$t_copy[1], 13)
+    })
+})
+
+test_that("gtrack.copy: src 'chr1' -> dest '1' handles prefix variant via rename", {
+    withr::with_tempdir({
+        create_test_db("src_chrprefix", chrom_sizes = data.frame(
+            chrom = c("chr1", "chr2"), size = c(10000, 10000)
+        ))
+        create_test_db("dest_noprefix", chrom_sizes = data.frame(
+            chrom = c("1", "2"), size = c(10000, 10000)
+        ))
+        gsetroot("src_chrprefix")
+        gtrack.create_sparse("t", "src", gintervals(1, 0, 100), 7)
+
+        gtrack.copy("t", "t_copy", db = normalizePath("dest_noprefix"))
+
+        gsetroot("dest_noprefix")
+        expect_true(gtrack.exists("t_copy"))
+        # Chrom is "1" (no prefix) in dest
+        expect_equal(gextract("t_copy", gintervals("1", 0, 100))$t_copy[1], 7)
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -66,3 +66,57 @@ test_that("split_indexed_to_per_chrom is byte-identical to pre-conversion", {
         expect_equal(after, before)
     })
 })
+
+test_that("split_indexed_to_per_chrom handles multiple non-empty chroms", {
+    withr::with_tempdir({
+        create_test_db("db_multi")
+        gsetroot("db_multi")
+        # Write data on BOTH chr1 and chr2 so the splitter has to produce two output files.
+        intervs <- rbind(
+            gintervals(1, 0, 1000),
+            gintervals(2, 0, 1000)
+        )
+        gtrack.create_sparse("tm", "test", intervs, c(5, 5))
+        track_dir <- file.path(normalizePath("db_multi"), "tracks", "tm.track")
+        files_before <- list.files(track_dir)
+        bytes_before <- setNames(
+            lapply(file.path(track_dir, files_before), readBin, what = "raw", n = 1e8),
+            files_before
+        )
+
+        gtrack.convert_to_indexed("tm")
+        chrom_names <- misha:::.gdb.chrom_names_at(normalizePath("db_multi"))
+        misha:::.gtrack.split_indexed_to_per_chrom(track_dir, chrom_names, remove_indexed = TRUE)
+
+        # Both chrom files reappeared, byte-identical
+        files_after <- list.files(track_dir)
+        expect_setequal(files_after, files_before)
+        bytes_after <- setNames(
+            lapply(file.path(track_dir, files_after), readBin, what = "raw", n = 1e8),
+            files_after
+        )
+        expect_equal(bytes_after[files_before], bytes_before[files_before])
+        # Sanity: track values still extract correctly
+        expect_equal(gextract("tm", gintervals(1, 0, 500))$tm[1], 5)
+        expect_equal(gextract("tm", gintervals(2, 0, 500))$tm[1], 5)
+    })
+})
+
+test_that("split_indexed_to_per_chrom with remove_indexed=FALSE keeps track.dat/idx", {
+    withr::with_tempdir({
+        create_test_db("db_keep")
+        gsetroot("db_keep")
+        gtrack.create_sparse("tk", "test", gintervals(1, 0, 1000), 3)
+        track_dir <- file.path(normalizePath("db_keep"), "tracks", "tk.track")
+        gtrack.convert_to_indexed("tk")
+        expect_true(file.exists(file.path(track_dir, "track.idx")))
+
+        chrom_names <- misha:::.gdb.chrom_names_at(normalizePath("db_keep"))
+        misha:::.gtrack.split_indexed_to_per_chrom(track_dir, chrom_names, remove_indexed = FALSE)
+
+        expect_true(file.exists(file.path(track_dir, "track.idx")))
+        expect_true(file.exists(file.path(track_dir, "track.dat")))
+        # Per-chrom files also produced
+        expect_true("chr1" %in% list.files(track_dir))
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -375,3 +375,55 @@ test_that("gtrack.copy: overwrite=FALSE errors on existing dest, overwrite=TRUE 
         expect_equal(gextract("x_copy", gintervals(1, 0, 100))$x_copy[1], 99)
     })
 })
+
+test_that("gtrack.copy: .attrs and .vars survive cross-db split+pack roundtrip", {
+    withr::with_tempdir({
+        create_test_db("perchrom")
+        create_test_db("indexed")
+        gdb.init("indexed")
+        gdb.convert_to_indexed(force = TRUE, verbose = FALSE)
+        gsetroot("perchrom")
+        gtrack.create_sparse("t_attr", "src", gintervals(1, 0, 100), 5)
+        gtrack.attr.set("t_attr", "experiment", "foo")
+        gtrack.var.set("t_attr", "extra_metadata", list(x = 1, y = "hello"))
+
+        gtrack.copy("t_attr", "t_attr_copy", db = normalizePath("indexed"))
+
+        gsetroot("indexed")
+        expect_true(gtrack.exists("t_attr_copy"))
+        expect_equal(gtrack.attr.get("t_attr_copy", "experiment"), "foo")
+        expect_equal(
+            gtrack.var.get("t_attr_copy", "extra_metadata"),
+            list(x = 1, y = "hello")
+        )
+    })
+})
+
+test_that("split followed by pack reproduces the original indexed pair byte-for-byte", {
+    withr::with_tempdir({
+        create_test_db("rt")
+        gsetroot("rt")
+        gtrack.create_sparse(
+            "t_rt", "src",
+            rbind(gintervals(1, 0, 100), gintervals(2, 0, 100)),
+            c(7, 7)
+        )
+        track_dir <- file.path(normalizePath("rt"), "tracks", "t_rt.track")
+        gtrack.convert_to_indexed("t_rt")
+
+        # Snapshot original indexed bytes
+        idx_before <- readBin(file.path(track_dir, "track.idx"), "raw", n = 1e8)
+        dat_before <- readBin(file.path(track_dir, "track.dat"), "raw", n = 1e8)
+
+        chrom_names <- misha:::.gdb.chrom_names_at(normalizePath("rt"))
+        misha:::.gtrack.split_indexed_to_per_chrom(track_dir, chrom_names, remove_indexed = TRUE)
+        # Determine track type from a per-chrom file (sparse here)
+        misha:::.gtrack.pack_per_chrom_to_indexed(track_dir, chrom_names, "sparse")
+
+        idx_after <- readBin(file.path(track_dir, "track.idx"), "raw", n = 1e8)
+        dat_after <- readBin(file.path(track_dir, "track.dat"), "raw", n = 1e8)
+
+        expect_equal(idx_after, idx_before)
+        expect_equal(dat_after, dat_before)
+    })
+})

--- a/tests/testthat/test-track-copy-crossdb.R
+++ b/tests/testthat/test-track-copy-crossdb.R
@@ -120,3 +120,35 @@ test_that("split_indexed_to_per_chrom with remove_indexed=FALSE keeps track.dat/
         expect_true("chr1" %in% list.files(track_dir))
     })
 })
+
+test_that("split_indexed_to_per_chrom errors on chromid out of range and preserves indexed pair", {
+    withr::with_tempdir({
+        create_test_db("db_oor")
+        gsetroot("db_oor")
+        # Create a track with data on BOTH chr1 and chr2 so that the index references
+        # chrom_id 0 AND chrom_id 1. Passing only one chrom name will trigger the guard.
+        intervs <- rbind(gintervals(1, 0, 1000), gintervals(2, 0, 1000))
+        gtrack.create_sparse("t_oor", "test", intervs, c(1, 1))
+        gtrack.convert_to_indexed("t_oor")
+        track_dir <- file.path(normalizePath("db_oor"), "tracks", "t_oor.track")
+
+        # Sanity: indexed pair exists
+        expect_true(file.exists(file.path(track_dir, "track.idx")))
+        expect_true(file.exists(file.path(track_dir, "track.dat")))
+
+        # Pass only one chrom name -- must fail with a clear message
+        expect_error(
+            misha:::.gtrack.split_indexed_to_per_chrom(track_dir, "only_one_chrom",
+                remove_indexed = TRUE
+            ),
+            "chrom_id"
+        )
+
+        # Indexed pair must still be intact (the splitter must NOT delete on error)
+        expect_true(file.exists(file.path(track_dir, "track.idx")))
+        expect_true(file.exists(file.path(track_dir, "track.dat")))
+
+        # No leftover .tmp files
+        expect_length(list.files(track_dir, pattern = "\\.tmp$"), 0)
+    })
+})


### PR DESCRIPTION
## Summary

`gtrack.copy()` now supports copying tracks across databases, with automatic
handling of format mismatches and chromosome-order differences:

```r
gtrack.copy(src, dest = NULL, db = NULL, overwrite = FALSE)
```

- **`db`** — destination database root (any path with `chrom_sizes.txt` + `tracks/`; need not be a loaded dataset). Defaults to current GWD's db (back-compat).
- **`dest`** — destination name; if `src` is a vector, treated as a namespace prefix.
- **`overwrite`** — replace an existing destination track.
- **multi-track input** — `src` may be a character vector.

The pipeline transparently handles all four format combos (per-chrom ↔ indexed, both directions), drops chromosomes not present in the destination (with a warning), and tolerates `chr` prefix variation between dbs.

### New C++ helpers

`src/GenomeTrackSplitIndexed.cpp` adds two explicit-path entry points that complement the existing GROOT-coupled `gtrack_convert_to_indexed_format`:

- `gtrack_split_indexed_to_per_chrom(track_dir, chrom_names, remove_indexed)`
- `gtrack_pack_per_chrom_to_indexed(track_dir, chrom_names, track_type)`

Together they make cross-db format conversion possible without needing to swap the active database.

### Drive-by fix

`.TRACK_INTERNAL_FILES` listed the wrong sidecar filenames (`.attrs`/`.vars` vs. real `.attributes`/`vars`). Corrected; eliminates a spurious "dropped chromosomes" warning the new feature surfaced.

### Out of scope (errors with a clear message)

- 2D track cross-db copy with format conversion to a non-active dataset — chrom-order remap for 2D requires a 2D-indexed splitter that doesn't yet exist.
- Cross-db copy to an unloaded dest path now skips in-memory registration; users run `gsetroot(dest)` afterward to use the track. The dest db's cache is marked dirty for the rescan.

## Test plan

- [x] New test file `tests/testthat/test-track-copy-crossdb.R` — 61 passing across 4 format combos × 2 chrom-order combos × multi-track × overwrite × `.attrs`/`.vars` round-trip × split→pack byte-identicality.
- [x] Existing back-compat tests `tests/testthat/test-multi-db.R` — 69/69 still pass (the legacy `gtrack.copy(src, dest)` form is untouched).
- [x] Existing `tests/testthat/test-indexed-integration.R` — 30/30 still pass.
- [ ] CI runs full suite.