### PR TITLE
fix(BinFinder): handle +/-Inf breaks in init

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.25
+Version: 5.6.26
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.26
+
+* Fixed `gpartition`, `gquantiles` and other consumers of `BinFinder` silently routing every value into the highest bin when the breaks vector contained both `-Inf` and `+Inf` (e.g. `c(-Inf, 0, Inf)`). The uniform-binsize fast path computed `Inf/Inf = NaN` whose cast to int is undefined behaviour. `BinFinder::init` now falls back to binary search when binsize is non-finite.
+
 # misha 5.6.25
 
 * `gsynth.sample()` and `gsynth.random()` now preserve `N` (and lowercase `n`) positions from the original reference by default. Previously, every position was filled with a sampled/random ACGT base, so reference gaps and centromeres came out as fabricated nucleotides. Pass `preserve_n = FALSE` to restore the legacy behavior.

--- a/src/BinFinder.cpp
+++ b/src/BinFinder.cpp
@@ -33,4 +33,11 @@ void BinFinder::init(const double *breaks, unsigned num_breaks, bool include_low
 
 		m_breaks.push_back(breaks[i]);
 	}
+
+	// When breaks contain +/-Inf the per-step diff is Inf and the loop above
+	// keeps m_binsize == Inf. The uniform-binsize fast path in val2bin() then
+	// computes Inf/Inf = NaN, whose cast to int is undefined behaviour and
+	// silently misroutes every value to a single bin. Force binary search.
+	if (!std::isfinite(m_binsize))
+		m_binsize = 0;
 }

--- a/tests/testthat/test-gpartition.R
+++ b/tests/testthat/test-gpartition.R
@@ -42,3 +42,35 @@ test_that("gpartition with test.rects and data size option", {
     r <- gintervals.load(temp_track_name)
     expect_regression(r, "gpartition_rects_data_size_result")
 })
+
+test_that("gpartition with c(-Inf, x, Inf) breaks distinguishes both bins", {
+    # Regression: BinFinder::init left m_binsize == Inf when every adjacent
+    # break-diff is Inf (e.g. c(-Inf, x, Inf)), which sent val2bin's
+    # uniform-binsize fast path through Inf/Inf -> NaN -> (int)NaN -> wrong
+    # bin, silently routing every value to the last bin.
+    intervs <- gintervals(1, 0, 5000)
+    cut_at <- 0.13 # roughly mid-range for test.fixedbin (~[0, 0.26])
+
+    res <- gpartition("test.fixedbin", c(-Inf, cut_at, Inf),
+        intervals = intervs, include.lowest = TRUE, iterator = 50L
+    )
+
+    # Both bins must actually appear, otherwise the buggy "always last bin"
+    # behaviour would still pass.
+    expect_true(any(res$bin == 1L, na.rm = TRUE))
+    expect_true(any(res$bin == 2L, na.rm = TRUE))
+
+    # Cross-check bp per bin against a manual R cut().  gpartition merges
+    # adjacent same-bin intervals so per-row equality is not meaningful, but
+    # total bp per bin must match.
+    raw <- gextract("test.fixedbin", intervs, iterator = 50L, colnames = "x")
+    expected_bin <- as.integer(cut(raw$x,
+        breaks = c(-Inf, cut_at, Inf), include.lowest = TRUE, right = TRUE
+    ))
+    expected_bp <- tapply(raw$end - raw$start, expected_bin, sum)
+    actual_bp <- tapply(res$end - res$start, res$bin, sum)
+    expect_equal(
+        as.numeric(actual_bp[c("1", "2")]),
+        as.numeric(expected_bp[c("1", "2")])
+    )
+})


### PR DESCRIPTION
## Summary
- `BinFinder::init` left `m_binsize == Inf` when every adjacent break-diff was `Inf` (e.g. `c(-Inf, 0, Inf)`). The uniform-binsize fast path in `val2bin` then computed `Inf/Inf = NaN`; `(int)NaN` is UB and on x86_64 yields `INT_MIN`, which `min(INT_MIN - 1, K - 1)` wraps to `K - 1` — every value silently routed to the last bin.
- Affects any consumer of user-supplied breaks (`gpartition`, `gquantiles`, `gscreen`, `gintervals.quantiles`, glm_pred selectors, ...). Caught while debugging a `glm_pred` vtrack with a `c(-Inf, 0, Inf)` polarization selector that ignored its negative-pol slice.
- Fix: force the binary-search path whenever `m_binsize` is non-finite.

## Test plan
- [x] Added regression test in `test-gpartition.R` using `c(-Inf, x, Inf)` breaks; verified it fails without the fix and passes with it.
- [x] `gpartition`/`gquantiles`/`gscreen`/`gintervals.quantiles` test suites — 28 PASS, 0 FAIL.
- [x] Independently verified the same fix on `feat/glm-pred` against `vtrack-glm-pred` (208 PASS) and a broader 12,270-test cross-check.
- [ ] CI (`devtools::check`) runs on push.