### PR TITLE
fix(C++): indexed dense tracks with empty leading chrom no longer SIGFPE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.10.0
+Version: 5.10.1
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.10.1
+
+* **Behavior fix:** indexed dense tracks whose first genome chrom has no data (typically produced by `gtrack.copy()` when the destination DB has a leading chrom that was not in the source's per-chrom files) no longer report `bin.size = 0` from `gtrack.info()` and no longer SIGFPE on subsequent reads. `GenomeTrackFixedBin::init_read` now back-fills `m_bin_size` from the first non-empty index entry on a length-0 lookup, instead of leaving it at the constructor default.
+
 # misha 5.10.0
 
 * `gdb.install_intervals()` / `gdb.build_genome()` now attach `name` (transcript accession) and `geneName` (gene symbol) columns to the installed `tss`/`exons`/`utr3`/`utr5` sets, taken from the source annotation. Sources without symbols build cleanly with a blank `geneName`.

--- a/src/GenomeTrackFixedBin.cpp
+++ b/src/GenomeTrackFixedBin.cpp
@@ -1151,7 +1151,25 @@ void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int 
 
 		auto entry = idx->get_entry(chromid);
 		if (!entry || entry->length == 0) {
-			// Chromosome not in index or empty contig - treat as empty
+			// Chromosome not in index or empty contig - treat as empty.
+			// But still populate m_bin_size from the first non-empty entry,
+			// otherwise gtrack.info on an indexed track whose probed chrom
+			// has no data (e.g. produced by gtrack.copy with a destination
+			// chrom that is not in the source's per-chrom file list) reports
+			// bin_size = 0, and subsequent unguarded `/ m_bin_size` divisions
+			// in the read paths (lines 236/249/402/450/652/663) trigger
+			// SIGFPE.
+			if (m_bin_size == 0) {
+				for (const auto &e : idx->get_all_entries()) {
+					if (e.length == 0) continue;
+					if (m_bfile.seek(e.offset, SEEK_SET))
+						TGLError<GenomeTrackFixedBin>("Failed to seek to offset %llu in %s",
+							(unsigned long long)e.offset, dat_path.c_str());
+					if (m_bfile.read(&m_bin_size, sizeof(m_bin_size)) != sizeof(m_bin_size))
+						TGLError<GenomeTrackFixedBin>("Invalid fixed-bin header in %s", dat_path.c_str());
+					break;
+				}
+			}
 			m_num_samples = 0;
 			m_chromid = chromid;
 			return;

--- a/tests/testthat/test-indexed-empty-leading-chrom.R
+++ b/tests/testthat/test-indexed-empty-leading-chrom.R
@@ -1,0 +1,55 @@
+load_test_db()
+
+# Regression for the gtrack.copy SIGFPE / gtrack.info bin_size=0 bug.
+#
+# When an indexed dense track is packed with a per-chrom file list that does
+# not include the genome's first chromosome (e.g. gtrack.copy with a
+# destination DB whose leading chrom is not in the source), the resulting
+# track.idx has length=0 for that chrom. The old GenomeTrackFixedBin::init_read
+# returned early on the length=0 entry without populating m_bin_size, leaving
+# it at the constructor default 0. gtrack.info then reported bin_size=0 and
+# subsequent reads tripped the unguarded `interval.start / m_bin_size`
+# division at GenomeTrackFixedBin.cpp:236/249/402/450/652/663 -> SIGFPE.
+test_that("indexed dense track with empty leading chrom reports correct bin_size", {
+    root <- tempfile("emptyleading_")
+    dir.create(root)
+    dir.create(file.path(root, "tracks"))
+    dir.create(file.path(root, "seq"))
+    writeLines(c("chr1\t10000", "chr2\t8000"), file.path(root, "chrom_sizes.txt"))
+    file.create(file.path(root, "seq", "chr1.seq"))
+    file.create(file.path(root, "seq", "chr2.seq"))
+    gsetroot(root)
+
+    # Build a dense track with data on chr2 only, by creating it normally then
+    # removing chr1's per-chrom file. The pack will then see no chr1 file and
+    # write a length=0 entry for it.
+    gtrack.create_dense(
+        track = "t", description = "x",
+        intervals = data.frame(chrom = c("chr1", "chr2"), start = c(0L, 0L), end = c(10000L, 8000L)),
+        values = c(1, 1),
+        binsize = 20, defval = 0, func = "coverage"
+    )
+    trackdir <- file.path(root, "tracks", "t.track")
+    file.remove(file.path(trackdir, "chr1")) # leave only chr2's per-chrom file
+    expect_true(file.exists(file.path(trackdir, "chr2")))
+
+    # Pack with both chroms in the dest chrom order; chr1 will get length=0.
+    misha:::.gcall(
+        "gtrack_pack_per_chrom_to_indexed",
+        trackdir, c("chr1", "chr2"), "dense", misha:::.misha_env()
+    )
+    expect_true(file.exists(file.path(trackdir, "track.dat")))
+    expect_true(file.exists(file.path(trackdir, "track.idx")))
+
+    # gtrack.info reads the FIRST chrom by convention. Before the fix, that
+    # chrom's length=0 entry skipped the bin_size read and returned 0. The fix
+    # falls back to the first non-empty entry in the index.
+    info <- gtrack.info("t")
+    expect_equal(info$bin.size, 20L)
+
+    # And reading chr2 (the populated chrom) must not be poisoned by the
+    # earlier empty-chrom open that left m_bin_size at 0.
+    out <- gextract("t", intervals = data.frame(chrom = "chr2", start = 0, end = 100), iterator = 20)
+    expect_equal(nrow(out), 5L)
+    expect_true(all(out$t == 1))
+})


### PR DESCRIPTION
## Summary

When `gtrack.copy()` packs a per-chrom dense track into an indexed
destination whose `chrom_sizes.txt` lists a leading chrom that has no
per-chrom file in the source, `gtrack_pack_per_chrom_to_indexed` writes a
`length = 0` index entry for that chrom.
`GenomeTrackFixedBin::init_read` (`src/GenomeTrackFixedBin.cpp:1152-1158`)
returned early on the length-0 lookup **without ever reading `m_bin_size`
from disk**, leaving it at the constructor default `0`.

The cascade:
- `gtrack.info()` always probes the genome's first chrom
  (`GenomeTrackInfo.cpp:71`). With the leading chrom empty, it returned
  `bin.size = 0`.
- Any subsequent read of the track tripped one of the unguarded
  `interval.start / m_bin_size` integer divisions in the read paths
  (`GenomeTrackFixedBin.cpp:236, 249, 402, 450, 652, 663`) -> **SIGFPE**.

`init_read` now back-fills `m_bin_size` from the first non-empty entry in
the index when the queried chrom is empty, so `gtrack.info` reports the
correct bin size and downstream reads are no longer poisoned. Behavior is
unchanged for tracks whose probed chrom has data.

PATCH bump -> 5.10.1.

## How users hit this in the wild

`gtrack.copy(src, dest, db = <some_db>)` where `<some_db>` was created
independently (e.g. a per-project mouse DB) and lists a leading
chromosome that the source's per-chrom files don't cover (often due to a
chrom-name convention mismatch the alias-rewrite step can't fully
resolve, or because the destination has additional contigs the source
lacks). The resulting indexed track silently has a length-0 chunk for
that chrom; the first `gtrack.info` or `gextract` call reveals the bug.

## Test Plan

- [x] New regression test
  `tests/testthat/test-indexed-empty-leading-chrom.R`: pack a per-chrom
  track that omits `chr1` into an indexed layout with `chr1, chr2` in
  the dest chrom list. Assert `gtrack.info()$bin.size == 20L` (was `0L`
  before the fix) and that `gextract` on the populated chrom returns
  correct values.
- [x] Full indexed/track-copy/track-management suite: 218 PASS, 0 FAIL.