### PR TITLE
docs(news): trim 5.7.0 entry to one bullet, drop misha.ext mentions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # misha 5.7.0
 
-* New `gintervals.to_mat()` and `gintervals.from_mat()` round-trip intervals + values data.frames to numeric matrices. Fixes a chrom-name corruption bug in `misha.ext::intervs_to_mat()` when chrom names contain underscores. `from_mat` is ~12x faster than the legacy on 1M intervals.
-* `gintervals.to_mat()` gains a `labels = FALSE` argument to skip rowname construction (~25x faster `to_mat` for pipelines that don't need them). The matching `misha.ext` functions are now deprecated.
+* New `gintervals.to_mat()` and `gintervals.from_mat()` round-trip an intervals + values data.frame to a numeric matrix indexed by intervals. Pass `labels = FALSE` to skip rowname construction.
 
 # misha 5.6.33
 


### PR DESCRIPTION
Per project NEWS convention: one bullet per feature, no cross-package references (NEWS is about misha, not its downstream packages), no benchmark numbers in NEWS.

Implementation details from the original entry (perf vs the legacy ext function, the chrom-corruption fix, the C helper, the misha.ext deprecation) all live in the merge commit message of #120 and the design notes - NEWS just tells the user what's new in 5.7.0.