### PR TITLE
fix: two perf-audit regressions (indexed empty-contig stale mmap + pwm below N-skip) - 5.10.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.10.2
+Version: 5.10.3
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# misha 5.10.3
+
+* **Behavior fix:** reading an indexed dense track on an empty (length-0) contig that follows a populated one in the same scan no longer returns the previous chromosome's values. The mmap read path (added in 5.6.7) left its window pointing at the prior chrom on a length-0 entry, so `max.pos.*`/`min.pos.*`, mixed-function, and `avg`+`nearest` virtual tracks could read stale values for the empty contig instead of `NA`. Single-function `avg`/`sum`/`lse` tracks were unaffected.
+* **Behavior fix:** `pwm.edit_distance` / `pwm.edit_distance.pos` / `pwm.max.edit_distance` with `direction = "below"` and `max_edits` set no longer skip N-containing windows. An N is not a mandatory edit when going below threshold, so an N-heavy window already scoring below threshold needs 0 edits; the N-count skip (added in 5.6.11) wrongly pruned such windows, returning `NA` or missing the true minimum. The skip is now restricted to `direction = "above"` substitutions-only, where it is exact.
+
 # misha 5.10.2
 
 * **Performance fix:** a single-function `lse` (or `sum`/`exists`/`size`) virtual track scanned over a sliding window (`gvtrack.iterator(sshift=, eshift=)`) genome-wide is fast again. Since 5.6.7 a single-function "fast path" recomputed the windowed reduction from scratch on every step, bypassing the incremental sliding-window path; the common motif-energy quantile workload (windowed `lse` + `gquantiles`/`gscreen`) was ~2.5x slower (worse with wider windows). Such single-function reducers now keep the sliding-window path. Output is unchanged.

--- a/src/GenomeTrackFixedBin.cpp
+++ b/src/GenomeTrackFixedBin.cpp
@@ -1141,6 +1141,17 @@ void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int 
 	m_lse_sliding_valid = false;
 	m_running_lse_initialized = false;
 
+	// Reset the mmap read window up front, BEFORE any early return. Otherwise a
+	// reused object (indexed tracks keep one GenomeTrackFixedBin alive across all
+	// chromosomes) that reads a non-empty chrom and then an empty/length-0 contig
+	// would keep m_mmap_data / m_mmap_num_bins pointing at the previous chrom, and
+	// read_next_bin/goto_bin (which bound on m_mmap_num_bins, not m_num_samples)
+	// would return the previous chromosome's values instead of NA. Re-established
+	// below for non-empty chromosomes.
+	m_mmap_data = nullptr;
+	m_mmap_num_bins = 0;
+	m_cur_bin = 0;
+
 	// Check for indexed format FIRST. get_track_index() hits the process-
 	// static index cache (avoiding a stat() per chromosome transition on the
 	// hot iterator path) and returns nullptr when the track has no index.
@@ -1231,10 +1242,7 @@ void GenomeTrackFixedBin::init_read(const char *filename, const char *mode, int 
 
 	// Set up mmap for read-only mode (naryn pattern)
 	// For indexed format: reuse existing mmap if same file (avoid re-mmap per chromosome)
-	m_mmap_data = nullptr;
-	m_mmap_num_bins = 0;
-	m_cur_bin = 0;
-
+	// (m_mmap_data / m_mmap_num_bins / m_cur_bin were reset at the top of init_read.)
 	if (setup_mmap && strcmp(mode, "rb") == 0 && m_num_samples > 0) {
 		const std::string file_path = m_dat_open ? m_dat_path : std::string(filename);
 

--- a/src/GenomeTrackFixedBin.h
+++ b/src/GenomeTrackFixedBin.h
@@ -142,6 +142,16 @@ protected:
 
 inline void GenomeTrackFixedBin::goto_bin(uint64_t bin)
 {
+	// Empty contig (e.g. a length-0 chrom in an indexed track.dat): there is no
+	// data to position to. Skip the seek: for an indexed track m_bfile is the
+	// shared track.dat and a seek would land in another chromosome's bytes; for a
+	// per-chrom file it would seek past EOF and error. read_next_bin returns NA.
+	if (m_num_samples == 0) {
+		m_cur_bin = bin;
+		m_cur_coord = bin * m_bin_size;
+		return;
+	}
+
 	if (m_mmap_data) {
 		m_cur_bin = bin;
 	} else {
@@ -154,6 +164,13 @@ inline void GenomeTrackFixedBin::goto_bin(uint64_t bin)
 
 inline bool GenomeTrackFixedBin::read_next_bin(float &val)
 {
+	// Empty contig: no data, so every read is "missing" (NA). This also stops the
+	// bfile fallback from reading a neighbouring chromosome's bytes out of a shared
+	// indexed track.dat (read_bins_bulk already clamps on m_num_samples). One extra
+	// already-hot comparison; negligible on the non-empty path.
+	if (m_num_samples == 0)
+		return false;
+
 	if (m_mmap_data) {
 		if (m_cur_bin >= m_mmap_num_bins)
 			return false;

--- a/src/PWMEditDistanceScorer.cpp
+++ b/src/PWMEditDistanceScorer.cpp
@@ -800,7 +800,19 @@ PWMEditDistanceScorer::ScanMetrics PWMEditDistanceScorer::evaluate_windows(const
     // Sliding-window N-count for fast skip of N-heavy regions.
     // N bases force mandatory edits; if a window has more than max_edits Ns,
     // it's unreachable. We maintain a running count, O(1) per window step.
-    bool use_n_skip = (m_max_edits >= 0 && max_start > 0);
+    //
+    // This is only sound for ABOVE direction with substitutions only:
+    //   - BELOW: an N is NOT a mandatory edit (m_mandatory_table[i][4] == false,
+    //     see precompute_tables). An N is scored at col_max (worst case for going
+    //     below), so an all-N window can already be <= threshold (0 edits). Skipping
+    //     it on N-count alone wrongly returns NA / misses the true minimum.
+    //   - indels (m_max_indels > 0): the alignment span is not fixed at
+    //     motif_length, so an N counted in the leading motif_length window may fall
+    //     outside the optimal alignment (e.g. shortened by deletions) and not force
+    //     an edit. Counting over a fixed window then over-rejects.
+    // For ABOVE + subs-only the true edit count is >= mandatory_edits >= n_count,
+    // so the skip is exact (matches the pigeonhole prefilter's own domain).
+    bool use_n_skip = (m_max_edits >= 0 && max_start > 0 && !is_below() && m_max_indels == 0);
     int n_count = 0;
     if (use_n_skip) {
         for (size_t j = 0; j < motif_length && j < target_length; j++) {

--- a/tests/testthat/test-indexed-empty-nonleading-chrom.R
+++ b/tests/testthat/test-indexed-empty-nonleading-chrom.R
@@ -1,0 +1,129 @@
+load_test_db()
+
+# Regression for the stale-mmap-window bug in GenomeTrackFixedBin (introduced by
+# the mmap read path in commit 1cbfa801, "C++ optimization audit").
+#
+# Indexed dense tracks keep ONE GenomeTrackFixedBin object alive across all
+# chromosomes (the persistent indexed backend in TrackExpressionVars). init_read
+# sets up m_mmap_data / m_mmap_num_bins for a non-empty chromosome, but on a
+# length-0 contig it returned early WITHOUT resetting those fields (the reset sat
+# below the early return). read_next_bin / goto_bin bound the read on the stale
+# m_mmap_num_bins (the previous chrom's bin count), not m_num_samples, so reading
+# an empty contig AFTER a populated one returned the previous chromosome's values
+# instead of NA.
+#
+# read_bins_bulk clamps on m_num_samples and was always safe, so single-function
+# avg/sum/lse vtracks (mode 1/3) did not expose it. The bug surfaced on the paths
+# that use read_next_bin/goto_bin: the general path (e.g. a max.pos vtrack) and
+# mode 2 (avg+nearest), on single-bin iterators.
+#
+# Note the empty contig must be read in the SAME process right after the
+# populated one, so the test runs single-process (gmultitasking = FALSE);
+# otherwise different chroms can land in fresh worker backends with no stale
+# state.
+
+make_indexed_track_with_empty_trailing_chrom <- function(root, binsize = 20L,
+                                                         chr1_size = 200L,
+                                                         chr2_size = 200L) {
+    dir.create(root)
+    dir.create(file.path(root, "tracks"))
+    dir.create(file.path(root, "seq"))
+    writeLines(
+        c(sprintf("chr1\t%d", chr1_size), sprintf("chr2\t%d", chr2_size)),
+        file.path(root, "chrom_sizes.txt")
+    )
+    file.create(file.path(root, "seq", "chr1.seq"))
+    file.create(file.path(root, "seq", "chr2.seq"))
+    gsetroot(root)
+
+    # Distinct per-bin values on chr1 so a stale read is unmistakable; chr2 will
+    # become the length-0 entry. Build per-chrom, then drop chr2's file so the
+    # pack writes a length-0 entry for it (mirror of the empty-leading-chrom
+    # fixture, but with the empty chrom trailing a populated one).
+    gtrack.create_dense(
+        track = "t", description = "x",
+        intervals = data.frame(
+            chrom = c("chr1", "chr2"),
+            start = c(0L, 0L),
+            end = c(chr1_size, chr2_size)
+        ),
+        values = c(7, 7),
+        binsize = binsize, defval = 0, func = "coverage"
+    )
+    trackdir <- file.path(root, "tracks", "t.track")
+    file.remove(file.path(trackdir, "chr2")) # leave only chr1's per-chrom file
+    expect_true(file.exists(file.path(trackdir, "chr1")))
+
+    misha:::.gcall(
+        "gtrack_pack_per_chrom_to_indexed",
+        trackdir, c("chr1", "chr2"), "dense", misha:::.misha_env()
+    )
+    expect_true(file.exists(file.path(trackdir, "track.dat")))
+    expect_true(file.exists(file.path(trackdir, "track.idx")))
+    invisible(trackdir)
+}
+
+test_that("indexed track: empty contig after a populated one reads as NA (general path)", {
+    old <- options(gmultitasking = FALSE)
+    on.exit(options(old), add = TRUE)
+
+    root <- tempfile("emptytrailing_")
+    binsize <- 20L
+    make_indexed_track_with_empty_trailing_chrom(root, binsize = binsize)
+
+    remove_all_vtracks()
+    # max.pos.abs routes through the generic read path (read_next_bin/goto_bin),
+    # the one the stale mmap window corrupts.
+    gvtrack.create("v_maxpos", "t", func = "max.pos.abs")
+
+    scope <- data.frame(
+        chrom = c("chr1", "chr2"),
+        start = c(0L, 0L),
+        end = c(200L, 200L)
+    )
+    res <- gextract("v_maxpos", intervals = scope, iterator = binsize)
+
+    chr1 <- res[res$chrom == "chr1", ]
+    chr2 <- res[res$chrom == "chr2", ]
+
+    # chr1 has data in every bin -> max.pos is non-NA everywhere.
+    expect_true(nrow(chr1) > 1)
+    expect_false(any(is.na(chr1$v_maxpos)))
+
+    # chr2 is an empty (length-0) contig: every bin must be NA, NOT chr1's
+    # values leaked through the stale mmap window. Pre-fix, chr2 bins >= 1
+    # returned non-NA positions.
+    expect_true(nrow(chr2) > 1)
+    expect_true(all(is.na(chr2$v_maxpos)))
+})
+
+test_that("indexed track: empty contig after a populated one reads as NA (avg + multi-function)", {
+    old <- options(gmultitasking = FALSE)
+    on.exit(options(old), add = TRUE)
+
+    root <- tempfile("emptytrailing2_")
+    binsize <- 20L
+    make_indexed_track_with_empty_trailing_chrom(root, binsize = binsize)
+
+    remove_all_vtracks()
+
+    scope <- data.frame(
+        chrom = c("chr1", "chr2"),
+        start = c(0L, 0L),
+        end = c(200L, 200L)
+    )
+
+    # Plain avg (single-function fast path, mode 3) was already safe via
+    # read_bins_bulk; assert it stays correct as a control.
+    avg_res <- gextract("t", intervals = scope, iterator = binsize)
+    expect_false(any(is.na(avg_res$t[avg_res$chrom == "chr1"])))
+    expect_true(all(is.na(avg_res$t[avg_res$chrom == "chr2"])))
+
+    # avg + nearest in one expression set forces the avg/nearest fast path
+    # (mode 2), which also uses read_next_bin/goto_bin.
+    gvtrack.create("v_avg", "t", func = "avg")
+    gvtrack.create("v_near", "t", func = "nearest")
+    mn <- gextract("v_avg", "v_near", intervals = scope, iterator = binsize)
+    expect_true(all(is.na(mn$v_avg[mn$chrom == "chr2"])))
+    expect_true(all(is.na(mn$v_near[mn$chrom == "chr2"])))
+})

--- a/tests/testthat/test-pwm-edit-distance-below-n-skip.R
+++ b/tests/testthat/test-pwm-edit-distance-below-n-skip.R
@@ -1,0 +1,113 @@
+# Regression for the N-count skip false-negative in PWMEditDistanceScorer
+# (introduced by commit cb1f287a, "perf: sliding-window N-count skip for edit
+# distance").
+#
+# evaluate_windows skips any window whose N-count exceeds max_edits, on the
+# rationale that "each N forces a mandatory edit". That holds only for
+# direction="above" with substitutions only. For direction="below" an N is NOT
+# a mandatory edit (precompute_tables sets m_mandatory_table[i][N]=false and
+# scores N at col_max), so an N-heavy window can already be at/below threshold
+# (0 edits). The unconditional skip wrongly returned NA / missed the true
+# minimum for below queries with max_edits set. (For indels the fixed-width
+# N window is also not a sound bound.) The fix gates the skip to
+# !is_below() && max_indels == 0.
+#
+# This needs sequence containing real N bases, so we build a tiny genome whose
+# .seq is all N (misha .seq files are raw bytes, position == coordinate).
+
+make_all_n_genome <- function(root, chrom_size = 120L) {
+    dir.create(root)
+    dir.create(file.path(root, "tracks"))
+    dir.create(file.path(root, "seq"))
+    writeLines(sprintf("chr1\t%d", chrom_size), file.path(root, "chrom_sizes.txt"))
+    # Raw-byte .seq: every base is N.
+    writeBin(
+        charToRaw(paste(rep("N", chrom_size), collapse = "")),
+        file.path(root, "seq", "chr1.seq")
+    )
+    gsetroot(root)
+    invisible(root)
+}
+
+test_that("pwm.edit_distance below: N-heavy window already below threshold returns 0, not NA (max_edits set)", {
+    root <- tempfile("nskip_below_")
+    make_all_n_genome(root, chrom_size = 120L)
+    tryCatch(remove_all_vtracks(), error = function(e) NULL)
+
+    # 4-position motif: more positions than max_edits=1, so an all-N window has
+    # n_count = 4 > max_edits = 1 and the buggy skip fires.
+    pssm <- matrix(c(
+        0.7, 0.1, 0.1, 0.1,
+        0.1, 0.7, 0.1, 0.1,
+        0.1, 0.1, 0.7, 0.1,
+        0.1, 0.1, 0.1, 0.7
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(1, 10, 50)
+
+    # Threshold extremely high: any window already scores below it -> 0 edits.
+    # True regardless of how N is scored (col_max <= 0 < 100).
+    threshold <- 100.0
+
+    gvtrack.create("edist_n_maxedits", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        score.min = -Inf, direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0,
+        max_edits = 1
+    )
+    res_maxedits <- gextract("edist_n_maxedits", test_intervals, iterator = test_intervals)
+
+    # The N window is already below the threshold -> 0 edits. Pre-fix the window
+    # was skipped (n_count=4 > max_edits=1) and the result was NA.
+    expect_false(is.na(res_maxedits$edist_n_maxedits[1]))
+    expect_equal(res_maxedits$edist_n_maxedits[1], 0, tolerance = 1e-6)
+
+    # Cross-check: with no max_edits the skip never fires (m_max_edits = -1), so
+    # this path was always correct. The max_edits path must now agree with it.
+    gvtrack.create("edist_n_nomax", NULL,
+        func = "pwm.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        score.min = -Inf, direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    res_nomax <- gextract("edist_n_nomax", test_intervals, iterator = test_intervals)
+    expect_equal(res_maxedits$edist_n_maxedits[1], res_nomax$edist_n_nomax[1], tolerance = 1e-6)
+})
+
+test_that("pwm.max.edit_distance below over an N region is not poisoned by the N-count skip", {
+    root <- tempfile("nskip_below2_")
+    make_all_n_genome(root, chrom_size = 120L)
+    tryCatch(remove_all_vtracks(), error = function(e) NULL)
+
+    pssm <- matrix(c(
+        0.7, 0.1, 0.1, 0.1,
+        0.1, 0.7, 0.1, 0.1,
+        0.1, 0.1, 0.7, 0.1,
+        0.1, 0.1, 0.1, 0.7
+    ), ncol = 4, byrow = TRUE)
+    colnames(pssm) <- c("A", "C", "G", "T")
+
+    test_intervals <- gintervals(1, 10, 60)
+    threshold <- 100.0
+
+    gvtrack.create("medist_max", NULL,
+        func = "pwm.max.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        score.min = -Inf, direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0,
+        max_edits = 1
+    )
+    gvtrack.create("medist_nomax", NULL,
+        func = "pwm.max.edit_distance",
+        pssm = pssm, score.thresh = threshold,
+        score.min = -Inf, direction = "below",
+        bidirect = FALSE, extend = FALSE, prior = 0
+    )
+    res <- gextract("medist_max", "medist_nomax", test_intervals, iterator = test_intervals)
+
+    # With max_edits set, the result must match the (always-correct) no-max path
+    # rather than collapsing to NA because every N window got skipped.
+    expect_equal(res$medist_max[1], res$medist_nomax[1], tolerance = 1e-6)
+})


### PR DESCRIPTION
Follow-up audit of the performance-optimization commits, hunting for the same class of fast-path-vs-slow-path divergence that produced the 5.10.2 regression. Two confirmed correctness regressions, each fixed with a regression test that fails on the pre-fix code and passes after.

## 1. Indexed dense tracks returned a previous chromosome's values for an empty contig
`GenomeTrackFixedBin::init_read` reset the mmap read window (`m_mmap_data`/`m_mmap_num_bins`/`m_cur_bin`) only *after* the length-0/empty-contig early return. Indexed tracks reuse one track object across all chromosomes, so after reading a populated chrom then an empty contig, the window still pointed at the previous chrom.

`read_bins_bulk` clamps on `m_num_samples` and was safe (single-function `avg`/`sum`/`lse`, modes 1/3). But `read_next_bin`/`goto_bin` bound on the stale `m_mmap_num_bins`, so `max.pos.*`/`min.pos.*`, mixed-function, and `avg`+`nearest` (mode 2) vtracks on single-bin iterators returned the prior chrom's values instead of `NA`.

**Fix:** reset the window before any early return + guard `read_next_bin`/`goto_bin` on `m_num_samples == 0` (also prevents the bfile fallback from reading a neighbouring chrom out of a shared `track.dat`, and a seek-past-EOF on a per-chrom empty file). Bulk read path untouched.

Regression from the mmap read path in `1cbfa801` (v5.6.7).

## 2. `pwm.edit_distance` `direction="below"` + `max_edits` dropped N-heavy windows
`PWMEditDistanceScorer::evaluate_windows` skipped any window with more than `max_edits` Ns, assuming each N forces a mandatory edit. That only holds for `above` + substitutions-only - the code's own `m_mandatory_table[i][N]` is `false` for `below` (N scored at `col_max`), so an N-heavy window already below threshold needs 0 edits but was skipped → `NA` / missed minimum. For indels the fixed-width N window is also not a sound bound.

**Fix:** gate the skip to `!is_below() && m_max_indels == 0` (the pigeonhole prefilter's own domain), where `true_edits >= mandatory_edits >= n_count` makes it exact. Perf win preserved for the common above+subs case. `pwm.n_mutations` and `gseq.pwm_edits` were never affected.

Regression from the N-count skip in `cb1f287a` (v5.6.11).

## Verification
Both new tests confirmed red on the pre-fix build, green after. Surrounding suites pass: PWM/edit-distance, gseq-pwm-edits, indexed-track, empty-chrom, vtrack/lse/sliding-sum, and core gextract/gsummary/gquantiles/gscreen/gdist (~1700 assertions, 0 failures).

## Not in scope
Reviewed clean: sliding-window reducers, func bitmask conversion, gextract direct-to-R, seq-var classification cache, dedup helpers, quantiles/StreamPercentiler, genome caches. The in-flight perf branches (multi-expression fast paths, BatchScreen/BatchTrackScan) are unmerged and were not reviewed here.