### PR TITLE
fix(install-intervals): tolerate unconvertible GFF records (5.6.31)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.30
+Version: 5.6.31
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.6.31
+
+* `gdb.install_intervals(..., sets = "genes")` from NCBI no longer aborts on a handful of unconvertible GFF records (typically the immunoglobulin loci in RefSeq human/mouse): `gff3ToGenePred` is now invoked with `-warnAndContinue`, so the offending transcripts are skipped with a warning and the rest of the genome is installed.
+
 # misha 5.6.30
 
 * `gtrack.rm()` (and `gintervals.rm()`) now returns immediately even when the target directory contains millions of files; the actual filesystem cleanup runs in the background.

--- a/R/genome-build-installers.R
+++ b/R/genome-build-installers.R
@@ -129,8 +129,13 @@
     } else if (asset$format == "gff3") {
         converter <- .gff3_to_genepred_resolve_or_install()
         gp_raw <- file.path(workdir, "raw.genePred")
+        # -warnAndContinue + -maxConvertErrors=-1 keep the conversion alive when
+        # NCBI's RefSeq GFF has a handful of records the tool can't convert
+        # (typical case: immunoglobulin V/D/J segments whose CDS coords don't
+        # fit inside parent exons). Without these flags a 5-record problem
+        # aborts the entire ~70k-record run.
         ret <- system2(converter,
-            args = c(shQuote(src), shQuote(gp_raw)),
+            args = c("-warnAndContinue", "-maxConvertErrors=-1", shQuote(src), shQuote(gp_raw)),
             stdout = if (verbose) "" else FALSE,
             stderr = if (verbose) "" else FALSE
         )

--- a/tests/testthat/test-genome-build-installers.R
+++ b/tests/testthat/test-genome-build-installers.R
@@ -230,6 +230,48 @@ test_that(".install_genes_set with NA in gene_sets skips that role", {
     expect_false(gintervals.exists("utr5"))
 })
 
+test_that(".install_genes_set tolerates GFF3 records that fail conversion (NCBI Ig case)", {
+    # NCBI's RefSeq human GFF carries a handful of immunoglobulin V/D/J
+    # records whose CDS coords extend beyond their parent exon. Without
+    # -warnAndContinue the whole ~70k-row conversion aborts on the first
+    # such record, leaving only the mitochondrial subset (which converts
+    # before the loop reaches the Ig loci).
+    converter <- tryCatch(.gff3_to_genepred_resolve_or_install(),
+        error = function(e) NULL
+    )
+    skip_if(is.null(converter), "gff3ToGenePred binary not available")
+
+    groot <- make_test_groot()
+    on.exit(unlink(groot, recursive = TRUE))
+    dir.create(file.path(groot, "downloads"), showWarnings = FALSE)
+    gdb.init(groot, rescan = TRUE)
+
+    gff <- tempfile(fileext = ".gff3")
+    writeLines(c(
+        "##gff-version 3",
+        # Good gene: CDS sits inside exons.
+        "chr1\tsrc\tgene\t101\t500\t.\t+\t.\tID=g1;Name=GOOD",
+        "chr1\tsrc\tmRNA\t101\t500\t.\t+\t.\tID=m1;Parent=g1;Name=GOOD-tx",
+        "chr1\tsrc\texon\t101\t500\t.\t+\t.\tID=e1;Parent=m1",
+        "chr1\tsrc\tCDS\t151\t450\t.\t+\t0\tID=c1;Parent=m1",
+        # Bad gene: CDS extends beyond exon (Ig-style annotation).
+        "chr1\tsrc\tgene\t600\t900\t.\t+\t.\tID=g2;Name=BAD",
+        "chr1\tsrc\tmRNA\t600\t900\t.\t+\t.\tID=m2;Parent=g2;Name=BAD-tx",
+        "chr1\tsrc\texon\t600\t700\t.\t+\t.\tID=e2;Parent=m2",
+        "chr1\tsrc\tCDS\t750\t850\t.\t+\t0\tID=c2;Parent=m2"
+    ), gff)
+
+    .install_genes_set(
+        list(file = gff, format = "gff3"),
+        prefix = "",
+        gene_sets = c(tss = "tss", exons = "exons", utr3 = "utr3", utr5 = "utr5"),
+        overwrite = FALSE, verbose = FALSE
+    )
+    # GOOD record converts; BAD is skipped with a warning.
+    expect_true(gintervals.exists("tss"))
+    expect_equal(nrow(gintervals.load("tss")), 1L)
+})
+
 test_that(".install_genes_set creates intermediate dirs for dotted prefix", {
     groot <- make_test_groot()
     on.exit(unlink(groot, recursive = TRUE))


### PR DESCRIPTION
## Summary

NCBI's RefSeq human/mouse GFFs include a handful of immunoglobulin V/D/J segments whose CDS coordinates extend beyond their parent exon. Without `-warnAndContinue`, `gff3ToGenePred` aborts the entire conversion on the first such record - in practice the human GRCh38 GFF aborts after 5 errors and leaves the caller with only the mitochondrial subset of TSSes/exons.

This patch passes `-warnAndContinue -maxConvertErrors=-1` so the offending records are skipped with a warning and the rest of the genome converts normally.

## What changed

- `R/genome-build-installers.R`: add `-warnAndContinue -maxConvertErrors=-1` to the `gff3ToGenePred` invocation in `.install_genes_set()`.
- `tests/testthat/test-genome-build-installers.R`: new test that builds a synthetic GFF3 with one well-formed transcript and one Ig-style record (CDS outside exon), runs it through `.install_genes_set()`, and verifies the good record installs while the bad one is dropped. Skipped if the converter binary cannot be resolved.
- `NEWS.md` + `DESCRIPTION`: 5.6.31 entry and version bump.

## Test plan

- [x] `devtools::test(filter = 'genome-build-installers')` - 33 tests pass locally
- [ ] CI green