### PR TITLE
fix(gdb.reload): clear C++ track-index cache on rescan (5.7.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.7.2
+Version: 5.7.3
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.7.3
+
+* `gdb.reload()` now also clears the C++ track-index cache, so a track replaced out-of-process (sibling R session, manual rebuild from another script) is picked up by the running session without restarting R. Previously the cached track type could shadow the new on-disk track and surface as e.g. `function global.percentile.max is not supported by sparse tracks` after the track was already rebuilt as dense.
+
 # misha 5.7.2
 
 * `gtrack.import()` of a malformed WIG/CSV file now surfaces the underlying parser error (file name, line number, what was wrong) instead of the opaque `Unrecognized format of file ...`. Makes typical failure modes (e.g. a value line glued to a fixedStep header from a botched cat-style concatenation) diagnosable at a glance.

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -26,6 +26,17 @@ gdb.reload <- function(rescan = TRUE) {
         .gdb.clear_scan_cache()
     }
 
+    # Drop every entry from the process-static index caches the C++ side
+    # maintains (track type / layout, bigset layout). Without this, an
+    # out-of-process mutation (sibling R session, manual rm/cp, external
+    # rebuild) leaves the caller routing reads through stale entries -
+    # e.g. a track converted from sparse to dense reads back as the cached
+    # sparse type until R restarts. gdb.reload(rescan = TRUE) is the
+    # documented "rescan from disk" hook; the C++ caches must follow.
+    if (rescan && exists(".gdb.clear_all_dir_caches", mode = "function")) {
+        .gdb.clear_all_dir_caches()
+    }
+
     assign("GTRACKS", NULL, envir = .misha)
     assign("GINTERVS", NULL, envir = .misha)
     assign("GTRACK_DATASET", NULL, envir = .misha)

--- a/R/db-invalidate-cache.R
+++ b/R/db-invalidate-cache.R
@@ -21,3 +21,18 @@
     )
     invisible(NULL)
 }
+
+# Wipe every process-static index-cache entry (1D / 2D track index, 1D /
+# 2D bigset index). Used by gdb.reload(rescan = TRUE) so out-of-process
+# mutations (a sibling R session, a manual rm/cp, an external rebuild)
+# cannot leave the caller routing reads through a stale `dir ->
+# shared_ptr<TrackIndex>` entry.
+#
+# Best-effort: failures swallowed.
+.gdb.clear_all_dir_caches <- function() {
+    tryCatch(
+        .gcall("gdb_clear_all_dir_caches", .misha_env()),
+        error = function(e) NULL
+    )
+    invisible(NULL)
+}

--- a/src/GdbInvalidateCaches.cpp
+++ b/src/GdbInvalidateCaches.cpp
@@ -45,4 +45,21 @@ SEXP gdb_invalidate_dir_cache(SEXP _dir, SEXP _envir)
     return R_NilValue;
 }
 
+// Wipe every entry from every process-static index cache. Used by
+// gdb.reload(rescan = TRUE) so out-of-process mutations (a sibling R
+// session, a manual rm/cp, an external rebuild) cannot leave the
+// caller routing reads through a stale track-type / layout entry.
+SEXP gdb_clear_all_dir_caches(SEXP _envir)
+{
+    try {
+        GenomeTrack::clear_index_cache();
+        TrackIndex2D::clear_cache();
+        GIntervalsBigSet1D::clear_index_cache();
+        GIntervalsBigSet2D::clear_index_cache();
+    } catch (TGLException &e) {
+        rerror("%s", e.msg());
+    }
+    return R_NilValue;
+}
+
 }

--- a/src/misha-init.cpp
+++ b/src/misha-init.cpp
@@ -73,6 +73,7 @@ extern "C" {
     extern SEXP ginterv_convert(SEXP, SEXP, SEXP);
     extern SEXP ginterv2d_convert(SEXP, SEXP, SEXP);
     extern SEXP gdb_invalidate_dir_cache(SEXP, SEXP);
+    extern SEXP gdb_clear_all_dir_caches(SEXP);
     extern SEXP gtrackcor(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrackcor_multitask(SEXP, SEXP, SEXP, SEXP, SEXP);
     extern SEXP gtrackcor_spearman(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -184,6 +185,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"ginterv_convert", (DL_FUNC)&ginterv_convert, 3},
     {"ginterv2d_convert", (DL_FUNC)&ginterv2d_convert, 3},
     {"gdb_invalidate_dir_cache", (DL_FUNC)&gdb_invalidate_dir_cache, 2},
+    {"gdb_clear_all_dir_caches", (DL_FUNC)&gdb_clear_all_dir_caches, 1},
     {"gtrackcor", (DL_FUNC)&gtrackcor, 5},
     {"gtrackcor_multitask", (DL_FUNC)&gtrackcor_multitask, 5},
     {"gtrackcor_spearman", (DL_FUNC)&gtrackcor_spearman, 5},


### PR DESCRIPTION
## Summary

`gdb.reload()` refreshed the R-side `GTRACKS` / `GINTERVS` listings but never invalidated the process-static C++ index caches (`GenomeTrack::s_index_cache` and its 2D / 1D-bigset / 2D-bigset siblings). When a track was rebuilt out-of-process — a sibling R session, a manual `rm + create_*` from another script, an external pipeline — the running session kept routing reads through the cached `shared_ptr<TrackIndex>` from the previous lifecycle. Symptoms include `function global.percentile.max is not supported by sparse tracks` on a track that is already dense on disk, or `Cannot open track.dat` after a format conversion. Workaround was to restart R.

The in-process `rm + create` cycle was already handled in 5.6.33 via `.gdb.invalidate_dir_cache`, wired into `gtrack.rm` and `.gtrack.create_atomic`. This PR closes the cross-process gap by wiring the same mechanism into `gdb.reload(rescan = TRUE)`, which is the documented "rescan from disk" hook.

## Changes

- `src/GdbInvalidateCaches.cpp` — new `gdb_clear_all_dir_caches` entry calling `clear_index_cache()` on all four caches.
- `src/misha-init.cpp` — registers it.
- `R/db-invalidate-cache.R` — exposes `.gdb.clear_all_dir_caches()`.
- `R/db-cache.R` — `gdb.reload(rescan = TRUE)` calls it (right after `.gdb.clear_scan_cache()`).
- `rescan = FALSE` deliberately leaves the cache alone — that path is the opt-out from re-reading.
- `DESCRIPTION` + `NEWS.md` bump to 5.7.3.

## Test plan

- [x] Reproduction: create sparse track, hydrate cache via `gextract`, rebuild as dense in a separate `Rscript`, then `gdb.reload()` in the original session. Now reports `type= dense` and `global.percentile.max` succeeds. Before the fix it still reported `type= sparse`.
- [x] Full test suite (`alutil::tst(parallel = TRUE)`): `FAIL 6, PASS 18944` — identical to baseline (same 6 pre-existing infra failures: `gdb.init not set`, read-only tempdir DBs, `liftover-hg19-hg38`; none touching `gdb.reload` or vtrack creation).