### PR TITLE
docs: drop internal dev/ path references

### DIFF
--- a/R/genome-build.R
+++ b/R/genome-build.R
@@ -5,8 +5,6 @@
 #   gdb.list_genomes()           - list resolvable genome names
 #   gdb.genome_info()            - show resolved recipe without building
 #   gdb.install_gff3_converter() - pre-install UCSC's gff3ToGenePred binary
-#
-# Spec: dev/notes/specs/2026-04-30_genome-build-design.md
 
 # ---------------------------------------------------------------------------
 # Internal constants

--- a/tests/testthat/test-dataset.R
+++ b/tests/testthat/test-dataset.R
@@ -1,5 +1,4 @@
 # Tests for dataset API
-# Following spec: dev/notes/2026-01-13-dataset-api-spec.md
 # Note: create_test_db() helper is defined in helper-test_db.R
 
 # ==============================================================================


### PR DESCRIPTION
Two source files referenced `dev/notes/...` paths in header comments. `dev/` is gitignored from the public repo, so the pointers are dead for anyone reading on GitHub. Stripping them.

- `R/genome-build.R`: drop `# Spec: dev/notes/specs/2026-04-30_genome-build-design.md` line
- `tests/testthat/test-dataset.R`: drop `# Following spec: dev/notes/2026-01-13-dataset-api-spec.md` line

No functional change.

## Test plan

- [x] Style check passes
- [ ] R-CMD-check passes