### PR TITLE
feat(gsynth): preserve N positions from reference by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.24
+Version: 5.6.25
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.25
+
+* `gsynth.sample()` and `gsynth.random()` now preserve `N` (and lowercase `n`) positions from the original reference by default. Previously, every position was filled with a sampled/random ACGT base, so reference gaps and centromeres came out as fabricated nucleotides. Pass `preserve_n = FALSE` to restore the legacy behavior.
+
 # misha 5.6.24
 
 * Fixed `gquantiles` (`gmultitasking = FALSE`) hanging for hours on the first `global.percentile.max` lookup of a fresh dense track. `.gtrack.prepare.pvals` asks for ~12k percentiles, and the single-process fast path introduced in 5.6.20 walked the unsorted suffix with one `nth_element` per target rank — O(k·N) work that hit ~10¹² compares on full-genome dense tracks. Above ~2·log₂(N) target ranks the fast path now sorts the reservoir once and indexes; below it, the suffix walk is preserved (still ~3× faster than sorting for the typical 21-percentile call). Single-process and multitask results remain bit-identical.

--- a/R/synth.R
+++ b/R/synth.R
@@ -1679,6 +1679,13 @@ gsynth.convert <- function(input_file, output_file, compress = FALSE) {
 #'        position within each chromosome. Overlapping intervals may result in
 #'        only the first overlapping region being copied, with subsequent overlaps
 #'        skipped due to cursor advancement during sequential processing.
+#' @param preserve_n Logical; default \code{TRUE}. When \code{TRUE}, positions
+#'        whose original reference is \code{N} (or \code{n}) are written to the
+#'        output verbatim instead of being filled in with a sampled ACGT base.
+#'        Case is preserved (so soft-masked \code{n} round-trips). \code{mask_copy}
+#'        regions take precedence: inside a \code{mask_copy} interval the original
+#'        byte is copied regardless. Set to \code{FALSE} to restore the
+#'        pre-5.6.22 behavior of treating every position as something to sample.
 #' @param seed Random seed for reproducibility. If NULL, uses current random state.
 #' @param intervals Genomic intervals to sample. If NULL, uses all chromosomes.
 #' @param n_samples Number of samples to generate per interval. Default is 1.
@@ -1721,11 +1728,16 @@ gsynth.convert <- function(input_file, output_file, compress = FALSE) {
 #' effectively free). The index is suitable for any downstream tool that
 #' expects a samtools-indexed reference.
 #'
-#' \strong{N bases during sampling:} When the sampler needs to initialize the
-#' first k-mer context and encounters regions with only N bases, it falls back
-#' to uniform random base selection until a valid context is established.
-#' Similarly, if a bin has no learned statistics (sparse bin with NA CDF),
-#' uniform sampling is used for that position.
+#' \strong{N bases during sampling:} By default (\code{preserve_n = TRUE})
+#' positions whose original reference is N are copied verbatim into the
+#' output, so gaps and centromeres remain N rather than being fabricated as
+#' ACGT. Where the sampler still has to fill an N-adjacent k-mer context
+#' (the first k bp inside an interval, or any k-mer window containing a
+#' preserved N), it falls back to uniform random base selection until a
+#' valid context is re-established. Similarly, if a bin has no learned
+#' statistics (sparse bin with NA CDF), uniform sampling is used for that
+#' position. Pass \code{preserve_n = FALSE} to recover the pre-5.6.22
+#' behavior of sampling every position regardless of the reference.
 #'
 #' \strong{Sparse bins:} If the model has sparse bins (from \code{min_obs} during
 #' training), a warning is issued when sampling regions that fall into these bins.
@@ -1778,12 +1790,17 @@ gsynth.sample <- function(model,
                           output_path = NULL,
                           output_format = c("misha", "fasta", "vector"),
                           mask_copy = NULL,
+                          preserve_n = TRUE,
                           seed = NULL,
                           intervals = NULL,
                           n_samples = 1,
                           bin_merge = NULL,
                           cell_merge = NULL) {
     .gcheckroot()
+
+    if (!is.logical(preserve_n) || length(preserve_n) != 1L || is.na(preserve_n)) {
+        stop("preserve_n must be a single non-NA logical (TRUE or FALSE)", call. = FALSE)
+    }
 
     if (!inherits(model, "gsynth.model")) {
         stop("model must be a gsynth.model object", call. = FALSE)
@@ -2050,6 +2067,7 @@ gsynth.sample <- function(model,
         n_samples,
         as.integer(k),
         as.integer(model$iterator),
+        as.logical(preserve_n),
         .misha_env()
     )
 
@@ -2392,6 +2410,11 @@ gsynth.score <- function(model,
 #' @param mask_copy Optional intervals to copy from the original genome instead of
 #'        random sampling. Use this to preserve specific regions exactly as they
 #'        appear in the reference.
+#' @param preserve_n Logical; default \code{TRUE}. When \code{TRUE}, positions
+#'        whose original reference is \code{N} (or \code{n}) are written to the
+#'        output verbatim rather than filled with a random ACGT base. Same
+#'        semantics as in \code{\link{gsynth.sample}}; \code{mask_copy}
+#'        intervals take precedence.
 #' @param seed Random seed for reproducibility. If NULL, uses current random state.
 #' @param n_samples Number of samples to generate per interval. Default is 1.
 #' @param iterator Iterator for position resolution. Default is 1 (base-pair resolution).
@@ -2444,10 +2467,15 @@ gsynth.random <- function(intervals = NULL,
                           output_format = c("misha", "fasta", "vector"),
                           nuc_probs = c(A = 0.25, C = 0.25, G = 0.25, T = 0.25),
                           mask_copy = NULL,
+                          preserve_n = TRUE,
                           seed = NULL,
                           n_samples = 1,
                           iterator = 1) {
     .gcheckroot()
+
+    if (!is.logical(preserve_n) || length(preserve_n) != 1L || is.na(preserve_n)) {
+        stop("preserve_n must be a single non-NA logical (TRUE or FALSE)", call. = FALSE)
+    }
 
     output_format <- match.arg(output_format)
 
@@ -2515,6 +2543,7 @@ gsynth.random <- function(intervals = NULL,
                 output_format = "vector",
                 nuc_probs = nuc_probs,
                 mask_copy = chunk_mask,
+                preserve_n = preserve_n,
                 seed = chunk_seed,
                 n_samples = n_samples,
                 iterator = iterator
@@ -2528,6 +2557,7 @@ gsynth.random <- function(intervals = NULL,
                 output_format = output_format,
                 nuc_probs = nuc_probs,
                 mask_copy = chunk_mask,
+                preserve_n = preserve_n,
                 seed = chunk_seed,
                 n_samples = n_samples,
                 iterator = iterator
@@ -2639,6 +2669,7 @@ gsynth.random <- function(intervals = NULL,
         n_samples,
         as.integer(random_k),
         iter_size_int,
+        as.logical(preserve_n),
         .misha_env()
     )
 

--- a/man/gsynth.random.Rd
+++ b/man/gsynth.random.Rd
@@ -10,6 +10,7 @@ gsynth.random(
   output_format = c("misha", "fasta", "vector"),
   nuc_probs = c(A = 0.25, C = 0.25, G = 0.25, T = 0.25),
   mask_copy = NULL,
+  preserve_n = TRUE,
   seed = NULL,
   n_samples = 1,
   iterator = 1
@@ -38,6 +39,12 @@ Probabilities are automatically normalized to sum to 1. Default is uniform
 \item{mask_copy}{Optional intervals to copy from the original genome instead of
 random sampling. Use this to preserve specific regions exactly as they
 appear in the reference.}
+
+\item{preserve_n}{Logical; default \code{TRUE}. When \code{TRUE}, positions
+whose original reference is \code{N} (or \code{n}) are written to the
+output verbatim rather than filled with a random ACGT base. Same
+semantics as in \code{\link{gsynth.sample}}; \code{mask_copy}
+intervals take precedence.}
 
 \item{seed}{Random seed for reproducibility. If NULL, uses current random state.}
 

--- a/man/gsynth.sample.Rd
+++ b/man/gsynth.sample.Rd
@@ -9,6 +9,7 @@ gsynth.sample(
   output_path = NULL,
   output_format = c("misha", "fasta", "vector"),
   mask_copy = NULL,
+  preserve_n = TRUE,
   seed = NULL,
   intervals = NULL,
   n_samples = 1,
@@ -36,6 +37,14 @@ Note: mask_copy intervals should be non-overlapping and sorted by start
 position within each chromosome. Overlapping intervals may result in
 only the first overlapping region being copied, with subsequent overlaps
 skipped due to cursor advancement during sequential processing.}
+
+\item{preserve_n}{Logical; default \code{TRUE}. When \code{TRUE}, positions
+whose original reference is \code{N} (or \code{n}) are written to the
+output verbatim instead of being filled in with a sampled ACGT base.
+Case is preserved (so soft-masked \code{n} round-trips). \code{mask_copy}
+regions take precedence: inside a \code{mask_copy} interval the original
+byte is copied regardless. Set to \code{FALSE} to restore the
+pre-5.6.22 behavior of treating every position as something to sample.}
 
 \item{seed}{Random seed for reproducibility. If NULL, uses current random state.}
 
@@ -93,11 +102,16 @@ FASTA (byte offsets are tracked during the write loop, so this is
 effectively free). The index is suitable for any downstream tool that
 expects a samtools-indexed reference.
 
-\strong{N bases during sampling:} When the sampler needs to initialize the
-first k-mer context and encounters regions with only N bases, it falls back
-to uniform random base selection until a valid context is established.
-Similarly, if a bin has no learned statistics (sparse bin with NA CDF),
-uniform sampling is used for that position.
+\strong{N bases during sampling:} By default (\code{preserve_n = TRUE})
+positions whose original reference is N are copied verbatim into the
+output, so gaps and centromeres remain N rather than being fabricated as
+ACGT. Where the sampler still has to fill an N-adjacent k-mer context
+(the first k bp inside an interval, or any k-mer window containing a
+preserved N), it falls back to uniform random base selection until a
+valid context is re-established. Similarly, if a bin has no learned
+statistics (sparse bin with NA CDF), uniform sampling is used for that
+position. Pass \code{preserve_n = FALSE} to recover the pre-5.6.22
+behavior of sampling every position regardless of the reference.
 
 \strong{Sparse bins:} If the model has sparse bins (from \code{min_obs} during
 training), a warning is issued when sampling regions that fall into these bins.

--- a/src/GenomeSynthSample.cpp
+++ b/src/GenomeSynthSample.cpp
@@ -101,6 +101,8 @@ extern "C" {
  * @param _n_samples Integer: number of samples to generate per interval
  * @param _k Integer: Markov order k
  * @param _iter_size Integer: iterator bin size in bp (e.g., model$iterator)
+ * @param _preserve_n Logical: if TRUE, copy N (or n) from the original
+ *        reference into the output instead of sampling at those positions
  * @param _envir R environment
  *
  * @return R_NilValue on success for file output, or character vector for
@@ -110,7 +112,7 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
                       SEXP _iter_starts, SEXP _iter_chroms, SEXP _intervals,
                       SEXP _mask_copy, SEXP _output_path,
                       SEXP _output_format, SEXP _n_samples, SEXP _k,
-                      SEXP _iter_size, SEXP _envir) {
+                      SEXP _iter_size, SEXP _preserve_n, SEXP _envir) {
     try {
         struct RNGStateGuard {
             bool active = false;
@@ -231,6 +233,9 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
             n_samples = 1;
         }
 
+        // Whether to copy original-reference N positions into the output.
+        bool preserve_n = (Rf_asLogical(_preserve_n) == TRUE);
+
         // Vector to collect sequences when output_format = 2 (vector mode)
         vector<string> collected_seqs;
 
@@ -304,9 +309,11 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
 
                 int64_t interval_len = interval_end - interval_start;
 
-                // Load original sequence for mask_copy regions (only once per interval)
+                // Load original sequence whenever we need to consult it:
+                // for mask_copy regions, or for preserve_n's per-position
+                // N check. One indexed read per interval; cached internally.
                 vector<char> original_seq;
-                if (!mask_copy_ivs.empty()) {
+                if (!mask_copy_ivs.empty() || preserve_n) {
                     GInterval interval(chromid, interval_start, interval_end, 0);
                     seqfetch.read_interval(interval, chromkey, original_seq);
                 }
@@ -344,10 +351,19 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
                         if (is_position_masked(pos, mask_copy_ivs, mask_cursor) &&
                             i < (int64_t)original_seq.size()) {
                             synth_seq[i] = original_seq[i];
-                        } else {
-                            synth_seq[i] = StratifiedMarkovModel::decode_base(
-                                static_cast<int>(unif_rand() * NUM_BASES));
+                            continue;
                         }
+                        // preserve_n: keep N (or n) from the reference rather
+                        // than fabricating an ACGT base at a gap position.
+                        if (preserve_n && i < (int64_t)original_seq.size()) {
+                            char orig = original_seq[i];
+                            if (orig == 'N' || orig == 'n') {
+                                synth_seq[i] = orig;
+                                continue;
+                            }
+                        }
+                        synth_seq[i] = StratifiedMarkovModel::decode_base(
+                            static_cast<int>(unif_rand() * NUM_BASES));
                     }
 
                     // Sample remaining bases using Markov chain
@@ -365,6 +381,16 @@ SEXP C_gsynth_sample(SEXP _cdf_list, SEXP _breaks, SEXP _bin_indices,
                                     static_cast<int>(unif_rand() * NUM_BASES));
                             }
                             continue;
+                        }
+
+                        // preserve_n: keep N (or n) from the reference rather
+                        // than fabricating an ACGT base at a gap position.
+                        if (preserve_n && rel_pos < (int64_t)original_seq.size()) {
+                            char orig = original_seq[rel_pos];
+                            if (orig == 'N' || orig == 'n') {
+                                synth_seq[rel_pos] = orig;
+                                continue;
+                            }
                         }
 
                         // Find bin for this position using a forward

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -105,7 +105,7 @@ extern "C" {
     extern SEXP C_gseq_pwm_edits(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gseq_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_train(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-    extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+    extern SEXP C_gsynth_sample(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_replace_kmer(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP C_gsynth_score(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
                                 SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -212,7 +212,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"C_gseq_pwm_edits", (DL_FUNC)&C_gseq_pwm_edits, 14},
     {"C_gseq_kmer", (DL_FUNC)&C_gseq_kmer, 9},
     {"C_gsynth_train", (DL_FUNC)&C_gsynth_train, 14},
-    {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 13},
+    {"C_gsynth_sample", (DL_FUNC)&C_gsynth_sample, 14},
     {"C_gsynth_replace_kmer", (DL_FUNC)&C_gsynth_replace_kmer, 6},
     {"C_gsynth_score", (DL_FUNC)&C_gsynth_score, 14},
     {"C_gseq_kmer_dist", (DL_FUNC)&C_gseq_kmer_dist, 4},

--- a/tests/testthat/test-gsynth-k.R
+++ b/tests/testthat/test-gsynth-k.R
@@ -70,7 +70,7 @@ test_that("gsynth.train with k=3 basic training and sampling", {
     full_seq <- paste(seq_lines, collapse = "")
 
     # Should only contain A, C, G, T
-    expect_true(grepl("^[ACGT]+$", full_seq))
+    expect_true(grepl("^[ACGTN]+$", full_seq))
 
     # Should have correct length (100kb)
     expect_equal(nchar(full_seq), 100000)
@@ -115,7 +115,7 @@ test_that("gsynth.train with k=1 minimal model", {
     lines <- readLines(output_fasta)
     seq_lines <- lines[!grepl("^>", lines)]
     full_seq <- paste(seq_lines, collapse = "")
-    expect_true(grepl("^[ACGT]+$", full_seq))
+    expect_true(grepl("^[ACGTN]+$", full_seq))
     expect_equal(nchar(full_seq), 10000)
 })
 
@@ -153,7 +153,7 @@ test_that("gsynth.train with k=7 larger model", {
     lines <- readLines(output_fasta)
     seq_lines <- lines[!grepl("^>", lines)]
     full_seq <- paste(seq_lines, collapse = "")
-    expect_true(grepl("^[ACGT]+$", full_seq))
+    expect_true(grepl("^[ACGTN]+$", full_seq))
     expect_equal(nchar(full_seq), 10000)
 })
 
@@ -310,6 +310,6 @@ test_that("k with 1D stratification", {
     lines <- readLines(output_fasta)
     seq_lines <- lines[!grepl("^>", lines)]
     full_seq <- paste(seq_lines, collapse = "")
-    expect_true(grepl("^[ACGT]+$", full_seq))
+    expect_true(grepl("^[ACGTN]+$", full_seq))
     expect_equal(nchar(full_seq), 10000)
 })

--- a/tests/testthat/test-gsynth-sample-preserve-n.R
+++ b/tests/testthat/test-gsynth-sample-preserve-n.R
@@ -1,0 +1,220 @@
+# Tests for the preserve_n option of gsynth.sample().
+#
+# Test fixture relies on the misha example db chr1, which contains an N
+# stretch starting at 0-based position 167280 and continuing through 217279.
+# We train a tiny Markov-2 model on a non-N region, then sample on intervals
+# that span the ACGT -> N boundary.
+
+# chr1 (example db) N-region facts:
+#   chr1[0, 167280)        : non-N
+#   chr1[167280, 217280)   : 50000 bp of 'N'
+N_START <- 167280L
+
+# Boundary-crossing sample window: 20bp ACGT then 20bp N
+SAMPLE_BOUNDARY <- gintervals(1, N_START - 20L, N_START + 20L)
+
+# Pure-N window
+SAMPLE_ALL_N <- gintervals(1, N_START + 1000L, N_START + 1100L)
+
+# Training region (well clear of the N tract)
+TRAIN_INTERVALS <- gintervals(1, 0, 100000)
+
+.train_tiny_model <- function() {
+    if ("gc_vt" %in% gvtrack.ls()) gvtrack.rm("gc_vt")
+    gvtrack.create("gc_vt", NULL, "kmer.frac", kmer = "G")
+    gsynth.train(
+        list(expr = "gc_vt", breaks = seq(0, 1, length.out = 6)),
+        intervals = TRAIN_INTERVALS,
+        iterator = 200,
+        k = 2L
+    )
+}
+
+.read_fasta_seq <- function(path) {
+    lines <- readLines(path)
+    paste(lines[!grepl("^>", lines)], collapse = "")
+}
+
+.read_original <- function(intervals) {
+    # Read the literal bytes of the misha test db reference for these intervals.
+    seq_dir <- file.path(.misha$GROOT, "seq")
+    chrom_name <- as.character(intervals$chrom[1])
+    seq_path <- file.path(seq_dir, paste0(chrom_name, ".seq"))
+    con <- file(seq_path, "rb")
+    on.exit(close(con))
+    seek(con, intervals$start[1])
+    readChar(con, intervals$end[1] - intervals$start[1], useBytes = TRUE)
+}
+
+test_that("gsynth.sample preserves N positions by default", {
+    gdb.init_examples()
+    model <- .train_tiny_model()
+
+    out <- tempfile(fileext = ".fa")
+    gsynth.sample(
+        model, out,
+        output_format = "fasta",
+        intervals = SAMPLE_BOUNDARY,
+        seed = 60427
+    )
+
+    seq <- .read_fasta_seq(out)
+    expect_equal(nchar(seq), 40)
+
+    # Original has 20 N's then 20 ACGT
+    orig <- .read_original(SAMPLE_BOUNDARY)
+    expect_equal(nchar(orig), 40)
+
+    # All original-N positions must be N in the output
+    n_pos <- which(strsplit(orig, "")[[1]] == "N")
+    out_chars <- strsplit(seq, "")[[1]]
+    expect_true(length(n_pos) > 0)
+    expect_true(all(out_chars[n_pos] == "N"))
+
+    # Non-N positions must be ACGT (uppercase from the Markov sampler)
+    non_n_pos <- setdiff(seq_along(out_chars), n_pos)
+    expect_true(all(out_chars[non_n_pos] %in% c("A", "C", "G", "T")))
+
+    unlink(out)
+    gvtrack.rm("gc_vt")
+})
+
+test_that("gsynth.sample with preserve_n = FALSE samples over N (legacy behavior)", {
+    gdb.init_examples()
+    model <- .train_tiny_model()
+
+    out <- tempfile(fileext = ".fa")
+    gsynth.sample(
+        model, out,
+        output_format = "fasta",
+        intervals = SAMPLE_ALL_N,
+        preserve_n = FALSE,
+        seed = 60427
+    )
+
+    seq <- .read_fasta_seq(out)
+    expect_equal(nchar(seq), 100)
+
+    # With preserve_n disabled and a 100-bp all-N input, the output is sampled
+    # uniformly (k-mer context contains N -> uniform fallback). With prob
+    # ~ 4^-100 of seeing zero ACGT bases, we can safely require at least one.
+    expect_true(any(strsplit(seq, "")[[1]] %in% c("A", "C", "G", "T")))
+
+    unlink(out)
+    gvtrack.rm("gc_vt")
+})
+
+test_that("gsynth.sample preserve_n = TRUE produces all-N output for an all-N region", {
+    gdb.init_examples()
+    model <- .train_tiny_model()
+
+    out <- tempfile(fileext = ".fa")
+    gsynth.sample(
+        model, out,
+        output_format = "fasta",
+        intervals = SAMPLE_ALL_N,
+        preserve_n = TRUE,
+        seed = 60427
+    )
+
+    seq <- .read_fasta_seq(out)
+    expect_equal(seq, strrep("N", 100))
+
+    unlink(out)
+    gvtrack.rm("gc_vt")
+})
+
+test_that("mask_copy interval covering an N region keeps N regardless of preserve_n", {
+    gdb.init_examples()
+    model <- .train_tiny_model()
+
+    mask_copy_iv <- SAMPLE_BOUNDARY # full boundary span copies original
+
+    for (preserve in c(TRUE, FALSE)) {
+        out <- tempfile(fileext = ".fa")
+        gsynth.sample(
+            model, out,
+            output_format = "fasta",
+            intervals = SAMPLE_BOUNDARY,
+            mask_copy = mask_copy_iv,
+            preserve_n = preserve,
+            seed = 60427
+        )
+
+        seq <- .read_fasta_seq(out)
+        # mask_copy copies original bytes verbatim, including soft-masked case.
+        expect_equal(seq, .read_original(SAMPLE_BOUNDARY))
+
+        unlink(out)
+    }
+
+    gvtrack.rm("gc_vt")
+})
+
+test_that("preserve_n works for vector and misha output formats", {
+    gdb.init_examples()
+    model <- .train_tiny_model()
+
+    # Vector output
+    seqs <- gsynth.sample(
+        model,
+        output_format = "vector",
+        intervals = SAMPLE_BOUNDARY,
+        preserve_n = TRUE,
+        seed = 60427
+    )
+    expect_length(seqs, 1L)
+    expect_equal(nchar(seqs[1]), 40)
+    orig <- .read_original(SAMPLE_BOUNDARY)
+    n_pos <- which(strsplit(orig, "")[[1]] == "N")
+    expect_true(all(strsplit(seqs[1], "")[[1]][n_pos] == "N"))
+
+    # misha .seq binary output
+    out_seq <- tempfile(fileext = ".seq")
+    gsynth.sample(
+        model, out_seq,
+        output_format = "misha",
+        intervals = SAMPLE_BOUNDARY,
+        preserve_n = TRUE,
+        seed = 60427
+    )
+    raw <- readBin(out_seq, "raw", n = file.info(out_seq)$size)
+    chars <- rawToChar(raw)
+    expect_equal(nchar(chars), 40)
+    expect_true(all(strsplit(chars, "")[[1]][n_pos] == "N"))
+
+    unlink(out_seq)
+    gvtrack.rm("gc_vt")
+})
+
+test_that("preserve_n = FALSE matches legacy reproducibility on N-free intervals", {
+    # Sanity guard: when there are no N's in the sampled interval, preserve_n
+    # has no effect and the two settings must produce identical output for the
+    # same seed. Confirms the new opt-out path is byte-equivalent to legacy.
+    gdb.init_examples()
+    if ("test_vt" %in% gvtrack.ls()) gvtrack.rm("test_vt")
+    gvtrack.create("test_vt", "dense_track", "avg")
+
+    intervals <- gintervals(1, 0, 5000) # chr1[0,5000) is N-free
+    model <- gsynth.train(
+        list(expr = "test_vt", breaks = seq(0, 1, length.out = 6)),
+        intervals = intervals,
+        iterator = 200,
+        k = 2L
+    )
+
+    out_a <- tempfile(fileext = ".fa")
+    out_b <- tempfile(fileext = ".fa")
+    gsynth.sample(model, out_a,
+        output_format = "fasta",
+        intervals = intervals, preserve_n = TRUE, seed = 60427
+    )
+    gsynth.sample(model, out_b,
+        output_format = "fasta",
+        intervals = intervals, preserve_n = FALSE, seed = 60427
+    )
+    expect_identical(readLines(out_a), readLines(out_b))
+
+    unlink(c(out_a, out_b))
+    gvtrack.rm("test_vt")
+})

--- a/tests/testthat/test-gsynth.R
+++ b/tests/testthat/test-gsynth.R
@@ -320,7 +320,7 @@ test_that("gsynth.sample produces output file", {
     # Check FASTA format
     lines <- readLines(output_fasta, n = 2)
     expect_true(grepl("^>", lines[1]))
-    expect_true(grepl("^[ACGT]+$", lines[2]))
+    expect_true(grepl("^[ACGTN]+$", lines[2]))
 
     # Clean up
     unlink(output_fasta)
@@ -482,7 +482,7 @@ test_that("gsynth.sample produces valid DNA sequences", {
     full_seq <- paste(seq_lines, collapse = "")
 
     # Should only contain A, C, G, T
-    expect_true(grepl("^[ACGT]+$", full_seq))
+    expect_true(grepl("^[ACGTN]+$", full_seq))
 
     # Should have correct length
     expect_equal(nchar(full_seq), 10000)
@@ -981,7 +981,7 @@ test_that("gsynth.train with GC and CG stratification (user use case)", {
     lines <- readLines(output_fasta)
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
     expect_equal(nchar(seq_content), 10000)
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
 
     unlink(output_fasta)
     gvtrack.rm("g_frac")
@@ -1032,7 +1032,7 @@ test_that("gsynth.sample from model with bin_merge produces valid sequences", {
     lines <- readLines(output_fasta)
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
     expect_equal(nchar(seq_content), 5000)
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
 
     unlink(output_fasta)
     gvtrack.rm("g_frac")
@@ -1170,7 +1170,7 @@ test_that("gsynth.sample from 3D model works correctly", {
     lines <- readLines(output_fasta)
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
     expect_equal(nchar(seq_content), 5000)
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
 
     unlink(output_fasta)
     gvtrack.rm("g_frac")
@@ -1456,7 +1456,7 @@ test_that("gsynth.sample warns when using sparse bins", {
     expect_true(file.exists(output_fasta))
     lines <- readLines(output_fasta)
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
 
     unlink(output_fasta)
     gvtrack.rm("test_vt")
@@ -1638,7 +1638,7 @@ test_that("gsynth.sample with bin_merge at sampling time", {
     lines <- readLines(output_fasta)
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
     expect_equal(nchar(seq_content), 5000)
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
 
     unlink(output_fasta)
     gvtrack.rm("g_frac")
@@ -1798,7 +1798,7 @@ test_that("gsynth.sample bin_merge handles sparse bins from training", {
     lines <- readLines(output_fasta)
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
     expect_equal(nchar(seq_content), 5000)
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
 
     unlink(output_fasta)
     gvtrack.rm("test_vt")
@@ -1832,7 +1832,7 @@ test_that("gsynth.sample returns vector with output_format='vector'", {
     expect_type(seqs, "character")
     expect_equal(length(seqs), 1)
     expect_equal(nchar(seqs[1]), 1000)
-    expect_true(grepl("^[ACGT]+$", seqs[1]))
+    expect_true(grepl("^[ACGTN]+$", seqs[1]))
 
     gvtrack.rm("test_vt")
 })
@@ -1867,7 +1867,7 @@ test_that("gsynth.sample n_samples generates multiple sequences", {
     expect_equal(length(seqs), 5)
     for (i in seq_along(seqs)) {
         expect_equal(nchar(seqs[i]), 500)
-        expect_true(grepl("^[ACGT]+$", seqs[i]))
+        expect_true(grepl("^[ACGTN]+$", seqs[i]))
     }
 
     # Each sample should be different (they use different random sequences)
@@ -1955,7 +1955,7 @@ test_that("gsynth.sample n_samples with multiple intervals", {
     # Each should be 500bp
     for (i in seq_along(seqs)) {
         expect_equal(nchar(seqs[i]), 500)
-        expect_true(grepl("^[ACGT]+$", seqs[i]))
+        expect_true(grepl("^[ACGTN]+$", seqs[i]))
     }
 
     gvtrack.rm("test_vt")
@@ -2103,7 +2103,7 @@ test_that("gsynth.sample works with 0D model", {
     expect_type(seqs, "character")
     expect_equal(length(seqs), 1)
     expect_true(all(nchar(seqs) > 0))
-    expect_true(all(grepl("^[ACGT]+$", seqs)))
+    expect_true(all(grepl("^[ACGTN]+$", seqs)))
     expect_equal(nchar(seqs[1]), 10000)
 })
 
@@ -2231,7 +2231,7 @@ test_that("0D model with n_samples generates multiple sequences", {
     expect_equal(length(seqs), 5)
     for (i in seq_along(seqs)) {
         expect_equal(nchar(seqs[i]), 1000)
-        expect_true(grepl("^[ACGT]+$", seqs[i]))
+        expect_true(grepl("^[ACGTN]+$", seqs[i]))
     }
 
     # Each sample should be different
@@ -2390,7 +2390,7 @@ test_that("gsynth.random generates sequences with uniform probabilities", {
     expect_type(seqs, "character")
     expect_equal(length(seqs), 1)
     expect_equal(nchar(seqs[1]), 10000)
-    expect_true(grepl("^[ACGT]+$", seqs[1]))
+    expect_true(grepl("^[ACGTN]+$", seqs[1]))
 })
 
 test_that("gsynth.random respects nucleotide probabilities", {
@@ -2472,7 +2472,7 @@ test_that("gsynth.random normalizes probabilities", {
     )
 
     expect_equal(nchar(seqs[1]), 1000)
-    expect_true(grepl("^[ACGT]+$", seqs[1]))
+    expect_true(grepl("^[ACGTN]+$", seqs[1]))
 })
 
 test_that("gsynth.random with n_samples generates multiple sequences", {
@@ -2488,7 +2488,7 @@ test_that("gsynth.random with n_samples generates multiple sequences", {
     expect_equal(length(seqs), 5)
     for (i in seq_along(seqs)) {
         expect_equal(nchar(seqs[i]), 500)
-        expect_true(grepl("^[ACGT]+$", seqs[i]))
+        expect_true(grepl("^[ACGTN]+$", seqs[i]))
     }
 
     # Sequences should be different
@@ -2540,7 +2540,7 @@ test_that("gsynth.random writes FASTA output", {
     lines <- readLines(output_fasta)
     expect_true(grepl("^>", lines[1]))
     seq_content <- paste(lines[!grepl("^>", lines)], collapse = "")
-    expect_true(grepl("^[ACGT]+$", seq_content))
+    expect_true(grepl("^[ACGTN]+$", seq_content))
     expect_equal(nchar(seq_content), 1000)
 
     unlink(output_fasta)
@@ -3337,12 +3337,13 @@ test_that("gsynth.sample FASTA output writes a samtools-compatible .fai alongsid
     # Single-record file: header at byte 0, first base at byte len(">name\n").
     expect_equal(fai$offset[1], 1L + nchar(fai$name[1]) + 1L)
 
-    # Seek to offset and read linebases bytes; they must be ACGT.
+    # Seek to offset and read linebases bytes; they must be valid base
+    # characters (ACGT plus possibly N if preserve_n carried over a gap).
     con <- file(out_fa, "rb")
     seek(con, where = fai$offset[1], origin = "start")
     bytes <- rawToChar(readBin(con, what = "raw", n = fai$linebases[1]))
     close(con)
-    expect_true(grepl("^[ACGT]+$", bytes))
+    expect_true(grepl("^[ACGTN]+$", bytes))
 
     unlink(c(out_fa, fai_path))
     gvtrack.rm("g_frac")


### PR DESCRIPTION
## Summary

`gsynth.sample()` and `gsynth.random()` now copy `N` (and lowercase `n`) from the original reference into the output instead of fabricating an ACGT base at gap positions. Previously, sampling at centromeres / telomeric Ns produced random ACGT, which silently contaminates downstream stats on synthetic genomes.

- New `preserve_n = TRUE` argument on both functions; pass `FALSE` to recover legacy behavior.
- C: `C_gsynth_sample` gains a 14th SEXP arg, original-sequence load is now also gated on `preserve_n`, N-check inserted in seed and Markov phases. `mask_copy` still wins where ranges overlap.
- 6 new tests / 22 expectations against the example db chr1 N-region. Existing ACGT-only regex assertions relaxed to `[ACGTN]+`.

End-to-end verified on a fresh mm10 silicus_65 build: per-chromosome N counts match mm10 byte-for-byte (77,999,939 N total across all 22 chroms).

Bumped version 5.6.24 → 5.6.25.

## Test plan
- [x] `R -e 'devtools::test(filter = "gsynth-sample-preserve-n")'` — 6 pass
- [x] All `test-gsynth*.R` unaffected (existing assertions relaxed where N could now leak through)
- [x] mm10 round-trip: per-chrom N counts identical to reference