### PR TITLE
perf(C++): single-function lse/sum/exists/size vtrack keeps sliding-window path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.10.1
+Version: 5.10.2
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.10.2
+
+* **Performance fix:** a single-function `lse` (or `sum`/`exists`/`size`) virtual track scanned over a sliding window (`gvtrack.iterator(sshift=, eshift=)`) genome-wide is fast again. Since 5.6.7 a single-function "fast path" recomputed the windowed reduction from scratch on every step, bypassing the incremental sliding-window path; the common motif-energy quantile workload (windowed `lse` + `gquantiles`/`gscreen`) was ~2.5x slower (worse with wider windows). Such single-function reducers now keep the sliding-window path. Output is unchanged.
+
 # misha 5.10.1
 
 * **Behavior fix:** indexed dense tracks whose first genome chrom has no data (typically produced by `gtrack.copy()` when the destination DB has a leading chrom that was not in the source's per-chrom files) no longer report `bin.size = 0` from `gtrack.info()` and no longer SIGFPE on subsequent reads. `GenomeTrackFixedBin::init_read` now back-fills `m_bin_size` from the first non-empty index entry on a length-0 lookup, instead of leaving it at the constructor default.

--- a/src/GenomeTrackFixedBin.cpp
+++ b/src/GenomeTrackFixedBin.cpp
@@ -91,10 +91,22 @@ void GenomeTrackFixedBin::classify_fast_path_mode()
 {
 	// Single-function fast path: if exactly one function is registered and no quantile,
 	// we can run a tight loop for just that function.
+	//
+	// Exception: SUM/LSE/EXISTS/SIZE are reducer functions that mode 1
+	// (read_interval_reducers_only) maintains incrementally with a sliding
+	// window across consecutive overlapping interval reads. Routing a single
+	// LSE through read_interval_single_function recomputes the whole window
+	// from scratch on every step, which is dramatically slower for the windowed
+	// vtrack scan pattern (e.g. func="lse" with sshift/eshift scanned bin-by-bin
+	// genome-wide - the motif-energy quantile workload). Let those fall through
+	// to the reducer classification so they keep the sliding-window fast path.
 	if (!m_use_quantile && __builtin_popcount(m_func_mask) == 1) {
-		m_fast_path_mode = 3;
-		m_single_func = static_cast<Functions>(__builtin_ctz(m_func_mask));
-		return;
+		const Functions f = static_cast<Functions>(__builtin_ctz(m_func_mask));
+		if (f != SUM && f != LSE && f != EXISTS && f != SIZE) {
+			m_fast_path_mode = 3;
+			m_single_func = f;
+			return;
+		}
 	}
 
 	bool reducer_only = !m_use_quantile;

--- a/tests/testthat/test-perf-regression.R
+++ b/tests/testthat/test-perf-regression.R
@@ -128,6 +128,35 @@ test_that("gextract vtrack with LSE sliding window stays fast", {
     expect_perf_baseline(measured, "vtrack lse+window", baseline_ms = 18)
 })
 
+test_that("gquantiles vtrack LSE windowed full-chr scan stays fast (mode-3 sliding-bypass regression)", {
+    # Bug history: v5.6.7 (commit 1cbfa801, "C++ optimization audit") added a
+    # single-function fast path (mode 3) in GenomeTrackFixedBin that intercepted
+    # single-function LSE *before* the mode-1 reducer path. Mode 3 recomputes the
+    # log-sum-exp from scratch over the whole window on every output bin, bypassing
+    # the incremental sliding-window LSE that mode 1 maintains. For a windowed lse
+    # vtrack scanned bin-by-bin genome-wide - Tamar's motif-energy quantile
+    # workload (compute_genomewide_motif_quantiles) - this was ~7.7x slower at a
+    # 40-bin window (5111ms vs 667ms here) and grows with the window width.
+    #
+    # Two reasons the small_chr1 LSE test above could not catch it: (1) a ~20-bin
+    # scope is dominated by fixed overhead, hiding the per-bin sliding advantage;
+    # (2) it uses gextract, which materializes every output row back to R and so
+    # dwarfs the C++ inner-loop cost. This test uses gquantiles (a streaming
+    # reduction, exactly her workload) over full chr1 (~5M bins) with a wide
+    # 40-bin window, so the per-bin LSE cost dominates and the regressed path
+    # lands well outside the 3x budget.
+    skip_unless_perf()
+    fix <- .perf_setup(n_dense_tracks = 1)
+    on.exit(.perf_cleanup(fix), add = TRUE)
+    on.exit(try(gvtrack.rm("v_lse_full"), silent = TRUE), add = TRUE)
+
+    gvtrack.create("v_lse_full", fix$dense_tracks[1], func = "lse")
+    gvtrack.iterator("v_lse_full", sshift = -1000, eshift = 1000)
+
+    measured <- time_op(gquantiles("v_lse_full", percentiles = 0.99, intervals = fix$full_chr1, iterator = 50))
+    expect_perf_baseline(measured, "vtrack lse+window full-chr", baseline_ms = 667)
+})
+
 test_that("gscreen on many dense tracks stays fast", {
     # gscreen is the second hottest entry point after gextract for Tamar's
     # workloads. Same setup-cost characteristic as gextract — the validation


### PR DESCRIPTION
## Summary

A collaborator reported misha being "slower than usual" on a motif-enrichment pipeline. Bisected a real **~2.4x genome-wide regression** (worse with wider windows) and fixed it.

The hot path is `compute_genomewide_motif_quantiles`: a `func="lse"` virtual track with `gvtrack.iterator(sshift, eshift)` (a sliding window), scanned bin-by-bin genome-wide and reduced with `gquantiles`. Plain `gextract` was unaffected, which pointed at the windowed-reduction path rather than the dense read.

## Root cause (bisected to `1cbfa801`, v5.6.7 "C++ optimization audit")

`GenomeTrackFixedBin::classify_fast_path_mode()` routed **any** single registered function to the new mode-3 single-function fast path (`read_interval_single_function`), which recomputes the windowed reduction **from scratch on every output bin**. For `SUM`/`LSE`/`EXISTS`/`SIZE` this preempts **mode 1** (`read_interval_reducers_only`), which maintains an **incremental sliding window** (one push + one pop per step). So a windowed `lse` scan went from O(1)/step to O(window)/step.

Bisect (chr19, `lse` vtrack + `gquantiles`):

| commit | version | time |
|---|---|---|
| `3352c135` (parent) | 5.6.7-pre | **0.628s** |
| `1cbfa801` | 5.6.7 | **1.690s** |
| HEAD | 5.10.1 | **1.472s** |

The regression shipped in every release since 5.6.7.

## Fix

Exclude the four sliding-capable reducers (`SUM`/`LSE`/`EXISTS`/`SIZE`) from the mode-3 shortcut so they fall through to the mode-1 reducer classification - exactly as before `1cbfa801`. Single `AVG`/`NEAREST` keep mode 3 (mode 2 never slid them, so no loss); single `MIN`/`MAX`/`STDDEV`/positional keep mode 3 (the genuine speedup). **Output is byte-identical** (qval `-1.10189` before/after; `vtrack-lse`, `sliding-sum-precision`, `vtrack-values`, `gsummary` suites all green).

## Verification

- Fixed build returns the chr19 scan to **0.632s** (matching the pre-regression baseline), output unchanged.
- New perf-regression test (`gquantiles` + full-chr1 + 40-bin window): **667ms fixed vs 5111ms regressed (~7.7x)** - lands the regressed path well outside the 3x budget. The pre-existing `small_chr1` LSE perf test could not catch this (overhead-bound scope + `gextract` materializing all rows to R dwarfed the inner loop).
- All 13 `MISHA_PERF_TESTS` baselines pass.

## Why this wasn't caught earlier

There was already an LSE-sliding perf test, but it used a ~20-bin `small_chr1` scope (overhead-bound) and `gextract` (R-materialization dominated). The new test uses a streaming `gquantiles` reduction over full chr1 with a wide window - matching the real workload.