### PR TITLE
fix(gtrack.import): pass func= to gtrack_create_dense (5.7.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.7.0
+Version: 5.7.1
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.7.1
+
+* Fixed `gtrack.import()` of BED files with `binsize` failing with `func argument is not a string`. The BED-to-dense path was not updated when `gtrack.create_dense()` gained the `func` argument in 5.6.31; it now passes the historical `"weighted.mean"` default.
+
 # misha 5.7.0
 
 * New `gintervals.to_mat()` and `gintervals.from_mat()` round-trip an intervals + values data.frame to a numeric matrix indexed by intervals. Pass `labels = FALSE` to skip rowname construction.

--- a/R/track-import.R
+++ b/R/track-import.R
@@ -228,7 +228,7 @@ gtrack.import <- function(track = NULL, description = NULL, file = NULL, binsize
                             end = bed_parsed$intervals$end,
                             value = as.numeric(bed_parsed$values)
                         )
-                        .gcall("gtrack_create_dense", trackstr, intervalData, binsize, defval, .misha_env())
+                        .gcall("gtrack_create_dense", trackstr, intervalData, binsize, defval, "weighted.mean", .misha_env())
                     } else {
                         .gcall("gtrack_create_sparse", trackstr, bed_parsed$intervals, bed_parsed$values, .misha_env())
                     }


### PR DESCRIPTION
## Summary

- The BED-to-dense path in `gtrack.import()` (R/track-import.R:231) was not updated when `gtrack.create_dense()` gained the `func` argument in v5.6.31.
- Calling `gtrack.import(..., binsize = N)` on a BED file errored at the C++ layer with `func argument is not a string`.
- Pass the historical `"weighted.mean"` default to restore the prior behavior.

## Test plan

- [x] `devtools::test(filter = "gtrack.import2")` now passes (was failing on master)