### PR TITLE
feat(R): gene names in gdb.install_intervals annotation sets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.9.1
+Version: 5.10.0
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.10.0
+
+* `gdb.install_intervals()` / `gdb.build_genome()` now attach `name` (transcript accession) and `geneName` (gene symbol) columns to the installed `tss`/`exons`/`utr3`/`utr5` sets, taken from the source annotation. Sources without symbols build cleanly with a blank `geneName`.
+
 # misha 5.9.1
 
 ### Bug fixes

--- a/R/genome-build-installers.R
+++ b/R/genome-build-installers.R
@@ -119,8 +119,11 @@
     if (asset$format == "gtf") {
         converter <- .gtf_to_genepred_resolve_or_install()
         gp_raw <- file.path(workdir, "raw.genePred")
+        # -geneNameAsName2 writes the gene_name attribute (the symbol) into
+        # name2 instead of gene_id, so the installed sets carry symbols; falls
+        # back to gene_id when gene_name is absent.
         ret <- system2(converter,
-            args = c("-genePredExt", shQuote(src), shQuote(gp_raw)),
+            args = c("-genePredExt", "-geneNameAsName2", shQuote(src), shQuote(gp_raw)),
             stdout = if (verbose) "" else FALSE,
             stderr = if (verbose) "" else FALSE
         )

--- a/R/genome-build-installers.R
+++ b/R/genome-build-installers.R
@@ -200,12 +200,40 @@
         gp_trim <- gp_xlat
     }
 
-    # 4. Import into the groot. Returns a named list of data frames:
-    #    tss, exons, utr3, utr5 (NULL if the set is empty).
-    if (verbose) message("  Importing genes via gintervals.import_genes() ...")
-    result <- gintervals.import_genes(gp_trim)
+    # 4. Build a (name -> gene symbol) sidecar from the trimmed genePred so the
+    #    installed sets carry gene names. Col 1 is the transcript/RNA accession
+    #    (the join key the annots mechanism keys on), col 12 is name2 (the gene
+    #    symbol). Deduplicate by col 1: gintervals.import_genes' annots reader
+    #    rejects a repeated id. Empty name2 stays an empty field (na = ""), so
+    #    sources without symbols still build, just with a blank geneName.
+    use_dt <- requireNamespace("data.table", quietly = TRUE)
+    if (use_dt) {
+        name_map <- data.table::fread(gp_trim,
+            sep = "\t", header = FALSE, quote = "", showProgress = FALSE,
+            data.table = FALSE, select = c(1L, 12L), colClasses = "character",
+            na.strings = NULL
+        )
+    } else {
+        name_map <- utils::read.table(gp_trim,
+            sep = "\t", header = FALSE, quote = "", comment.char = "",
+            colClasses = "character", na.strings = character(0)
+        )[, c(1L, 12L), drop = FALSE]
+    }
+    name_map <- name_map[!duplicated(name_map[[1L]]), , drop = FALSE]
+    annots_file <- file.path(workdir, "gene_names.annots")
+    utils::write.table(name_map, annots_file,
+        sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE, na = ""
+    )
 
-    # 5. Save each role under the (prefixed, renamed) name. NA skips the role.
+    # 5. Import into the groot. Returns a named list of data frames:
+    #    tss, exons, utr3, utr5 (NULL if the set is empty), each with the
+    #    name / geneName annotation columns attached.
+    if (verbose) message("  Importing genes via gintervals.import_genes() ...")
+    result <- gintervals.import_genes(gp_trim, annots_file,
+        annots.names = c("name", "geneName")
+    )
+
+    # 6. Save each role under the (prefixed, renamed) name. NA skips the role.
     roles <- c("tss", "exons", "utr3", "utr5")
     for (role in roles) {
         target_name <- gene_sets[[role]]
@@ -235,7 +263,7 @@
         if (verbose) message(sprintf("  %s: saved %d intervals", full_name, nrow(df)))
     }
 
-    # 6. Reload so new sets are visible.
+    # 7. Reload so new sets are visible.
     gdb.reload()
     invisible(NULL)
 }

--- a/R/genome-build.R
+++ b/R/genome-build.R
@@ -825,7 +825,10 @@
 #' @param format \code{"indexed"} or \code{"per-chromosome"}; \code{NULL} =>
 #'   \code{getOption("gmulticontig.indexed_format", TRUE)}.
 #' @param verbose If \code{TRUE}, prints progress.
-#' @return None (invisible \code{NULL}).
+#' @return None (invisible \code{NULL}). The installed gene-derived sets
+#'   (\code{tss}, \code{exons}, \code{utr3}, \code{utr5}) carry a \code{name}
+#'   column (transcript/RNA accession) and a \code{geneName} column (gene symbol
+#'   from the source annotation; blank when the source has no symbol).
 #'
 #' @seealso \code{\link{gdb.install_intervals}}, \code{\link{gdb.create}},
 #'   \code{\link{gdb.list_genomes}}, \code{\link{gdb.genome_info}}.
@@ -1225,6 +1228,11 @@ gdb.install_gtf_converter <- function(force = FALSE) {
 #' @return Invisible \code{NULL}. Side effects: writes \code{.interv} files under
 #'   \code{<groot>/tracks/}, extends \code{<groot>/chrom_aliases.tsv}, appends to
 #'   \code{<groot>/genome_info.yaml}, and re-initializes the active groot.
+#'
+#'   The gene-derived sets (\code{tss}, \code{exons}, \code{utr3}, \code{utr5})
+#'   carry a \code{name} column (transcript/RNA accession) and a \code{geneName}
+#'   column (gene symbol from the source annotation; blank when the source has
+#'   no symbol).
 #'
 #' @seealso \code{\link{gdb.build_genome}}, \code{\link{gdb.install_gtf_converter}}.
 #'

--- a/man/gdb.build_genome.Rd
+++ b/man/gdb.build_genome.Rd
@@ -93,7 +93,10 @@ stricter single-column-only behavior.}
 \item{verbose}{If \code{TRUE}, prints progress.}
 }
 \value{
-None (invisible \code{NULL}).
+None (invisible \code{NULL}). The installed gene-derived sets
+  (\code{tss}, \code{exons}, \code{utr3}, \code{utr5}) carry a \code{name}
+  column (transcript/RNA accession) and a \code{geneName} column (gene symbol
+  from the source annotation; blank when the source has no symbol).
 }
 \description{
 Builds a misha genomic database for a named assembly. Resolves the name

--- a/man/gdb.install_intervals.Rd
+++ b/man/gdb.install_intervals.Rd
@@ -104,6 +104,11 @@ and we can skip the entry rescan. Users never set this directly.}
 Invisible \code{NULL}. Side effects: writes \code{.interv} files under
   \code{<groot>/tracks/}, extends \code{<groot>/chrom_aliases.tsv}, appends to
   \code{<groot>/genome_info.yaml}, and re-initializes the active groot.
+
+  The gene-derived sets (\code{tss}, \code{exons}, \code{utr3}, \code{utr5})
+  carry a \code{name} column (transcript/RNA accession) and a \code{geneName}
+  column (gene symbol from the source annotation; blank when the source has
+  no symbol).
 }
 \description{
 Given an existing groot and a source recipe (or registry name, or accession),

--- a/tests/testthat/test-genome-build-installers.R
+++ b/tests/testthat/test-genome-build-installers.R
@@ -166,6 +166,11 @@ test_that(".install_genes_set with default gene_sets produces tss/exons/utr3/utr
     expect_true(gintervals.exists("exons"))
     expect_true(gintervals.exists("utr3"))
     expect_true(gintervals.exists("utr5"))
+
+    tss <- gintervals.load("tss")
+    expect_true(all(c("name", "geneName") %in% colnames(tss)))
+    expect_equal(tss$name, "tx1")
+    expect_equal(tss$geneName, "gene1")
 })
 
 test_that(".install_genes_set drops genePred rows whose chrom didn't translate to a groot contig", {

--- a/tests/testthat/test-genome-build-installers.R
+++ b/tests/testthat/test-genome-build-installers.R
@@ -205,6 +205,33 @@ test_that(".install_genes_set tolerates empty gene names and duplicate ids", {
     expect_true(any(tss$geneName == ""))
 })
 
+test_that(".install_genes_set concatenates symbols for overlapping TSS", {
+    groot <- make_test_groot()
+    on.exit(unlink(groot, recursive = TRUE))
+    dir.create(file.path(groot, "downloads"), showWarnings = FALSE)
+    gdb.init(groot, rescan = TRUE)
+
+    gp <- tempfile(fileext = ".genePred")
+    # Two +-strand transcripts sharing txStart = 100 -> identical 1bp TSS, which
+    # the importer unifies; their distinct symbols concatenate with ";".
+    writeLines(c(
+        "txA\tchr1\t+\t100\t500\t150\t450\t1\t100,\t500,\t0\tGeneA",
+        "txB\tchr1\t+\t100\t600\t150\t550\t1\t100,\t600,\t0\tGeneB"
+    ), gp)
+
+    .install_genes_set(
+        list(file = gp, format = "genepred"),
+        prefix = "",
+        gene_sets = c(tss = "tss", exons = "exons", utr3 = "utr3", utr5 = "utr5"),
+        overwrite = FALSE, verbose = FALSE
+    )
+    tss <- gintervals.load("tss")
+    # Both TSS share start 100 -> one unified interval with both symbols.
+    expect_equal(nrow(tss), 1L)
+    expect_true(grepl("GeneA", tss$geneName) && grepl("GeneB", tss$geneName))
+    expect_match(tss$geneName, ";", fixed = TRUE)
+})
+
 test_that(".install_genes_set drops genePred rows whose chrom didn't translate to a groot contig", {
     # Real-world bison case: the genes GTF carries an MT transcript whose
     # refseq accession (NC_012346.1) lives in the chromAlias but the groot

--- a/tests/testthat/test-genome-build-installers.R
+++ b/tests/testthat/test-genome-build-installers.R
@@ -173,6 +173,38 @@ test_that(".install_genes_set with default gene_sets produces tss/exons/utr3/utr
     expect_equal(tss$geneName, "gene1")
 })
 
+test_that(".install_genes_set tolerates empty gene names and duplicate ids", {
+    groot <- make_test_groot()
+    on.exit(unlink(groot, recursive = TRUE))
+    dir.create(file.path(groot, "downloads"), showWarnings = FALSE)
+    gdb.init(groot, rescan = TRUE)
+
+    gp <- tempfile(fileext = ".genePred")
+    # 15-col extended genePred (as gff3ToGenePred / gtfToGenePred emit): cols
+    # 13-15 are cdsStartStat/cdsEndStat/exonFrames. Row 1 has an empty name2
+    # (col 12) - a real source-without-symbol case, and unlike a 12-col trailing
+    # empty it survives strsplit because cols 13-15 follow. Rows 2-3 share the
+    # transcript id "dup" to exercise the sidecar dedup.
+    writeLines(c(
+        "txEmpty\tchr1\t+\t100\t200\t150\t190\t1\t100,\t200,\t0\t\tcmpl\tcmpl\t0,",
+        "dup\tchr1\t+\t300\t400\t320\t380\t1\t300,\t400,\t0\tGeneD\tcmpl\tcmpl\t0,",
+        "dup\tchr1\t-\t500\t600\t520\t580\t1\t500,\t600,\t0\tGeneD\tcmpl\tcmpl\t0,"
+    ), gp)
+
+    expect_silent(
+        .install_genes_set(
+            list(file = gp, format = "genepred"),
+            prefix = "",
+            gene_sets = c(tss = "tss", exons = "exons", utr3 = "utr3", utr5 = "utr5"),
+            overwrite = FALSE, verbose = FALSE
+        )
+    )
+    tss <- gintervals.load("tss")
+    expect_true("geneName" %in% colnames(tss))
+    # The empty-name2 transcript installs with a blank geneName, not dropped.
+    expect_true(any(tss$geneName == ""))
+})
+
 test_that(".install_genes_set drops genePred rows whose chrom didn't translate to a groot contig", {
     # Real-world bison case: the genes GTF carries an MT transcript whose
     # refseq accession (NC_012346.1) lives in the chromAlias but the groot


### PR DESCRIPTION
## Summary

`gdb.install_intervals()` / `gdb.build_genome()` previously produced
`intervs.global.tss` / `exons` / `utr3` / `utr5` sets with only
`chrom, start, end, strand` - no gene names. The gene symbol was carried through
the genePred pipeline (column 12, `name2`) but discarded by the C++ importer's
unused `ALIGNID` slot. Names could only ever be attached via the separate
`annots.file` mechanism, which the installer never wired up.

This change routes a deduplicated `(transcript id, name2)` sidecar through that
existing mechanism in `.install_genes_set`, so the installed gene-derived sets
gain a `name` (transcript/RNA accession) and `geneName` (gene symbol) column,
sourced from each species' own annotation. The shared C++ importer and the
legacy `gdb.create` path are untouched.

- **R-only**, scoped to `.install_genes_set` (`R/genome-build-installers.R`).
- **GTF sources:** `gtfToGenePred` now runs with `-geneNameAsName2` so `name2`
  carries the symbol (`gene_name`) rather than `gene_id`. GFF3 already emits the
  symbol into `name2`.
- **Robust to missing names:** empty `name2` yields a blank `geneName` (not an
  error), so symbol-less sources (LOC-only annotations, draft genomes) still
  build. Duplicate transcript ids are deduplicated so the annots reader doesn't
  reject them. Overlapping TSS inherit the importer's existing `;`-join.
- Existing curated hg38/mm10 sets (knownGene + kgXref provenance) are unaffected.

MINOR bump -> 5.10.0 (new on-disk shape for freshly built annotation sets).

## Test Plan

- [x] New tests in `test-genome-build-installers.R`: `name`/`geneName` populated;
  blank `name2` and duplicate ids tolerated; overlapping TSS concatenate symbols.
- [x] Full suite green (19,048 passed, 0 failed; converter-gated GTF/GFF3 paths
  skip locally and run in CI).