### PR TITLE
ci: clear Node 20 / auto-activate-base deprecation warnings

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
       NOT_CRAN: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
@@ -31,7 +31,7 @@ jobs:
           channels: conda-forge
           channel-priority: strict
           activate-environment: base
-          auto-activate-base: true
+          auto-activate: true
 
       - name: Install conda-build and anaconda-client
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` v3/v4 -> v5 across all four workflows (Node 24 ready).
- Bumps `actions/cache` v3 -> v4 in `style.yaml`.
- Renames `auto-activate-base: true` to `auto-activate: true` in `conda-publish.yml`; `activate-environment: base` stays explicit, matching the new option contract.

## Why
GitHub will force Node-20 actions to Node 24 by June 2, 2026 and remove Node 20 from the runner by Sep 16, 2026. `auto-activate-base` was already renamed to `auto-activate` upstream. No behavior changes - the previous `v5.6.29` conda-publish ran clean with the deprecated knobs, this just silences the warnings before they bite.

## Test plan
- [ ] `R-CMD-check`, `pkgdown`, `style` checks pass on this PR.
- [ ] No `conda-publish` run on this PR (only fires on `v*` tags or workflow_dispatch); next tag will exercise it.