### PR TITLE
fix(gtrack.import): surface underlying WIG/CSV parser error (5.7.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.7.1
+Version: 5.7.2
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.7.2
+
+* `gtrack.import()` of a malformed WIG/CSV file now surfaces the underlying parser error (file name, line number, what was wrong) instead of the opaque `Unrecognized format of file ...`. Makes typical failure modes (e.g. a value line glued to a fixedStep header from a botched cat-style concatenation) diagnosable at a glance.
+
 # misha 5.7.1
 
 * `gextract()` gains an `intervals_join` argument with values `"id"` (default; current behavior), `"intervals"` (drop `intervalID`, attach the input intervals data frame's columns to each output row), or `"none"` (drop `intervalID`). Built-in replacement for `misha.ext::gextract.left_join`, around 2x faster on wide-window workloads (e.g. TSS +/- 5kb at 50bp iterator).

--- a/src/GenomeTrackImportWig.cpp
+++ b/src/GenomeTrackImportWig.cpp
@@ -52,12 +52,14 @@ SEXP gtrackimportwig(SEXP _track, SEXP _wig, SEXP _binsize, SEXP _defvalue, SEXP
 		vector<float> vals;
 		char filename[FILENAME_MAX];
 		bool is_csv = false;
+		string wig_err_msg;
 
 		try {
 			wig.init(iu.get_chromkey(), fname, true);
 		} catch (TGLException &e) {
 			if (e.type() != typeid(Wig) || e.code() == Wig::FILE_ERROR)
 				throw e;
+			wig_err_msg = e.msg();
 			is_csv = true;
 		}
 
@@ -69,7 +71,8 @@ SEXP gtrackimportwig(SEXP _track, SEXP _wig, SEXP _binsize, SEXP _defvalue, SEXP
 			} catch (TGLException &e) {
 				if (e.type() != typeid(GenomeArraysCsv) || e.code() == GenomeArraysCsv::FILE_ERROR)
 					throw e;
-				verror("Unrecognized format of file %s", fname);
+				verror("Unrecognized format of file %s.\nWIG parser error: %s\nCSV parser error: %s",
+				       fname, wig_err_msg.c_str(), e.msg());
 			}
 		}
 

--- a/tests/testthat/test-gtrack.import5.R
+++ b/tests/testthat/test-gtrack.import5.R
@@ -49,3 +49,28 @@ test_that("import with attrs parameter - list format", {
     expect_equal(gtrack.attr.get(tmptrack, "author"), "test_user")
     expect_equal(gtrack.attr.get(tmptrack, "version"), "2.0")
 })
+
+test_that("malformed WIG error message includes underlying parser diagnostic", {
+    tmptrack <- paste0("test.tmptrack_", sample(1:1e9, 1))
+    gtrack.rm(tmptrack, force = TRUE)
+    withr::defer(gtrack.rm(tmptrack, force = TRUE))
+
+    # Simulate the concatenation-without-newline corruption: a value line glued
+    # to a fixedStep header (e.g. "0.500fixedStep chrom=...").
+    temp_file <- tempfile(fileext = ".wig")
+    writeLines(c(
+        "fixedStep chrom=chr1 start=1 step=1",
+        "1.0",
+        "2.0",
+        "0.500fixedStep chrom=chr2 start=1 step=1",
+        "3.0"
+    ), temp_file)
+    withr::defer(unlink(temp_file))
+
+    # The error must surface the underlying WIG parser message (file + line)
+    # rather than the generic "Unrecognized format" that hid the root cause.
+    expect_error(
+        gtrack.import(tmptrack, "", temp_file, binsize = 1),
+        regexp = "WIG parser error.*Invalid format.*line"
+    )
+})


### PR DESCRIPTION
## Summary
- `gtrack.import()` on a malformed WIG/CSV file currently dies with `Unrecognized format of file ...`, which discards the underlying parser diagnostic (file, line number, what was wrong) and leaves users with no actionable signal.
- This PR preserves the `Wig::init` error message across the rethrow-to-CSV fallback in `GenomeTrackImportWig.cpp` and includes both the WIG and CSV parser messages in the final `verror()` when neither format matches.
- Adds a regression test for the typical failure case: a value line glued to a `fixedStep` header (the corruption pattern produced by `cat`-ing chunked WIGs whose final newline is missing).

## Motivation
Triggered by debugging a 16 GB concatenated phyloP WIG file where 5 of the 64 chunks were missing trailing newlines, producing 5 lines like `0.203fixedStep chrom=chr6 start=85087122 step=1`. The real `Wig` error was `Invalid format of WIG file /path, line 314921550`. None of that was reachable through the user-facing error.

## Test plan
- [x] `R -e 'devtools::test(filter = "gtrack.import5")'` passes (6/6)
- [x] `pkgbuild::compile_dll(debug = FALSE)` clean (pre-push hook)