### PR TITLE
fix: distance vtracks return the true nearest interval on overlapping sources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.9.0
+Version: 5.9.1
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# misha 5.9.1
+
+### Bug fixes
+
+* **Behavior fix:** the `distance`, `distance.edge`, and `distance.center` virtual-track functions now always return the true nearest source interval. With overlapping or nested sources (e.g. `intervs.global.rmsk`) the old scan could return a non-nearest interval - even a nonzero distance for a query that overlaps the source. `distance.edge` again matches `gintervals.neighbors` exactly.
+* `distance.center` now accepts overlapping source intervals (a query center inside several resolves to the nearest center) instead of erroring at vtrack creation.
+
 # misha 5.9.0
 
 ### New features

--- a/src/IntervVarProcessor.cpp
+++ b/src/IntervVarProcessor.cpp
@@ -41,103 +41,53 @@ void IntervVarProcessor::process_interv_vars(
 	}
 }
 
+namespace {
+// Build (or rebuild on chromosome change) the per-chromosome nearest-neighbor
+// index for `var`, populated from its start-sorted source intervals. Returns the
+// finder ready to query the given chromosome. An empty chromosome yields a finder
+// with no objects, so NNIterator::begin returns false and callers emit NaN.
+void ensure_finder(TrackExpressionVars::Interv_var &var, int chromid, const GenomeChromKey &chromkey)
+{
+	if (var.finder && var.finder_chromid == chromid)
+		return;
+
+	if (!var.finder)
+		var.finder = std::make_unique<SegmentFinder<GInterval>>();
+
+	var.finder->reset(0, (int64_t)chromkey.get_chrom_size(chromid));
+	for (var.sintervs.begin_chrom_iter(chromid); !var.sintervs.isend_chrom(); var.sintervs.next_in_chrom())
+		var.finder->insert(var.sintervs.cur_interval());
+
+	var.finder_chromid = chromid;
+}
+}
+
 void IntervVarProcessor::process_distance(
 	TrackExpressionVars::Interv_var &var,
 	const GInterval &interval,
 	unsigned idx)
 {
-	// if iterator modifier exists, iterator intervals might not come sorted => perform a binary search
-	if (var.imdf1d) {
-		const GInterval &eval_interval = var.imdf1d->interval;
-		double min_dist = numeric_limits<double>::max();
-		double dist;
-		int64_t coord = (eval_interval.start + eval_interval.end) / 2;
-		GIntervals::const_iterator iinterv = lower_bound(var.sintervs.begin(), var.sintervs.end(), eval_interval, GIntervals::compare_by_start_coord);
+	const GInterval &q = var.imdf1d ? var.imdf1d->interval : interval;
 
-		if (iinterv != var.sintervs.end() && iinterv->chromid == eval_interval.chromid)
-			min_dist = iinterv->dist2coord(coord, var.dist_margin);
-
-		if (iinterv != var.sintervs.begin() && (iinterv - 1)->chromid == eval_interval.chromid) {
-			dist = (iinterv - 1)->dist2coord(coord, var.dist_margin);
-			if (fabs(min_dist) > fabs(dist))
-				min_dist = dist;
-		}
-
-		// if min_dist == double_max then we haven't found an interval with the same chromosome as the iterator interval =>
-		// we can skip the second binary search
-		if (min_dist == numeric_limits<double>::max())
-			var.var[idx] = numeric_limits<double>::quiet_NaN();
-		else {
-			iinterv = lower_bound(var.eintervs.begin(), var.eintervs.end(), eval_interval, GIntervals::compare_by_end_coord);
-
-			if (iinterv != var.eintervs.end() && iinterv->chromid == eval_interval.chromid) {
-				dist = iinterv->dist2coord(coord, var.dist_margin);
-				if (fabs(min_dist) > fabs(dist))
-					min_dist = dist;
-			}
-
-			if (iinterv != var.eintervs.begin() && (iinterv - 1)->chromid == eval_interval.chromid) {
-				dist = (iinterv - 1)->dist2coord(coord, var.dist_margin);
-				if (fabs(min_dist) > fabs(dist))
-					min_dist = dist;
-			}
-
-			var.var[idx] = min_dist;
-		}
-	} else {
-		const GIntervals *pintervs[2] = { &var.sintervs, &var.eintervs };
-		GIntervals::const_iterator *piinterv[2] = { &var.siinterv, &var.eiinterv };
-		double dist[2] = { 0, 0 };
-
-		for (int i = 0; i < 2; ++i) {
-			const GIntervals &intervs = *pintervs[i];
-			GIntervals::const_iterator &iinterv = *piinterv[i];
-
-			while (iinterv != intervs.end() && iinterv->chromid < interval.chromid)
-				++iinterv;
-
-			if (iinterv == intervs.end() || iinterv->chromid != interval.chromid)
-				dist[i] = numeric_limits<double>::quiet_NaN();
-			else {
-				int64_t coord = (interval.start + interval.end) / 2;
-
-				// Scan backward to handle non-monotone access (overlapping regions)
-				while (iinterv != intervs.begin()) {
-					GIntervals::const_iterator prev = iinterv - 1;
-					if (prev->chromid != interval.chromid)
-						break;
-					double curr_dist = iinterv->dist2coord(coord, var.dist_margin);
-					double prev_dist = prev->dist2coord(coord, var.dist_margin);
-					if (fabs(curr_dist) <= fabs(prev_dist))
-						break;
-					--iinterv;
-				}
-
-				dist[i] = (double)iinterv->dist2coord(coord, var.dist_margin);
-				GIntervals::const_iterator iinterv_next = iinterv + 1;
-
-				while (iinterv_next != intervs.end() && iinterv_next->chromid == interval.chromid) {
-					double dist_next = iinterv_next->dist2coord(coord, var.dist_margin);
-
-					if (fabs(dist[i]) < fabs(dist_next))
-						break;
-
-					iinterv = iinterv_next;
-					dist[i] = dist_next;
-					++iinterv_next;
-				}
-			}
-		}
-
-		if (std::isnan(dist[0]) && std::isnan(dist[1]))
-			var.var[idx] = numeric_limits<double>::quiet_NaN();
-		else if (std::isnan(dist[0]))
-			var.var[idx] = dist[1];
-		else if (std::isnan(dist[1]))
-			var.var[idx] = dist[0];
-		else
-			var.var[idx] = fabs(dist[0]) < fabs(dist[1]) ? dist[0] : dist[1];
+	if (var.imdf1d && var.imdf1d->out_of_range) {
+		var.var[idx] = numeric_limits<double>::quiet_NaN();
+		return;
 	}
+
+	ensure_finder(var, q.chromid, m_iu.get_chromkey());
+
+	int64_t coord = (q.start + q.end) / 2;
+	SegmentFinder<GInterval>::NNIterator nn(var.finder.get());
+
+	// No source intervals on this chromosome => NaN.
+	if (!nn.begin(Segment(coord, coord + 1))) {
+		var.var[idx] = numeric_limits<double>::quiet_NaN();
+		return;
+	}
+
+	// The nearest interval to the query-bin center, measured at its edges
+	// (dist2coord returns the signed distance, 0 / normalized fraction when inside).
+	var.var[idx] = nn->dist2coord(coord, var.dist_margin);
 }
 
 void IntervVarProcessor::process_distance_center(
@@ -145,54 +95,36 @@ void IntervVarProcessor::process_distance_center(
 	const GInterval &interval,
 	unsigned idx)
 {
-	// if iterator modifier exists, iterator intervals might not come sorted => perform a binary search
-	if (var.imdf1d) {
-		if (var.imdf1d->out_of_range) {
-			var.var[idx] = numeric_limits<double>::quiet_NaN();
-			return;
-		}
+	const GInterval &q = var.imdf1d ? var.imdf1d->interval : interval;
 
-		int64_t coord = (var.imdf1d->interval.start + var.imdf1d->interval.end) / 2;
-		GInterval eval_interval(var.imdf1d->interval.chromid, coord, coord + 1, 0);
-		GIntervals::const_iterator iinterv = lower_bound(var.sintervs.begin(), var.sintervs.end(), eval_interval, GIntervals::compare_by_start_coord);
-		double dist = numeric_limits<double>::quiet_NaN();
-
+	if (var.imdf1d && var.imdf1d->out_of_range) {
 		var.var[idx] = numeric_limits<double>::quiet_NaN();
-
-		if (iinterv != var.sintervs.end() && iinterv->chromid == eval_interval.chromid)
-			dist = iinterv->dist2center(coord);
-
-		if (std::isnan(dist) && iinterv != var.sintervs.begin() && (iinterv - 1)->chromid == eval_interval.chromid)
-			dist = (iinterv - 1)->dist2center(coord);
-
-		var.var[idx] = dist;
-	} else {
-		int64_t coord = (interval.start + interval.end) / 2;
-		GIntervals::const_iterator &iinterv = var.siinterv;
-		double dist = numeric_limits<double>::quiet_NaN();
-
-		while (iinterv != var.sintervs.end() && var.siinterv->chromid < interval.chromid)
-			++iinterv;
-
-		// Scan backward to handle non-monotone access (overlapping regions)
-		while (iinterv != var.sintervs.begin()) {
-			GIntervals::const_iterator prev = iinterv - 1;
-			if (prev->chromid != interval.chromid)
-				break;
-			if (prev->end > coord)
-				--iinterv;
-			else
-				break;
-		}
-
-		while (iinterv != var.sintervs.end() && iinterv->chromid == interval.chromid && iinterv->start <= coord) {
-			if (iinterv->end > coord)
-				dist = iinterv->dist2center(coord);
-			++iinterv;
-		}
-
-		var.var[idx] = dist;
+		return;
 	}
+
+	ensure_finder(var, q.chromid, m_iu.get_chromkey());
+
+	int64_t coord = (q.start + q.end) / 2;
+	double best = numeric_limits<double>::quiet_NaN();
+
+	// distance.center is defined only when the query-bin center sits inside a
+	// source interval. NNIterator yields candidates by increasing proximity, so
+	// every interval containing the point precedes the first one that doesn't;
+	// among the containing intervals we keep the nearest center. With
+	// non-overlapping sources there is at most one such interval, preserving the
+	// historical behavior; overlapping sources now resolve to the nearest center
+	// instead of erroring.
+	SegmentFinder<GInterval>::NNIterator nn(var.finder.get());
+	for (bool ok = nn.begin(Segment(coord, coord + 1)); ok; ok = nn.next()) {
+		const GInterval &iv = *nn;
+		if (coord < iv.start || coord >= iv.end)
+			break;
+		double d = iv.dist2center(coord);
+		if (std::isnan(best) || fabs(d) < fabs(best))
+			best = d;
+	}
+
+	var.var[idx] = best;
 }
 
 void IntervVarProcessor::process_distance_edge(
@@ -200,120 +132,27 @@ void IntervVarProcessor::process_distance_edge(
 	const GInterval &interval,
 	unsigned idx)
 {
-	// If iterator modifier exists, intervals might not come sorted => perform binary search
-	if (var.imdf1d) {
-		const GInterval &eval_interval = var.imdf1d->interval;
+	const GInterval &q = var.imdf1d ? var.imdf1d->interval : interval;
 
-		if (var.imdf1d->out_of_range) {
-			var.var[idx] = numeric_limits<double>::quiet_NaN();
-			return;
-		}
-
-		int64_t min_dist = numeric_limits<int64_t>::max();
-		int64_t dist;
-
-		// Search in start-sorted intervals
-		GIntervals::const_iterator iinterv = lower_bound(var.sintervs.begin(), var.sintervs.end(),
-														 eval_interval, GIntervals::compare_by_start_coord);
-
-		// Check the interval at and after the lower_bound position
-		if (iinterv != var.sintervs.end() && iinterv->chromid == eval_interval.chromid) {
-			dist = eval_interval.dist2interv(*iinterv);
-			if (llabs(dist) < llabs(min_dist) || min_dist == numeric_limits<int64_t>::max())
-				min_dist = dist;
-		}
-
-		// Check the interval before the lower_bound position
-		if (iinterv != var.sintervs.begin() && (iinterv - 1)->chromid == eval_interval.chromid) {
-			dist = eval_interval.dist2interv(*(iinterv - 1));
-			if (llabs(dist) < llabs(min_dist))
-				min_dist = dist;
-		}
-
-		// If no interval found on same chromosome, return NaN
-		if (min_dist == numeric_limits<int64_t>::max()) {
-			var.var[idx] = numeric_limits<double>::quiet_NaN();
-			return;
-		}
-
-		// Also search in end-sorted intervals to find potentially closer intervals
-		iinterv = lower_bound(var.eintervs.begin(), var.eintervs.end(),
-							  eval_interval, GIntervals::compare_by_end_coord);
-
-		if (iinterv != var.eintervs.end() && iinterv->chromid == eval_interval.chromid) {
-			dist = eval_interval.dist2interv(*iinterv);
-			if (llabs(dist) < llabs(min_dist))
-				min_dist = dist;
-		}
-
-		if (iinterv != var.eintervs.begin() && (iinterv - 1)->chromid == eval_interval.chromid) {
-			dist = eval_interval.dist2interv(*(iinterv - 1));
-			if (llabs(dist) < llabs(min_dist))
-				min_dist = dist;
-		}
-
-		var.var[idx] = (double)min_dist;
-	} else {
-		// Sequential access mode - iterate through sorted intervals
-		const GIntervals *pintervs[2] = { &var.sintervs, &var.eintervs };
-		GIntervals::const_iterator *piinterv[2] = { &var.siinterv, &var.eiinterv };
-		int64_t dist[2] = { 0, 0 };
-
-		for (int i = 0; i < 2; ++i) {
-			const GIntervals &intervs = *pintervs[i];
-			GIntervals::const_iterator &iinterv = *piinterv[i];
-
-			// Skip past intervals on earlier chromosomes
-			while (iinterv != intervs.end() && iinterv->chromid < interval.chromid)
-				++iinterv;
-
-			if (iinterv == intervs.end() || iinterv->chromid != interval.chromid) {
-				// No intervals on this chromosome
-				dist[i] = numeric_limits<int64_t>::max();
-			} else {
-				// Scan backward to handle non-monotone access (overlapping regions)
-				while (iinterv != intervs.begin()) {
-					GIntervals::const_iterator prev = iinterv - 1;
-					if (prev->chromid != interval.chromid)
-						break;
-					int64_t curr_dist = interval.dist2interv(*iinterv);
-					int64_t prev_dist = interval.dist2interv(*prev);
-					if (llabs(curr_dist) <= llabs(prev_dist))
-						break;
-					--iinterv;
-				}
-
-				// Calculate edge-to-edge distance using dist2interv
-				// Use default touch_is_at_dist_one = false to match gintervals.neighbors
-				dist[i] = interval.dist2interv(*iinterv);
-				GIntervals::const_iterator iinterv_next = iinterv + 1;
-
-				// Look ahead for closer intervals
-				while (iinterv_next != intervs.end() && iinterv_next->chromid == interval.chromid) {
-					int64_t dist_next = interval.dist2interv(*iinterv_next);
-
-					// Stop if we're getting further away
-					if (llabs(dist[i]) < llabs(dist_next))
-						break;
-
-					iinterv = iinterv_next;
-					dist[i] = dist_next;
-					++iinterv_next;
-				}
-			}
-		}
-
-		// Return the distance with smaller absolute value
-		if (dist[0] == numeric_limits<int64_t>::max() && dist[1] == numeric_limits<int64_t>::max()) {
-			var.var[idx] = numeric_limits<double>::quiet_NaN();
-		} else if (dist[0] == numeric_limits<int64_t>::max()) {
-			var.var[idx] = (double)dist[1];
-		} else if (dist[1] == numeric_limits<int64_t>::max()) {
-			var.var[idx] = (double)dist[0];
-		} else {
-			var.var[idx] = llabs(dist[0]) <= llabs(dist[1]) ? (double)dist[0] : (double)dist[1];
-		}
+	if (var.imdf1d && var.imdf1d->out_of_range) {
+		var.var[idx] = numeric_limits<double>::quiet_NaN();
+		return;
 	}
+
+	ensure_finder(var, q.chromid, m_iu.get_chromkey());
+
+	SegmentFinder<GInterval>::NNIterator nn(var.finder.get());
+
+	// No source intervals on this chromosome => NaN.
+	if (!nn.begin(Segment(q.start, q.end))) {
+		var.var[idx] = numeric_limits<double>::quiet_NaN();
+		return;
+	}
+
+	// Edge-to-edge distance to the nearest source interval, signed by the source
+	// strand and 0 on overlap - identical to gintervals.neighbors, since both
+	// consume the same NNIterator over start-sorted intervals.
+	var.var[idx] = (double)q.dist2interv(*nn);
 }
 
 void IntervVarProcessor::process_neighbor_count(

--- a/src/TrackExpressionVars.cpp
+++ b/src/TrackExpressionVars.cpp
@@ -239,7 +239,9 @@ void TrackExpressionVars::parse_exprs(const vector<string> &track_exprs)
 
 	for (Interv_vars::iterator ivar = m_interv_vars.begin(); ivar != m_interv_vars.end(); ++ivar) {
 		ivar->siinterv = ivar->sintervs.begin();
-		if (ivar->val_func == Interv_var::DIST || ivar->val_func == Interv_var::DIST_EDGE || ivar->val_func == Interv_var::NEIGHBOR_COUNT)
+		// Only neighbor.count still uses the end-sorted (expanded) list; the
+		// distance family now queries the nearest-neighbor index instead.
+		if (ivar->val_func == Interv_var::NEIGHBOR_COUNT)
 			ivar->eiinterv = ivar->eintervs.begin();
 	}
 
@@ -1254,9 +1256,8 @@ TrackExpressionVars::Interv_var &TrackExpressionVars::add_vtrack_var_src_interv(
 		var.dist_margin = dist_margin * 0.5;
 		var.sintervs.swap(intervs1d);
 		var.sintervs.sort();
-		var.eintervs = var.sintervs;
-		var.eintervs.sort(GIntervals::compare_by_end_coord);
-		// cannot not set var.siinterv and var.eiinterv now because these iterators will be invalidated one a new var is added to m_interv_vars
+		// The nearest-neighbor index (built lazily per chromosome) supersedes the
+		// old end-sorted scan, so eintervs is no longer needed here.
 
 		if (var.dist_margin) {
 			// if dist_margin is not zero => we are measuring distances from the centers of the interval, therefore the intervals cannot overlap
@@ -1274,12 +1275,9 @@ TrackExpressionVars::Interv_var &TrackExpressionVars::add_vtrack_var_src_interv(
 		var.dist_margin = 0.;
 		var.sintervs.swap(intervs1d);
 		var.sintervs.sort();
-		// cannot not set var.siinterv and var.eiinterv now because these iterators will be invalidated one a new var is added to m_interv_vars
-
-		for (GIntervals::const_iterator iinterv = var.sintervs.begin() + 1; iinterv < var.sintervs.end(); ++iinterv) {
-			if (iinterv->do_touch(*(iinterv - 1)))
-				verror("Virtual track %s: intervals are overlapping and hence incompatible with %s function", vtrack.c_str(), func.c_str());
-		}
+		// Overlapping source intervals are allowed: the nearest-neighbor index
+		// resolves a query-bin center that falls inside several intervals to the
+		// one with the nearest center.
 	} else if (!strcmp(func.c_str(), Interv_var::FUNC_NAMES[Interv_var::DIST_EDGE])) {
 		var.val_func = Interv_var::DIST_EDGE;
 
@@ -1289,9 +1287,8 @@ TrackExpressionVars::Interv_var &TrackExpressionVars::add_vtrack_var_src_interv(
 		var.dist_margin = 0.;
 		var.sintervs.swap(intervs1d);
 		var.sintervs.sort();
-		var.eintervs = var.sintervs;
-		var.eintervs.sort(GIntervals::compare_by_end_coord);
-		// Overlapping intervals are allowed for edge-to-edge distance
+		// Overlapping intervals are allowed for edge-to-edge distance; the
+		// nearest-neighbor index replaces the old end-sorted scan (no eintervs).
 	} else if (!strcmp(func.c_str(), Interv_var::FUNC_NAMES[Interv_var::COVERAGE])) {
         var.val_func = Interv_var::COVERAGE;
 

--- a/src/TrackExpressionVars.h
+++ b/src/TrackExpressionVars.h
@@ -40,6 +40,7 @@
 #include "GenomeTrackInMemory.h"
 #include "GInterval.h"
 #include "GInterval2D.h"
+#include "SegmentFinder.h"
 #include "TrackExpressionIteratorBase.h"
 #include "PWMScorer.h"
 #include "PWMEditDistanceScorer.h"
@@ -202,6 +203,13 @@ public:
         GIntervals::const_iterator siinterv;
         GIntervals::const_iterator eiinterv;
         double                     dist_margin;
+        // Per-chromosome nearest-neighbor index for the distance family
+        // (distance / distance.center / distance.edge). Built lazily during the
+        // genome walk and rebuilt when the chromosome changes. Replaces the old
+        // greedy sequential scan that returned non-nearest intervals on
+        // overlapping / nested source sets.
+        std::unique_ptr<SegmentFinder<GInterval>> finder;
+        int                        finder_chromid{-1};
         // Filter for masking genomic regions (applied after iterator modifiers)
         std::shared_ptr<Genome1DFilter> filter;
     };

--- a/tests/testthat/test-vtrack-distance-nearest-trap.R
+++ b/tests/testthat/test-vtrack-distance-nearest-trap.R
@@ -1,0 +1,99 @@
+create_isolated_test_db()
+
+# Regression tests for the greedy local-minimum scan bug in the distance
+# vtrack family (distance / distance.edge / distance.center). With overlapping
+# or nested source intervals the old sequential scan stopped at the first local
+# minimum of the distance sequence and returned a non-nearest interval - in the
+# extreme, a nonzero distance for a query that overlaps the source.
+#
+# Trap geometry (single chromosome):
+#   C  = [800, 900]    upstream of query
+#   C2 = [850, 870]    nested inside C  (sources overlap each other)
+#   D  = [950, 1500]   OVERLAPS the query  -> true nearest, distance 0
+#   E  = [1250, 1300]  downstream, placed to also trap the end-sorted scan
+# query = [1000, 1100], center 1050, sits inside D.
+trap_src <- function() {
+    gintervals(1, c(800, 850, 950, 1250), c(900, 870, 1500, 1300))
+}
+trap_query <- gintervals(1, 1000, 1100)
+
+test_that("distance.edge returns 0 for a query overlapping the source (trap geometry)", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+
+    gvtrack.create("d_edge_trap", trap_src(), "distance.edge")
+    res <- gextract("d_edge_trap", trap_query, iterator = trap_query)
+
+    # Query overlaps D=[950,1500] -> distance must be 0, matching gintervals.neighbors.
+    nb <- gintervals.neighbors(trap_query, trap_src())
+    expect_equal(res$d_edge_trap, 0)
+    expect_equal(res$d_edge_trap, nb$dist[1])
+})
+
+test_that("distance returns 0 when the query center sits inside an overlapping source (trap geometry)", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+
+    gvtrack.create("d_plain_trap", trap_src(), "distance")
+    res <- gextract("d_plain_trap", trap_query, iterator = trap_query)
+
+    # center 1050 is inside D -> distance 0 (dist2coord returns 0 inside an interval).
+    expect_equal(res$d_plain_trap, 0)
+})
+
+test_that("distance.edge matches gintervals.neighbors on a dense overlapping source (stress)", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+
+    set.seed(42)
+    n_src <- 2000
+    s <- sample.int(1e6, n_src)
+    w <- sample(c(10:50, 500:2000), n_src, replace = TRUE) # mix of narrow and very wide
+    src <- gintervals(1, s, s + w)
+    gvtrack.create("d_edge_stress", src, "distance.edge")
+
+    n_q <- 3000
+    qs <- sample.int(1e6, n_q)
+    query <- gintervals(1, qs, qs + 30L)
+    query <- gintervals.canonic(query)
+
+    res <- gextract("d_edge_stress", query, iterator = query)
+    res <- res[order(res$intervalID), ]
+    nb <- gintervals.neighbors(query, src)
+    key <- match(paste(res$chrom, res$start, res$end), paste(nb$chrom, nb$start, nb$end))
+
+    expect_equal(res$d_edge_stress, nb$dist[key])
+})
+
+test_that("distance.center accepts overlapping source intervals (no longer errors)", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+
+    # Previously this threw "intervals are overlapping and hence incompatible".
+    expect_no_error(gvtrack.create("dc_overlap_src", trap_src(), "distance.center"))
+})
+
+test_that("distance.center returns distance to the containing interval's center (overlapping source)", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+
+    gvtrack.create("dc_single", trap_src(), "distance.center")
+    res <- gextract("dc_single", trap_query, iterator = trap_query)
+
+    # center 1050 is inside D=[950,1500] only; D's center is 1225 -> |1050-1225| = 175.
+    expect_equal(res$dc_single, 175)
+})
+
+test_that("distance.center picks the nearest center among overlapping containing intervals", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+
+    # C=[800,900] center 850, C2=[850,870] center 860 (C2 nested in C).
+    src <- gintervals(1, c(800, 850), c(900, 870))
+    gvtrack.create("dc_multi", src, "distance.center")
+
+    # query center 860 is inside both C and C2; nearest center is C2 (860) -> 0.
+    query <- gintervals(1, 855, 865)
+    res <- gextract("dc_multi", query, iterator = query)
+    expect_equal(res$dc_multi, 0)
+})

--- a/tests/testthat/test-vtrack-values.R
+++ b/tests/testthat/test-vtrack-values.R
@@ -438,14 +438,13 @@ test_that("intervals with value column work with interval-based summarizers even
     expect_true(!is.na(result$value))
     gvtrack.rm("test.distance.vt")
 
-    # Test distance.center function - note: this function requires non-overlapping intervals
-    # but the key point is that it's treated as an interval-based function, not value-based
-    # So the overlap check in the value-based path is skipped (which is the fix)
-    # However, distance.center itself will check for overlaps and error if they exist
-    expect_error(
-        gvtrack.create("test.distance.center.vt", src = intervals_df, func = "distance.center"),
-        regexp = "overlapping"
-    )
+    # Test distance.center function - overlapping source intervals are now allowed;
+    # a query center inside several of them resolves to the nearest center.
+    gvtrack.create("test.distance.center.vt", src = intervals_df, func = "distance.center")
+    iter_int <- gintervals("chr1", 170, 180) # center 175: inside [100,200) (center 150) and [150,250) (center 200)
+    result <- gextract("test.distance.center.vt", intervals = iter_int, iterator = iter_int, colnames = "value")
+    expect_equal(result$value, 25) # nearest center is 25bp away
+    gvtrack.rm("test.distance.center.vt")
 })
 
 test_that("intervals with value column and interval-based functions ignore value column", {


### PR DESCRIPTION
## Problem

The `distance.edge` virtual track does **not** behave like `gintervals.neighbors` on overlapping/nested source sets: it returns a nonzero distance for a query that overlaps the source (where `gintervals.neighbors` correctly returns 0), and more generally returns a *non-nearest* interval.

Root cause (in `src/IntervVarProcessor.cpp`): `process_distance`, `process_distance_edge`, and `process_distance_center` used a greedy sequential scan whose look-ahead stopped at the **first local minimum** of the distance sequence:

```cpp
if (llabs(dist[i]) < llabs(dist_next)) break;   // stops at first local min
```

That is only correct when distance is unimodal in start-/end-sorted order. With overlapping, nested, or widely varying source intervals (e.g. `intervs.global.rmsk`, 5.1M intervals) it is not, so the scan returns a non-nearest interval and can skip right past an overlapping (distance-0) one.

## Fix

Replace the scan in all three functions with the same `SegmentFinder`/`NNIterator` nearest-neighbor index that `gintervals.neighbors` already uses, built lazily per chromosome. Since both consume the same start-sorted `NNIterator`, `distance.edge` now matches `gintervals.neighbors` **exactly**, including tie-breaking.

- `distance.center` no longer errors on overlapping sources - a query center inside several intervals resolves to the nearest center (unchanged for non-overlapping sources).
- The now-dead end-sorted `eintervs` copy is dropped for `distance`/`distance.edge`, halving per-vtrack memory on large sources.

## When introduced

- **`distance.edge`** was buggy from the commit that introduced it (`34f652b8`); first shipped in **v5.3.1** and wrong in every release through v5.9.0.
- **`distance`** (plain) has shared the identical flaw since the earliest tracked C++ (2017 import); unreported because its semantics are documented as "mixed/surprising".
- **`distance.center`** never exhibited it in the wild because it hard-errored on overlapping sources.

## Performance (benchmarked, mm10 + full rmsk)

| Workload | old (buggy) | new |
|---|---|---|
| edge, per-interval 200k queries | 1.76s | 1.92s (1.07x) |
| edge, genome-wide fixed-bin chr1 | 1.00s | 1.76s (1.75x) |

The common per-interval path is essentially unchanged; the genome-wide fixed-bin path costs 1.75x for correctness plus exact `gintervals.neighbors` parity. A reusable-iterator optimization was measured and rejected (slower).

## Tests

New regression tests with overlap/nested trap geometry, plus the existing `distance.edge`, `distance.center`, `neighbor.count`, `coverage`, and `gintervals.neighbors` suites all pass. A 78k-query sweep on rmsk shows **zero** disagreements with `gintervals.neighbors`.

Version bumped to **5.9.1** (PATCH).