### PR TITLE
Audit fixes (5.8.1): format-string bugs, force_range perf, ggenome fail-fast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.8.0
+Version: 5.8.1
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# misha 5.8.1
+
+### Bug fixes
+
+* `gtrack.import_mappedseq()` and the strand-autocorrelation importer now print a correct message (instead of a garbage value or a possible crash) when given a non-positive `cols.order` entry; the latter also reports the offending `maxread` rather than `binsize`.
+* `ggenome.implant()` validates the output trackdb destination before writing the FASTA, so a pre-existing trackdb with `overwrite = FALSE` no longer leaves an orphaned output file behind.
+
+### Performance
+
+* `gintervals.force_range()` is markedly faster when writing to an output set (or with big-set inputs) on genomes with many contigs: the per-chromosome chromosome-end lookup is computed once instead of being re-derived from the full genome on every chromosome.
+
 # misha 5.8.0
 
 * `gtrack.import_mappedseq()` now accepts BAM files directly: bgzip magic bytes are auto-detected and the file is streamed through `samtools view` into the existing parser. Requires `samtools` on `PATH` (declared in `SystemRequirements`); a clear error names the missing tool otherwise. For BAM input the function treats the default `cols.order = c(9, 11, 13, 14)` as SAM mode (i.e. `NULL`); explicitly passing a non-NULL `cols.order` with a BAM file is rejected with an error.

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -400,7 +400,7 @@ gdb.reload <- function(rescan = TRUE) {
         try(
             {
                 retv <- try(.gcall_noninteractive(gtrack.info, track))
-                if (inherits(retv, "try-error") & length(grep("obsolete", retv)) > 0) {
+                if (inherits(retv, "try-error") && length(grep("obsolete", retv)) > 0) {
                     message(sprintf("Converting track %s", track))
                     .gcall_noninteractive(gtrack.convert, track)
                 }

--- a/R/genome-edit.R
+++ b/R/genome-edit.R
@@ -109,6 +109,18 @@ ggenome.implant <- function(intervals, donor, output, genome_fasta = NULL,
         stop(sprintf("Output file already exists: %s. Use overwrite = TRUE to replace it.", output), call. = FALSE)
     }
 
+    # Resolve and validate the trackdb destination up front so a pre-existing
+    # trackdb fails before we do the expensive FASTA export/write below (which
+    # would otherwise leave an orphaned output file behind).
+    if (create_trackdb) {
+        if (is.null(trackdb_path)) {
+            trackdb_path <- file.path(dirname(output), "trackdb")
+        }
+        if (dir.exists(trackdb_path) && !overwrite) {
+            stop(sprintf("Trackdb directory already exists: %s. Use overwrite = TRUE to replace it.", trackdb_path), call. = FALSE)
+        }
+    }
+
     # --- resolve donor sequences ---
     donor_is_db <- is.character(donor) && length(donor) == 1L && dir.exists(donor)
 
@@ -195,14 +207,8 @@ ggenome.implant <- function(intervals, donor, output, genome_fasta = NULL,
         ), call. = FALSE)
     }
 
-    # --- create trackdb ---
+    # --- create trackdb (trackdb_path was resolved/validated up front) ---
     if (create_trackdb) {
-        if (is.null(trackdb_path)) {
-            trackdb_path <- file.path(dirname(output), "trackdb")
-        }
-        if (dir.exists(trackdb_path) && !overwrite) {
-            stop(sprintf("Trackdb directory already exists: %s. Use overwrite = TRUE to replace it.", trackdb_path), call. = FALSE)
-        }
         if (dir.exists(trackdb_path)) {
             unlink(trackdb_path, recursive = TRUE)
         }

--- a/R/intervals-bigset.R
+++ b/R/intervals-bigset.R
@@ -1,7 +1,7 @@
 # Big intervals set handling
 
 .gintervals.is_bigset <- function(intervals.set, err_if_non_exist = TRUE) {
-    if (is.character(intervals.set) & length(intervals.set) == 1) {
+    if (is.character(intervals.set) && length(intervals.set) == 1) {
         if (intervals.set %in% get("GTRACKS", envir = .misha)) {
             intervfname <- .track_dir(intervals.set)
         } else {

--- a/R/intervals-operations.R
+++ b/R/intervals-operations.R
@@ -435,17 +435,24 @@ gintervals.force_range <- function(intervals = NULL, intervals.set.out = NULL) {
     # Original path: for bigsets or when intervals.set.out is specified
     res <- NULL
     res_nrows <- 0L
+    # Hoist the chromosome-end lookup out of the per-chromosome FUN. Computing
+    # it once as a named vector turns the per-call match() over the full
+    # ALLGENOME frame (O(num_chroms) each, called 2-4x per chromosome) into an
+    # O(1) named lookup - the same trick the fast path above uses. On genomes
+    # with ~1M scaffolds the old per-call match() was effectively O(M^2).
+    all_chrom_ends <- gintervals.all()
+    chrom_ends <- setNames(all_chrom_ends$end, all_chrom_ends$chrom)
     FUN <- function(intervals, intervals.set.out, envir) {
         intervals <- intervals[[1]]
         if (.gintervals.is1d(intervals)) {
             intervals$start <- pmax(intervals$start, 0)
-            intervals$end <- pmin(intervals$end, gintervals.all()[match(intervals$chrom, gintervals.all()$chrom), ]$end)
+            intervals$end <- pmin(intervals$end, chrom_ends[as.character(intervals$chrom)])
             intervals <- intervals[!is.na(intervals$end) & intervals$start < intervals$end, ]
         } else {
             intervals$start1 <- pmax(intervals$start1, 0)
-            intervals$end1 <- pmin(intervals$end1, gintervals.all()[match(intervals$chrom1, gintervals.all()$chrom), ]$end)
+            intervals$end1 <- pmin(intervals$end1, chrom_ends[as.character(intervals$chrom1)])
             intervals$start2 <- pmax(intervals$start2, 0)
-            intervals$end2 <- pmin(intervals$end2, gintervals.all()[match(intervals$chrom2, gintervals.all()$chrom), ]$end)
+            intervals$end2 <- pmin(intervals$end2, chrom_ends[as.character(intervals$chrom2)])
             intervals <- intervals[!is.na(intervals$end1) & !is.na(intervals$end2) & intervals$start1 < intervals$end1 & intervals$start2 < intervals$end2, ]
         }
         if (is.null(intervals.set.out)) {

--- a/src/GenomeComputeStrandAutocorr.cpp
+++ b/src/GenomeComputeStrandAutocorr.cpp
@@ -74,11 +74,11 @@ SEXP C_gcompute_strands_autocorr(SEXP _infile, SEXP _chrom, SEXP _binsize, SEXP 
 			verror("Invalid binsize value %g", binsize);
 
 		if (maxread <= 0)
-			verror("Invalid maxread value %g", binsize);
+			verror("Invalid maxread value %g", maxread);
 
 		for (int i = 0; i < NUM_COLS; i++) {
 			if (cols_order[i] <= 0)
-				verror("Invalid columns order: %s column's order is %d", COL_NAMES[i]);
+				verror("Invalid columns order: %s column's order is %d", COL_NAMES[i], cols_order[i]);
 
 			for (int j = i + 1; j < NUM_COLS; j++) {
 				if (cols_order[i] == cols_order[j]) {

--- a/src/GenomeSeqFetch.cpp
+++ b/src/GenomeSeqFetch.cpp
@@ -22,6 +22,11 @@ void GenomeSeqFetch::set_seqdir(const std::string &dir) {
     std::string idx_path = m_seqdir + "/genome.idx";
     struct stat st;
 
+    // Drop any index from a previous set_seqdir() call so repeated calls on
+    // the same object don't leak the earlier GenomeIndex.
+    delete m_index;
+    m_index = nullptr;
+
     if (stat(idx_path.c_str(), &st) == 0) {
         // Indexed mode: load index and open main genome.seq file
         m_indexed_mode = true;

--- a/src/GenomeTrackFindNeighbors.cpp
+++ b/src/GenomeTrackFindNeighbors.cpp
@@ -169,7 +169,7 @@ SEXP gfind_neighbors(SEXP _intervs1, SEXP _intervs2, SEXP _maxneighbors, SEXP _d
 
 		Progress_reporter progress;
 
-		if (type_mask1 &= IntervUtils::INTERVS1D) {
+		if (type_mask1 & IntervUtils::INTERVS1D) {
 			if (!Rf_isReal(_distrange_start))
 				verror("mindist argument is not numeric");
 			int64_t distance_start = (int64_t)REAL(_distrange_start)[0];

--- a/src/GenomeTrackImportMappedseq.cpp
+++ b/src/GenomeTrackImportMappedseq.cpp
@@ -235,7 +235,7 @@ SEXP gtrackimport_mappedseq(SEXP _track, SEXP _infile, SEXP _pileup, SEXP _binsi
 
 		for (int i = 0; i < NUM_COLS; i++) {
 			if (cols_order[i] <= 0)
-				verror("Invalid columns order: %s column's order is %d", COL_NAMES[i]);
+				verror("Invalid columns order: %s column's order is %d", COL_NAMES[i], cols_order[i]);
 
 			for (int j = i + 1; j < NUM_COLS; j++) {
 				if (cols_order[i] == cols_order[j])

--- a/tests/testthat/test-ggenome.R
+++ b/tests/testthat/test-ggenome.R
@@ -424,3 +424,35 @@ test_that("ggenome.implant overwrite guard works", {
         )
     )
 })
+
+test_that("ggenome.implant fails fast on pre-existing trackdb without writing output", {
+    local_db_state()
+
+    ref_fasta <- tempfile(fileext = ".fa")
+    out_fasta <- tempfile(fileext = ".fa")
+    trackdb_dir <- tempfile()
+    dir.create(trackdb_dir)
+    withr::defer({
+        unlink(ref_fasta)
+        unlink(out_fasta)
+        unlink(paste0(out_fasta, ".fai"))
+        unlink(trackdb_dir, recursive = TRUE)
+    })
+
+    cat(">chrA\nACGT\n", file = ref_fasta)
+    intervals <- data.frame(chrom = "chrA", start = 0, end = 2)
+    donor <- "NN"
+
+    # trackdb_dir already exists and overwrite = FALSE -> must error, and the
+    # error must come *before* the output FASTA is written (fail fast).
+    expect_error(
+        ggenome.implant(
+            intervals, donor, out_fasta,
+            genome_fasta = ref_fasta,
+            create_trackdb = TRUE,
+            trackdb_path = trackdb_dir
+        ),
+        "Trackdb directory already exists"
+    )
+    expect_false(file.exists(out_fasta))
+})

--- a/tests/testthat/test-gintervals1.R
+++ b/tests/testthat/test-gintervals1.R
@@ -214,3 +214,33 @@ test_that("gintervals.force_range handles 2D data correctly", {
         3L
     ), class = "data.frame"))
 })
+
+test_that("gintervals.force_range slow path (intervals.set.out) matches in-memory result", {
+    # The intervals.set.out path runs the per-chromosome FUN closure that was
+    # changed to hoist the chrom-end lookup. Verify it still produces the same
+    # clamped intervals as the vectorized in-memory fast path, across multiple
+    # chromosomes.
+    set_name <- paste0("test.force_range_", sample(1:1e9, 1))
+    gintervals.rm(set_name, force = TRUE)
+    withr::defer(gintervals.rm(set_name, force = TRUE))
+
+    input <- rbind(
+        data.frame(chrom = "chr1", start = 10, end = 100),
+        data.frame(chrom = "chr1", start = -100, end = 50),
+        data.frame(chrom = "chr1", start = 100, end = 1e+09),
+        data.frame(chrom = "chr2", start = 20, end = 200),
+        data.frame(chrom = "chr2", start = -50, end = 1e+09)
+    )
+
+    in_memory <- gintervals.force_range(input)
+    gintervals.force_range(input, intervals.set.out = set_name)
+    on_disk <- gintervals.load(set_name)
+
+    ord <- function(x) {
+        x$chrom <- as.character(x$chrom)
+        x <- x[order(x$chrom, x$start, x$end), c("chrom", "start", "end")]
+        rownames(x) <- NULL
+        x
+    }
+    expect_equal(ord(on_disk), ord(in_memory), ignore_attr = TRUE)
+})


### PR DESCRIPTION
Second autonomous code-audit pass over the misha source (the first landed at 5.7.4/5.8.0). Each finding was verified against the actual code; ~15 triage claims were rejected as false positives and are not included here.

## Fixes (→ 5.8.1, PATCH)

**Bug fixes**
- **Format-string UB** in two `verror()` calls: the invalid-`cols.order` message used `%d` with no matching argument, reading a garbage vararg (UB) when a user passed a non-positive column order. Affected `gtrack.import_mappedseq()` (`GenomeTrackImportMappedseq.cpp`) and the strand-autocorrelation importer (`GenomeComputeStrandAutocorr.cpp`). The latter also printed `binsize` in a `maxread`-validation error. Found via an arg-count sweep over all of `src/`.
- **`ggenome.implant()` fail-fast**: the `trackdb_path` existence/overwrite check ran only *after* exporting the reference FASTA and writing the output, so a pre-existing trackdb with `overwrite = FALSE` wrote the output then errored, orphaning the file. Hoisted the check into the up-front validation. (+ regression test)

**Performance**
- **`gintervals.force_range()` slow path** (big-set input or `intervals.set.out`): the per-chromosome closure called `gintervals.all()[match(chrom, gintervals.all()$chrom), ]$end` — `gintervals.all()` twice per chromosome (4× for 2D) plus a `match()` over the full `ALLGENOME` frame each call, i.e. O(M²) on M-scaffold genomes. Hoisted into a named `chrom_ends` lookup computed once (the trick the fast path already uses). Output unchanged. (+ regression test)

**Internal hardening** (no user-visible effect, omitted from NEWS)
- `&&` instead of `&` in two scalar `if()` guards (`.gintervals.is_bigset`, the obsolete-track converter) — short-circuits, avoids needless work on the common path.
- `GenomeSeqFetch::set_seqdir()` made idempotent (latent `GenomeIndex` leak if a fetcher were reused across genomes).
- `&` instead of `&=` in the find_neighbors type-mask test (removed a no-op mutation that read like a `==` typo).

## Notably *not* changed
- The prior audit's deferred "O(N²) list-append accumulator" in the gintervals FUN closures was **benchmarked and disproved** — it is O(1) amortized on R 4.4.1, so it was left as-is rather than refactored for no gain.
- Adding `__attribute__((format(printf)))` to `verror`/`rerror` (which would have caught the bugs above at compile time) was investigated and **reverted**: misha mixes `%ld`/`%lld` for `int64_t`, which would warn on one platform or the other absent a full `PRId64` migration.

## Testing
Full parallel suite: `FAIL 0 | WARN 92 | SKIP 31 | PASS 18990` (prior audit closed at PASS 18971; +19 includes the 2 new regression tests, WARN dropped 93→92). Targeted: gintervals1 50/50, neighbors 75/75, ggenome 26/26.