### PR TITLE
fix(install-intervals): error when a requested set is missing; add force=TRUE escape

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # misha (development version)
 
+* `gdb.install_intervals()` now errors if any requested set is unavailable from the source (previously skipped silently with a warning). Pass `force = TRUE` to demote the error to a summary warning and install the available sets.
+
 # misha 5.6.28
 
 * `gtrack.copy()` gained a `db` argument to copy tracks across databases, and an `overwrite` argument to replace existing destinations. Format conversion (per-chromosome <-> indexed) and chromosome-order remap are handled automatically. Multi-track input is also supported.

--- a/R/genome-build.R
+++ b/R/genome-build.R
@@ -1179,6 +1179,10 @@ gdb.install_gtf_converter <- function(force = FALSE) {
 #'   the \code{ucsc-hub} backend (which ships per-contig lengths in
 #'   \code{<acc>.chrom.sizes.txt}); other backends are unaffected. Set
 #'   \code{FALSE} for the stricter single-column-only behavior.
+#' @param force If \code{FALSE} (default), any requested set that the source
+#'   doesn't provide raises an error and aborts the call before touching the
+#'   groot. If \code{TRUE}, missing sets are demoted to a single summary
+#'   warning and the available sets are installed.
 #' @param verbose If \code{TRUE}, prints progress.
 #' @param prefetched_alias Optional pre-fetched chromAlias bundle (the
 #'   return value of \code{.hub_preflight_coverage}). When supplied the
@@ -1228,6 +1232,7 @@ gdb.install_intervals <- function(groot,
                                   target_lengths = NULL,
                                   min_coverage = 1.0,
                                   match_by_length = TRUE,
+                                  force = FALSE,
                                   verbose = TRUE,
                                   prefetched_alias = NULL,
                                   .from_build_genome = FALSE) {
@@ -1323,6 +1328,27 @@ gdb.install_intervals <- function(groot,
         stop(sprintf("No fetcher for source '%s'", recipe$source), call. = FALSE)
     )
     assets <- fetcher(recipe, sets, workdir, verbose)
+
+    # Detect requested sets the source couldn't provide. Fetchers warn-and-skip
+    # individually, which historically meant gdb.install_intervals returned
+    # cleanly even when some requested sets weren't installed. Surface that as
+    # an error (or a single summary warning under force=TRUE).
+    missing_sets <- sets[vapply(sets, function(s) is.null(assets[[s]]), logical(1))]
+    if (length(missing_sets) > 0L) {
+        msg <- sprintf(
+            "Requested set(s) not available from source '%s': %s",
+            recipe$source, paste(missing_sets, collapse = ", ")
+        )
+        if (isTRUE(force)) {
+            warning(msg, call. = FALSE)
+        } else {
+            stop(sprintf(
+                "%s\nPass force = TRUE to demote this to a warning and install the available sets.",
+                msg
+            ), call. = FALSE)
+        }
+    }
+    installed_sets <- setdiff(sets, missing_sets)
 
     # chromAlias: detect groot column and source columns; build translator closure.
     # Coverage is bp-weighted on the groot side -- a long-tail of small unmapped
@@ -1582,12 +1608,14 @@ gdb.install_intervals <- function(groot,
         spec$installer(df, prefix = prefix, overwrite = overwrite, verbose = verbose)
     }
 
-    # Provenance: append to genome_info.yaml.
-    .append_tracks_to_genome_info(groot, recipe, sets, prefix)
+    # Provenance: append to genome_info.yaml. Record only the sets that
+    # actually got installed (under force=TRUE some requested sets may have
+    # been missing and skipped).
+    .append_tracks_to_genome_info(groot, recipe, installed_sets, prefix)
 
     # Final reload + summary.
     gdb.init(groot, rescan = TRUE)
-    if (verbose) .install_intervals_summary(groot, recipe, sets, prefix)
+    if (verbose) .install_intervals_summary(groot, recipe, installed_sets, prefix)
     invisible(NULL)
 }
 

--- a/man/gdb.install_intervals.Rd
+++ b/man/gdb.install_intervals.Rd
@@ -17,6 +17,7 @@ gdb.install_intervals(
   target_lengths = NULL,
   min_coverage = 1,
   match_by_length = TRUE,
+  force = FALSE,
   verbose = TRUE,
   prefetched_alias = NULL,
   .from_build_genome = FALSE
@@ -82,6 +83,11 @@ scheme (or mixed schemes) imports cleanly. Currently honored only by
 the \code{ucsc-hub} backend (which ships per-contig lengths in
 \code{<acc>.chrom.sizes.txt}); other backends are unaffected. Set
 \code{FALSE} for the stricter single-column-only behavior.}
+
+\item{force}{If \code{FALSE} (default), any requested set that the source
+doesn't provide raises an error and aborts the call before touching the
+groot. If \code{TRUE}, missing sets are demoted to a single summary
+warning and the available sets are installed.}
 
 \item{verbose}{If \code{TRUE}, prints progress.}
 

--- a/tests/testthat/test-genome-build-install-intervals.R
+++ b/tests/testthat/test-genome-build-install-intervals.R
@@ -1,0 +1,48 @@
+# Tests for gdb.install_intervals partial-failure handling.
+
+make_tiny_groot_for_install <- function() {
+    groot <- tempfile("misha_test_install_")
+    dir.create(groot)
+    dir.create(file.path(groot, "tracks"))
+    dir.create(file.path(groot, "seq"))
+    writeLines(c("chr1\t1000", "chr2\t1000"), file.path(groot, "chrom_sizes.txt"))
+    file.create(file.path(groot, "seq", "chr1.seq"))
+    file.create(file.path(groot, "seq", "chr2.seq"))
+    groot
+}
+
+test_that("gdb.install_intervals errors when a requested set has no asset (default)", {
+    groot <- make_tiny_groot_for_install()
+    on.exit(unlink(groot, recursive = TRUE), add = TRUE)
+    gdb.init(groot, rescan = TRUE)
+
+    # `manual` source with no URLs: .manual_fetch_assets returns no entries
+    # for any of the requested sets. Currently the function returns silently;
+    # we want a hard error.
+    expect_error(
+        suppressWarnings(suppressMessages(gdb.install_intervals(
+            groot = groot,
+            source = list(source = "manual", fasta = "n/a"),
+            sets = c("genes", "rmsk"),
+            verbose = FALSE
+        ))),
+        "genes.*rmsk|rmsk.*genes"
+    )
+})
+
+test_that("gdb.install_intervals with force=TRUE warns instead of erroring on missing sets", {
+    groot <- make_tiny_groot_for_install()
+    on.exit(unlink(groot, recursive = TRUE), add = TRUE)
+    gdb.init(groot, rescan = TRUE)
+
+    expect_warning(
+        suppressMessages(gdb.install_intervals(
+            groot = groot,
+            source = list(source = "manual", fasta = "n/a"),
+            sets = c("genes", "rmsk"),
+            verbose = FALSE,
+            force = TRUE
+        )),
+        "genes.*rmsk|rmsk.*genes"
+    )
+})


### PR DESCRIPTION
## Summary
- `gdb.install_intervals()` previously returned cleanly when a source didn't provide a requested set: the per-set fetchers emitted `warning()`s and the orchestrator never checked. The function appeared to succeed.
- Now: after fetching, any requested set with no asset triggers a single summary `error` listing the missing sets and the source. Passing `force = TRUE` demotes that error to a `warning` and installs the available sets.
- `genome_info.yaml` provenance and the final summary record only the sets that were actually installed (not the requested set list).

## Scope
- `force` only governs the "asset missing from source" case. Runtime errors during parsing/installation still propagate as fatal regardless of `force` - intentionally narrow.

## Test plan
- [x] New `tests/testthat/test-genome-build-install-intervals.R`: two cases (default errors, `force = TRUE` warns) via the `manual` source with no URLs.
- [x] No regressions in `genome-build`, `genome-build-installers`, `genome-build-recipe`, `genome-build-resolve`, `genome-build-chromalias` (354 / 31 / 13 / 4 / 94 pass).