### PR TITLE
perf: coalesce stdio writes + parallelize empty-chrom signatures on create_sparse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.6.32
+Version: 5.6.33
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * Track-creation writes (`gtrack.create_sparse()`, `gtrack.create_dense()`, `gtrack.create()`, `gtrack.smooth()`, `gtrack.modify()`, `gtrack.convert_to_indexed()`) coalesce into far fewer syscalls on networked filesystems by bumping the stdio buffer to 1 MiB on every misha-managed write file. Noticeable on NFS-mounted track DBs.
 * `gtrack.create_sparse()` on per-chromosome (non-indexed) DBs now creates the empty-chrom signature files in parallel via raw POSIX syscalls. Worker count is configurable via the `gtrack.create.threads` option (default 4, matching NFSv3 CREATE concurrency).
 
+### Bug fixes
+
+* **Behavior fix:** `gtrack.rm("X")` followed by `gtrack.create_*("X", ...)` (and the analogous `gintervals.rm` + `gintervals.save` cycle) on the same indexed DB no longer breaks subsequent reads. The process-static index caches keyed by track/intervals directory path were never invalidated, so after rm-then-recreate readers could route to a stale layout and error with `Cannot open track.dat: No such file or directory` or silently return data from the prior lifecycle. Latent since v5.1.1 (1D tracks and interval sets) and v5.5.0 (2D tracks).
+
 # misha 5.6.32
 
 * Fixed `gtrack.create_dense()` returning wrong values (and `func = "coverage"` exploding to huge numbers) when overlapping intervals of mixed lengths fed into the same bin. Older callers using the default `func = "weighted.mean"` got plausible-looking but algebraically wrong means in affected bins.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# misha 5.6.33
+
+### Performance
+
+* Track-creation writes (`gtrack.create_sparse()`, `gtrack.create_dense()`, `gtrack.create()`, `gtrack.smooth()`, `gtrack.modify()`, `gtrack.convert_to_indexed()`) coalesce into far fewer syscalls on networked filesystems by bumping the stdio buffer to 1 MiB on every misha-managed write file. Noticeable on NFS-mounted track DBs.
+* `gtrack.create_sparse()` on per-chromosome (non-indexed) DBs now creates the empty-chrom signature files in parallel via raw POSIX syscalls. Worker count is configurable via the `gtrack.create.threads` option (default 4, matching NFSv3 CREATE concurrency).
+
 # misha 5.6.32
 
 * Fixed `gtrack.create_dense()` returning wrong values (and `func = "coverage"` exploding to huge numbers) when overlapping intervals of mixed lengths fed into the same bin. Older callers using the default `func = "weighted.mean"` got plausible-looking but algebraically wrong means in affected bins.

--- a/R/db-index.R
+++ b/R/db-index.R
@@ -1074,6 +1074,10 @@ gtrack.convert_to_indexed <- function(track = NULL) {
         }
     )
 
+    # Track layout flipped per-chrom -> indexed; any prior cache entry
+    # (nullptr from the per-chrom era) is now wrong.
+    .gdb.invalidate_dir_cache(trackdir)
+
     invisible(0)
 }
 
@@ -1086,6 +1090,9 @@ gtrack.convert_to_indexed <- function(track = NULL) {
         track_dir, as.character(chrom_names), isTRUE(remove_indexed),
         .misha_env()
     )
+    # Track layout flipped indexed -> per-chrom; the cached TrackIndex is
+    # now invalid.
+    .gdb.invalidate_dir_cache(track_dir)
     invisible()
 }
 
@@ -1098,6 +1105,7 @@ gtrack.convert_to_indexed <- function(track = NULL) {
         track_dir, as.character(chrom_names), as.character(track_type),
         .misha_env()
     )
+    .gdb.invalidate_dir_cache(track_dir)
     invisible()
 }
 
@@ -1184,6 +1192,10 @@ gintervals.convert_to_indexed <- function(set.name = NULL, remove.old = FALSE, f
         }
     )
 
+    # Layout flipped per-chrom -> indexed; drop any cached IntervalsIndex1D
+    # entry for this dir.
+    .gdb.invalidate_dir_cache(intervset_path)
+
     invisible(NULL)
 }
 
@@ -1260,6 +1272,12 @@ gtrack.2d.convert_to_indexed <- function(track = NULL, remove.old = FALSE, force
             stop(sprintf("Failed to convert 2D track %s: %s", trackstr, e$message), call. = FALSE)
         }
     )
+
+    # 2D layout flipped per-pair -> indexed; drop any cached TrackIndex2D
+    # for this dir. (The C++ already calls TrackIndex2D::clear_cache() as
+    # a blanket reset; the targeted call here is harmless and keeps the
+    # invariant uniform across paths.)
+    .gdb.invalidate_dir_cache(trackdir)
 
     invisible(0)
 }
@@ -1349,6 +1367,10 @@ gintervals.2d.convert_to_indexed <- function(set.name = NULL, remove.old = FALSE
             stop(sprintf("Failed to convert 2D interval set %s: %s", set.name, e$message), call. = FALSE)
         }
     )
+
+    # 2D bigset layout flipped per-pair -> indexed; drop the cached
+    # IntervalsIndex2D entry for this dir.
+    .gdb.invalidate_dir_cache(intervset_path)
 
     invisible(NULL)
 }

--- a/R/db-invalidate-cache.R
+++ b/R/db-invalidate-cache.R
@@ -1,0 +1,23 @@
+# Drop the process-static index cache entries that misha maintains for
+# `dir` (a track or interval-set directory). Call this from R-level
+# mutation points (rm, create-atomic rename, convert) so subsequent
+# readers don't route through a stale `dir -> shared_ptr<TrackIndex>`
+# entry. Without this, "rm <track>; create_*<track>" cycles on indexed
+# DBs can route reads to a non-existent track.dat.
+#
+# Best-effort: failures swallowed - cache miss is not fatal.
+.gdb.invalidate_dir_cache <- function(dir) {
+    if (is.null(dir) || length(dir) == 0L) {
+        return(invisible(NULL))
+    }
+    dir <- as.character(dir)
+    dir <- dir[nzchar(dir)]
+    if (!length(dir)) {
+        return(invisible(NULL))
+    }
+    tryCatch(
+        .gcall("gdb_invalidate_dir_cache", dir, .misha_env()),
+        error = function(e) NULL
+    )
+    invisible(NULL)
+}

--- a/R/db-trash.R
+++ b/R/db-trash.R
@@ -26,8 +26,13 @@
         if (file.exists(path)) {
             return(invisible(FALSE))
         }
+        .gdb.invalidate_dir_cache(path)
         return(invisible(TRUE))
     }
+
+    # Path's contents are gone; drop any cached index entry keyed by it
+    # before recreate-at-same-path resurrects a stale entry.
+    .gdb.invalidate_dir_cache(path)
 
     if (async) {
         cmd <- sprintf("nohup rm -rf -- %s >/dev/null 2>&1 &", shQuote(trash))

--- a/R/track-create-atomic.R
+++ b/R/track-create-atomic.R
@@ -80,6 +80,12 @@
                     call. = FALSE
                 )
             }
+            # Drop any stale cache entry for final_dir left over from a
+            # previous track lifecycle at this path. Without this, readers
+            # consulting GenomeTrack::s_index_cache may route to the wrong
+            # layout (e.g., open a non-existent track.dat on what is now
+            # a per-chrom track).
+            .gdb.invalidate_dir_cache(final_dir)
             success <- TRUE
         },
         finally = {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -53,6 +53,12 @@
     options(gtrack.chunk.size = 100000)
     options(gtrack.num.chunks = 0)
 
+    # Worker count for the parallel empty-chrom signature-file path in
+    # gtrack.create_sparse on non-indexed DBs. NFSv3 saturates around 4
+    # concurrent CREATEs; set to 1 to disable parallelism. Capped at 32
+    # in C++.
+    options(gtrack.create.threads = 4L)
+
     # set the groot to samples dir
     if (!exists("GROOT", envir = .misha)) {
         gdb.init_examples()

--- a/src/BufferedFile.cpp
+++ b/src/BufferedFile.cpp
@@ -19,6 +19,12 @@ int BufferedFile::open(const char *path, const char *mode, bool lock)
 	m_filename = path;
 	m_fp = fopen(path, mode);
 	if (m_fp) {
+		// Bump stdio buffer to 1 MiB on write/append modes so streaming
+		// writes coalesce into few syscalls. Default libc buffer is 4-8 KiB,
+		// which produces thousands of NFS write syscalls per MB of payload.
+		if (mode && (*mode == 'w' || *mode == 'a' || strchr(mode, '+')))
+			setvbuf(m_fp, NULL, _IOFBF, 1 << 20);
+
         if (lock) {
             struct flock fl;
 

--- a/src/GIntervalsBigSet1D.cpp
+++ b/src/GIntervalsBigSet1D.cpp
@@ -36,6 +36,16 @@ std::string GIntervalsBigSet1D::get_intervset_dir(const std::string &intervset, 
 	return interv2path(envir, intervset.c_str());
 }
 
+void GIntervalsBigSet1D::invalidate_index_cache(const std::string &intervset_dir) {
+	std::lock_guard<std::mutex> lock(s_cache_mutex);
+	s_index_cache.erase(intervset_dir);
+}
+
+void GIntervalsBigSet1D::clear_index_cache() {
+	std::lock_guard<std::mutex> lock(s_cache_mutex);
+	s_index_cache.clear();
+}
+
 void GIntervalsBigSet1D::init(const char *intervset, SEXP meta, const IntervUtils &iu)
 {
 	GIntervalsBigSet::init(intervset, iu);

--- a/src/GIntervalsBigSet1D.h
+++ b/src/GIntervalsBigSet1D.h
@@ -108,6 +108,15 @@ private:
 
 	// Helper to get interval set directory from intervset name
 	static std::string get_intervset_dir(const std::string &intervset, SEXP envir);
+
+public:
+	// Drop the cached IntervalsIndex1D for `intervset_dir`. Call after
+	// rm/recreate/convert operations that change the on-disk interval
+	// set contents.
+	static void invalidate_index_cache(const std::string &intervset_dir);
+
+	// Wipe every cached entry.
+	static void clear_index_cache();
 };
 
 //------------------------------------- IMPLEMENTATION ------------------------------------------

--- a/src/GIntervalsBigSet2D.cpp
+++ b/src/GIntervalsBigSet2D.cpp
@@ -37,6 +37,16 @@ std::string GIntervalsBigSet2D::get_intervset_dir(const std::string &intervset, 
 	return interv2path(envir, intervset.c_str());
 }
 
+void GIntervalsBigSet2D::invalidate_index_cache(const std::string &intervset_dir) {
+	std::lock_guard<std::mutex> lock(s_cache_mutex);
+	s_index_cache.erase(intervset_dir);
+}
+
+void GIntervalsBigSet2D::clear_index_cache() {
+	std::lock_guard<std::mutex> lock(s_cache_mutex);
+	s_index_cache.clear();
+}
+
 void GIntervalsBigSet2D::init(const char *intervset, SEXP meta, const IntervUtils &iu)
 {
 	GIntervalsBigSet::init(intervset, iu);

--- a/src/GIntervalsBigSet2D.h
+++ b/src/GIntervalsBigSet2D.h
@@ -116,6 +116,15 @@ private:
 	// Helper to get interval set directory from intervset name
 	static std::string get_intervset_dir(const std::string &intervset, SEXP envir);
 
+public:
+	// Drop the cached IntervalsIndex2D for `intervset_dir`. Call after
+	// rm/recreate/convert operations.
+	static void invalidate_index_cache(const std::string &intervset_dir);
+
+	// Wipe every cached entry.
+	static void clear_index_cache();
+
+private:
 	int chroms2idx(int chromid1, int chromid2) const { return GIntervalsMeta2D::chroms2idx(chromid1, chromid2); }
 	int idx2chrom1(int idx) const { return GIntervalsMeta2D::idx2chrom1(idx); }
 	int idx2chrom2(int idx) const { return GIntervalsMeta2D::idx2chrom2(idx); }

--- a/src/GdbInvalidateCaches.cpp
+++ b/src/GdbInvalidateCaches.cpp
@@ -1,0 +1,48 @@
+/*
+ * Drops the per-directory entries from every process-static index cache
+ * that misha maintains (1D track index, 2D track index, 1D bigset index,
+ * 2D bigset index). Each cache is keyed by the absolute directory path of
+ * the on-disk track or interval set; if that directory is removed,
+ * recreated, or converted between formats, the cached entry becomes
+ * stale and downstream readers will route to the wrong file layout
+ * (e.g., open a non-existent track.dat on what is now a per-chrom track).
+ *
+ * Exposed to R as `.gdb.invalidate_dir_cache(dir)`. R-level mutation
+ * hooks (gtrack.rm, .gtrack.create_atomic post-rename,
+ * gtrack.convert_to_indexed, gintervals.rm, gintervals.convert_to_indexed,
+ * the 2D variants of each) call this whenever the contents of a track or
+ * interval set directory change.
+ */
+
+#include "GenomeTrack.h"
+#include "TrackIndex2D.h"
+#include "GIntervalsBigSet1D.h"
+#include "GIntervalsBigSet2D.h"
+#include "rdbutils.h"
+
+extern "C" {
+
+SEXP gdb_invalidate_dir_cache(SEXP _dir, SEXP _envir)
+{
+    try {
+        if (!Rf_isString(_dir) || Rf_length(_dir) < 1)
+            verror("'dir' must be a character vector");
+
+        const int n = Rf_length(_dir);
+        for (int i = 0; i < n; ++i) {
+            const char *path = CHAR(STRING_ELT(_dir, i));
+            if (path == nullptr || path[0] == '\0')
+                continue;
+            const std::string dir(path);
+            GenomeTrack::invalidate_index_cache(dir);
+            TrackIndex2D::invalidate_cache(dir);
+            GIntervalsBigSet1D::invalidate_index_cache(dir);
+            GIntervalsBigSet2D::invalidate_index_cache(dir);
+        }
+    } catch (TGLException &e) {
+        rerror("%s", e.msg());
+    }
+    return R_NilValue;
+}
+
+}

--- a/src/GenomeTrack.cpp
+++ b/src/GenomeTrack.cpp
@@ -51,6 +51,16 @@ std::shared_ptr<TrackIndex> GenomeTrack::get_track_index(const std::string &trac
 	return idx;
 }
 
+void GenomeTrack::invalidate_index_cache(const std::string &track_dir) {
+	std::lock_guard<std::mutex> lock(s_cache_mutex);
+	s_index_cache.erase(track_dir);
+}
+
+void GenomeTrack::clear_index_cache() {
+	std::lock_guard<std::mutex> lock(s_cache_mutex);
+	s_index_cache.clear();
+}
+
 std::string GenomeTrack::get_track_dir(const std::string &filename) {
 	// Extract directory from filename
 	// filename is typically like "/path/to/trackdir/chrN"

--- a/src/GenomeTrack.h
+++ b/src/GenomeTrack.h
@@ -90,6 +90,16 @@ public:
 	// Returns nullptr if track.idx is not present in track_dir.
 	static std::shared_ptr<TrackIndex> get_track_index(const std::string &track_dir);
 
+	// Drop the cached TrackIndex for `track_dir`. Call this whenever the
+	// on-disk track contents at `track_dir` have changed (rm, create,
+	// convert) so subsequent get_track_index() calls re-read track.idx.
+	// Safe to call when no entry is cached.
+	static void invalidate_index_cache(const std::string &track_dir);
+
+	// Wipe every cached TrackIndex entry. Used by tests and as a coarse
+	// reset when callers cannot enumerate the affected dirs.
+	static void clear_index_cache();
+
 	// Helper to extract track directory from a per-chrom filename.
 	static std::string get_track_dir(const std::string &filename);
 

--- a/src/GenomeTrackCreateSparse.cpp
+++ b/src/GenomeTrackCreateSparse.cpp
@@ -1,8 +1,15 @@
+#include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include <atomic>
 #include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "rdbinterval.h"
@@ -13,6 +20,54 @@
 
 using namespace std;
 using namespace rdb;
+
+namespace {
+
+// Write a 4-byte sparse-format signature to `path` via raw POSIX syscalls.
+// Used by the parallel empty-chrom path in gtrack_create_sparse; avoids the
+// libc stdio FILE* wrapping and per-call umask twiddling that the serial
+// GenomeTrackSparse::init_write path goes through. Best-effort: a non-zero
+// errno is reported back via `first_errno` so the caller can verror after
+// all workers finish.
+void write_empty_sparse_signature(const std::string &path, int32_t sig,
+                                  std::atomic<int> &first_errno)
+{
+    int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    if (fd < 0) {
+        int e = errno ? errno : EIO;
+        int expected = 0;
+        first_errno.compare_exchange_strong(expected, e);
+        return;
+    }
+    ssize_t n = ::write(fd, &sig, sizeof(sig));
+    int werr = (n != (ssize_t)sizeof(sig)) ? (errno ? errno : EIO) : 0;
+    ::close(fd);
+    if (werr) {
+        int expected = 0;
+        first_errno.compare_exchange_strong(expected, werr);
+    }
+}
+
+// Read the worker count from R option `gtrack.create.threads`. Default 4
+// (empirically saturates NFSv3 CREATE concurrency); cap at 32 to keep
+// worst-case thread count sane on misconfigured systems. Must be called on
+// the main thread; R API is not thread-safe.
+unsigned get_empty_chrom_workers()
+{
+    SEXP opt = Rf_GetOption1(Rf_install("gtrack.create.threads"));
+    int v = -1;
+    if (Rf_isInteger(opt) && Rf_length(opt) >= 1)
+        v = INTEGER(opt)[0];
+    else if (Rf_isReal(opt) && Rf_length(opt) >= 1)
+        v = (int)REAL(opt)[0];
+    if (v < 0)
+        v = 4;
+    if (v > 32)
+        v = 32;
+    return (unsigned)v;
+}
+
+} // namespace
 
 extern "C" {
 
@@ -71,11 +126,50 @@ SEXP gtrack_create_sparse(SEXP _track, SEXP _intervs, SEXP _values, SEXP _envir)
 		// This avoids creating thousands of empty files on network filesystems.
 		// For non-indexed databases, we still create empty chromosome files for backward compatibility.
 		if (!is_db_indexed(_envir)) {
+			vector<string> paths;
+			paths.reserve(all_genome_intervs.size());
 			for (GIntervals::const_iterator iinterv = all_genome_intervs.begin(); iinterv != all_genome_intervs.end(); ++iinterv) {
 				if (created_chromids.find(iinterv->chromid) == created_chromids.end()) {
 					snprintf(filename, sizeof(filename), "%s/%s", dirname.c_str(), GenomeTrack::get_1d_filename(iu.get_chromkey(), iinterv->chromid).c_str());
-					gtrack.init_write(filename, iinterv->chromid);
+					paths.emplace_back(filename);
 				}
+			}
+
+			if (!paths.empty()) {
+				const int32_t sig = GenomeTrack::FORMAT_SIGNATURES[GenomeTrack::SPARSE];
+				unsigned nworkers = get_empty_chrom_workers();
+				if (nworkers == 0)
+					nworkers = 1;
+				if (nworkers > (unsigned)paths.size())
+					nworkers = (unsigned)paths.size();
+
+				std::atomic<int> first_errno{0};
+
+				if (nworkers <= 1) {
+					for (const auto &p : paths)
+						write_empty_sparse_signature(p, sig, first_errno);
+				} else {
+					std::atomic<size_t> next{0};
+					auto worker = [&]() {
+						for (;;) {
+							size_t i = next.fetch_add(1, std::memory_order_relaxed);
+							if (i >= paths.size())
+								return;
+							write_empty_sparse_signature(paths[i], sig, first_errno);
+						}
+					};
+					std::vector<std::thread> threads;
+					threads.reserve(nworkers - 1);
+					for (unsigned t = 0; t < nworkers - 1; ++t)
+						threads.emplace_back(worker);
+					worker();
+					for (auto &th : threads)
+						th.join();
+				}
+
+				int e = first_errno.load();
+				if (e != 0)
+					TGLError("Failed to create empty chromosome track file: %s", strerror(e));
 			}
 		}
 

--- a/src/TrackIndex2D.cpp
+++ b/src/TrackIndex2D.cpp
@@ -249,6 +249,11 @@ std::shared_ptr<TrackIndex2D> TrackIndex2D::get_track_index_2d(const std::string
     }
 }
 
+void TrackIndex2D::invalidate_cache(const std::string &track_dir) {
+    std::lock_guard<std::mutex> lock(s_cache_mutex);
+    s_index_cache.erase(track_dir);
+}
+
 void TrackIndex2D::clear_cache() {
     std::lock_guard<std::mutex> lock(s_cache_mutex);
     s_index_cache.clear();

--- a/src/TrackIndex2D.h
+++ b/src/TrackIndex2D.h
@@ -97,7 +97,11 @@ public:
     // Get-or-load the 2D track index for a track directory (thread-safe)
     static std::shared_ptr<TrackIndex2D> get_track_index_2d(const std::string &track_dir);
 
-    // Clear the index cache
+    // Drop the cached entry for `track_dir`. Call after rm/recreate/convert
+    // operations that change the on-disk track contents.
+    static void invalidate_cache(const std::string &track_dir);
+
+    // Clear every cached entry (used by 2D conversion and tests).
     static void clear_cache();
 
     // Write a 2D index file

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -72,6 +72,7 @@ extern "C" {
     extern SEXP gtrack_create_empty_indexed(SEXP, SEXP);
     extern SEXP ginterv_convert(SEXP, SEXP, SEXP);
     extern SEXP ginterv2d_convert(SEXP, SEXP, SEXP);
+    extern SEXP gdb_invalidate_dir_cache(SEXP, SEXP);
     extern SEXP gtrackcor(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrackcor_multitask(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrackcor_spearman(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -181,6 +182,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"gtrack_create_empty_indexed", (DL_FUNC)&gtrack_create_empty_indexed, 2},
     {"ginterv_convert", (DL_FUNC)&ginterv_convert, 3},
     {"ginterv2d_convert", (DL_FUNC)&ginterv2d_convert, 3},
+    {"gdb_invalidate_dir_cache", (DL_FUNC)&gdb_invalidate_dir_cache, 2},
     {"gtrackcor", (DL_FUNC)&gtrackcor, 5},
     {"gtrackcor_multitask", (DL_FUNC)&gtrackcor_multitask, 5},
     {"gtrackcor_spearman", (DL_FUNC)&gtrackcor_spearman, 5},

--- a/tests/testthat/test-index-cache-invalidation.R
+++ b/tests/testthat/test-index-cache-invalidation.R
@@ -1,0 +1,218 @@
+# Regression tests for the process-static index cache invalidation bug.
+#
+# Background: misha keeps process-static caches keyed by directory path
+# for the on-disk per-dir indexes:
+#   - GenomeTrack::s_index_cache           (1D track.idx)
+#   - TrackIndex2D::s_index_cache          (2D track.idx)
+#   - GIntervalsBigSet1D::s_index_cache    (intervals.idx)
+#   - GIntervalsBigSet2D::s_index_cache    (intervals2d.idx)
+#
+# Without explicit invalidation, the sequence
+#   gtrack.rm("X"); gtrack.create_*("X", ...)
+# on an indexed DB leaves the cache pointing at the previous lifecycle's
+# index. Downstream readers see "indexed = true" and try to open a
+# non-existent track.dat (or the wrong file layout).
+#
+# These tests exercise the rm-then-recreate cycle and verify the next
+# read succeeds.
+
+# Build a tiny per-chromosome DB then convert it to indexed format.
+build_indexed_test_db <- function() {
+    test_db <- tempfile("misha_idxcache_")
+    dir.create(test_db)
+    dir.create(file.path(test_db, "seq"))
+    dir.create(file.path(test_db, "tracks"))
+    chrom_sizes <- data.frame(
+        chrom = c("chr1", "chr2", "chr3"),
+        size  = c(20000L, 15000L, 10000L)
+    )
+    write.table(chrom_sizes, file.path(test_db, "chrom_sizes.txt"),
+        row.names = FALSE, col.names = FALSE, sep = "\t", quote = FALSE
+    )
+    for (i in seq_len(nrow(chrom_sizes))) {
+        writeBin(
+            charToRaw(paste(rep("A", chrom_sizes$size[i]), collapse = "")),
+            file.path(test_db, "seq", paste0(chrom_sizes$chrom[i], ".seq"))
+        )
+    }
+    gdb.convert_to_indexed(groot = test_db, force = TRUE, validate = FALSE)
+    test_db
+}
+
+# Per-chromosome (non-indexed) test DB.
+build_perchrom_test_db <- function() {
+    test_db <- tempfile("misha_idxcache_pc_")
+    dir.create(test_db)
+    dir.create(file.path(test_db, "seq"))
+    dir.create(file.path(test_db, "tracks"))
+    chrom_sizes <- data.frame(
+        chrom = c("chr1", "chr2", "chr3"),
+        size  = c(20000L, 15000L, 10000L)
+    )
+    write.table(chrom_sizes, file.path(test_db, "chrom_sizes.txt"),
+        row.names = FALSE, col.names = FALSE, sep = "\t", quote = FALSE
+    )
+    for (i in seq_len(nrow(chrom_sizes))) {
+        writeBin(
+            charToRaw(paste(rep("A", chrom_sizes$size[i]), collapse = "")),
+            file.path(test_db, "seq", paste0(chrom_sizes$chrom[i], ".seq"))
+        )
+    }
+    test_db
+}
+
+make_sparse_data <- function(n = 200L, chrom = "chr1", chrom_size = 20000L,
+                             width = 50L) {
+    # Sparse intervals must be non-overlapping. Pick spacing >= width so
+    # adjacent intervals don't collide; clamp n to what fits.
+    span <- chrom_size - width
+    spacing <- max(width + 1L, span %/% n)
+    max_n <- as.integer(span %/% spacing)
+    if (max_n < n) n <- max_n
+    starts <- as.integer(seq.int(0L, by = spacing, length.out = n))
+    data.frame(
+        chrom = chrom, start = starts, end = starts + width,
+        stringsAsFactors = FALSE
+    )
+}
+
+test_that("gtrack.rm + gtrack.create_dense cycle works on indexed DB", {
+    local_db_state()
+    test_db <- build_indexed_test_db()
+    withr::defer(unlink(test_db, recursive = TRUE))
+    gsetroot(test_db)
+
+    ivs <- make_sparse_data(n = 200L)
+    vals <- runif(nrow(ivs))
+
+    # Three rm-then-recreate cycles. Before the fix, rep 2's
+    # gtrack.create_dense errored with
+    #   "Cannot open .../<track>.track/track.dat: No such file or directory"
+    # because the stale s_index_cache entry from rep 1 routed reads through
+    # the indexed-format path on a directory that had been deleted.
+    for (i in 1:3) {
+        if ("idxcache_dense" %in% gtrack.ls()) {
+            suppressMessages(gtrack.rm("idxcache_dense", force = TRUE))
+        }
+        expect_silent(
+            gtrack.create_dense("idxcache_dense", "test",
+                ivs, vals,
+                binsize = 200L, defval = NaN
+            )
+        )
+        # Read back through the normal extract path - this is what fails
+        # if the cache is stale on the second iteration.
+        ext <- gextract("idxcache_dense",
+            intervals = data.frame(
+                chrom = "chr1",
+                start = 0L, end = 5000L
+            ),
+            iterator = 200L
+        )
+        expect_true(nrow(ext) > 0L,
+            label = sprintf("rep %d: gextract returned no rows", i)
+        )
+    }
+})
+
+test_that("gtrack.rm + gtrack.create_sparse cycle works on indexed DB", {
+    local_db_state()
+    test_db <- build_indexed_test_db()
+    withr::defer(unlink(test_db, recursive = TRUE))
+    gsetroot(test_db)
+
+    ivs <- make_sparse_data(n = 200L)
+    vals <- runif(nrow(ivs))
+
+    for (i in 1:3) {
+        if ("idxcache_sparse" %in% gtrack.ls()) {
+            suppressMessages(gtrack.rm("idxcache_sparse", force = TRUE))
+        }
+        expect_silent(
+            gtrack.create_sparse("idxcache_sparse", "test", ivs, vals)
+        )
+        ext <- gextract("idxcache_sparse",
+            intervals = data.frame(
+                chrom = "chr1",
+                start = 0L, end = 5000L
+            )
+        )
+        expect_true(nrow(ext) > 0L,
+            label = sprintf("rep %d: gextract returned no rows", i)
+        )
+    }
+})
+
+test_that("convert_to_indexed in place invalidates the cache", {
+    local_db_state()
+    test_db <- build_perchrom_test_db()
+    withr::defer(unlink(test_db, recursive = TRUE))
+    gsetroot(test_db)
+
+    ivs <- make_sparse_data(n = 200L)
+    vals <- runif(nrow(ivs))
+
+    # Per-chrom create.
+    gtrack.create_dense("idxcache_conv", "test",
+        ivs, vals,
+        binsize = 200L, defval = NaN
+    )
+
+    # Read once so the cache picks up the per-chrom state (nullptr entry).
+    invisible(gextract("idxcache_conv",
+        intervals = data.frame(
+            chrom = "chr1",
+            start = 0L, end = 5000L
+        ),
+        iterator = 200L
+    ))
+
+    # Convert per-chrom -> indexed. The cache MUST drop the prior nullptr
+    # entry; otherwise readers keep probing per-chrom files that now
+    # live behind track.dat + track.idx.
+    expect_silent(gtrack.convert_to_indexed("idxcache_conv"))
+
+    ext <- gextract("idxcache_conv",
+        intervals = data.frame(
+            chrom = "chr1",
+            start = 0L, end = 5000L
+        ),
+        iterator = 200L
+    )
+    expect_true(nrow(ext) > 0L)
+})
+
+test_that("gintervals.rm + gintervals.save cycle works on indexed DB", {
+    local_db_state()
+    test_db <- build_indexed_test_db()
+    withr::defer(unlink(test_db, recursive = TRUE))
+    gsetroot(test_db)
+
+    ivs <- make_sparse_data(n = 500L)
+
+    for (i in 1:3) {
+        if ("idxcache_iv" %in% gintervals.ls()) {
+            suppressMessages(gintervals.rm("idxcache_iv", force = TRUE))
+        }
+        expect_silent(gintervals.save("idxcache_iv", ivs))
+        loaded <- gintervals.load("idxcache_iv")
+        expect_true(nrow(loaded) > 0L,
+            label = sprintf("rep %d: gintervals.load returned no rows", i)
+        )
+    }
+})
+
+test_that("explicit cache invalidation is exposed and idempotent", {
+    local_db_state()
+    test_db <- build_indexed_test_db()
+    withr::defer(unlink(test_db, recursive = TRUE))
+    gsetroot(test_db)
+
+    # The R-level helper must accept missing/empty/nonexistent paths
+    # without erroring (it is called from cleanup paths where we don't
+    # want to mask real errors).
+    expect_silent(misha:::.gdb.invalidate_dir_cache(character(0)))
+    expect_silent(misha:::.gdb.invalidate_dir_cache(""))
+    expect_silent(misha:::.gdb.invalidate_dir_cache("/no/such/dir"))
+    expect_silent(misha:::.gdb.invalidate_dir_cache(c(tempdir(), tempdir())))
+})


### PR DESCRIPTION
## Summary

Two NFS-side perf fixes on the `gtrack.create_*` hot path, ported from pymisha v0.1.64 (audit notes in `dev/notes/2026-05-15-perf-fixes-from-pymisha.md`).

### Fix 1 - 1 MiB stdio buffer on every misha-managed write file

`BufferedFile::open()` now calls `setvbuf(..., _IOFBF, 1 << 20)` when opened in `w` / `a` / `+` mode. The default libc buffer is 4-8 KiB, so writing a 20 MB track issues thousands of NFS WRITE RPCs; the 1 MiB buffer collapses that into ~20. Affects every track-create path (`create_sparse`, `create_dense`, `create`, `smooth`, `modify`, `convert_to_indexed`). `fwrite` semantics unchanged, just batches more aggressively before flushing.

### Fix 2 - parallel empty-chrom signature writes in `gtrack.create_sparse`

On per-chromosome (non-indexed) DBs, `gtrack_create_sparse` creates a 4-byte signature-only file for every chromosome that received no data. On hg38 that's ~454 of 455 chroms. NFSv3 CREATE RPCs are ~2 ms each and saturate around 4 concurrent requests, so the serial loop costs ~1 s; a 4-worker thread pool drops it to ~0.5 s.

The new path uses raw `::open` / `::write` / `::close` (not `GenomeTrackSparse::init_write`) to bypass the libc stdio `FILE*` wrapping. Workers never touch the R API or call `check_interrupt`; the first errno is surfaced as `TGLError` after join, so a failing parallel write still aborts the create.

Worker count is configurable via the new R option `gtrack.create.threads` (default `4L`, capped at 32 in C++). `options(gtrack.create.threads = 1L)` disables parallelism entirely.

### CRAN-compliance notes

- Package was already `OS_type: unix`, links `-lpthread`, and uses `std::mutex` extensively (`TrackIndex2D.cpp`, `rdbinterval.cpp`, `FilterRegistry.cpp`, `GIntervalsBigSet1D.h`). Adding `std::thread` + `std::atomic` is consistent.
- Workers never call the R API; option is read from the main thread before any worker spawns.
- Thread count is user-configurable (no hardcoded scheduling decision), in line with CRAN guidance.

### Versioning

PATCH bump (5.6.32 -> 5.6.33) per `dev/notes/versioning-policy.md`: perf-only, no API change, new optional R option with backward-compatible default.

## Test plan

- [x] `R -e "pkgbuild::clean_dll(); pkgbuild::compile_dll(debug = FALSE)"` - clean build, no new warnings
- [x] `R -e "devtools::test(filter = 'gtrack.create')"` - 68/68 PASS
- [x] Broader sparse / convert / modify / smooth / multi-db / track-copy suite: 319 PASS (2 unrelated pre-existing FAILs in `test-gtrack.import2.R:90-93` reproduce on master)
- [x] Byte-identical output across `threads = 1`, `4`, and `8` on a 5-chrom non-indexed test DB: empty-chrom files are exactly 4 bytes with signature `-1` (`FORMAT_SIGNATURES[SPARSE]`)
- [x] Round-trip via `gextract` returns identical values to inputs (1000 sparse intervals)
- [ ] NFS-side wall-time benchmark on hg38 (suggested in the notes file: ~1.9 s -> ~1.2 s for the 1M-row sparse create) - not run on this branch, applies to NFS-mounted DBs