### PR TITLE
fix(C++): gextract no longer truncates column names to 40 chars (5.11.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.10.3
+Version: 5.11.0
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.0
+
+* **Breaking:** `gextract()` no longer truncates auto-generated column names to 40 characters - columns are named after the full expression (the complete track name) instead of `<first 37 chars>...`. Long names that previously collapsed to the same truncated name, hiding a column, are now distinct. Pass `colnames=` to set names explicitly.
+
 # misha 5.10.3
 
 * **Behavior fix:** reading an indexed dense track on an empty (length-0) contig that follows a populated one in the same scan no longer returns the previous chromosome's values. The mmap read path (added in 5.6.7) left its window pointing at the prior chrom on a length-0 entry, so `max.pos.*`/`min.pos.*`, mixed-function, and `avg`+`nearest` virtual tracks could read stale values for the empty contig instead of `NA`. Single-function `avg`/`sum`/`lse` tracks were unaffected.

--- a/src/GenomeTrackExtract.cpp
+++ b/src/GenomeTrackExtract.cpp
@@ -152,7 +152,7 @@ static SEXP build_rintervals_extract(GIntervalsFetcher1D *out_intervals1d, GInte
     SEXP col_names = rprotect_ptr(Rf_getAttrib(answer, R_NamesSymbol));
 	for (unsigned iexpr = 0; iexpr < num_exprs; ++iexpr) {
 		if (Rf_isNull(_colnames))
-			SET_STRING_ELT(col_names, num_interv_cols + iexpr, Rf_mkChar(get_bounded_colname(CHAR(STRING_ELT(_exprs, iexpr))).c_str()));
+			SET_STRING_ELT(col_names, num_interv_cols + iexpr, STRING_ELT(_exprs, iexpr));
 		else
 			SET_STRING_ELT(col_names, num_interv_cols + iexpr, STRING_ELT(_colnames, iexpr));
 	}
@@ -210,7 +210,7 @@ static void set_extract_value_column_names(SEXP answer, unsigned num_interv_cols
 	SEXP col_names = rprotect_ptr(Rf_getAttrib(answer, R_NamesSymbol));
 	for (unsigned iexpr = 0; iexpr < num_exprs; ++iexpr) {
 		if (Rf_isNull(_colnames))
-			SET_STRING_ELT(col_names, num_interv_cols + iexpr, Rf_mkChar(get_bounded_colname(CHAR(STRING_ELT(_exprs, iexpr))).c_str()));
+			SET_STRING_ELT(col_names, num_interv_cols + iexpr, STRING_ELT(_exprs, iexpr));
 		else
 			SET_STRING_ELT(col_names, num_interv_cols + iexpr, STRING_ELT(_colnames, iexpr));
 	}
@@ -577,7 +577,7 @@ SEXP C_gextract(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iterator_pol
 				if (iexpr)
 					outfile << "\t";
 				if (Rf_isNull(_colnames))
-					outfile << get_bounded_colname(CHAR(STRING_ELT(_exprs, iexpr)));
+					outfile << CHAR(STRING_ELT(_exprs, iexpr));
 				else
 					outfile << CHAR(STRING_ELT(_colnames, iexpr));
 			}
@@ -845,7 +845,7 @@ SEXP C_gextract(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iterator_pol
 			}
 			for (unsigned iexpr = 0; iexpr < num_exprs; ++iexpr) {
 				const char *cn = Rf_isNull(_colnames) ?
-					get_bounded_colname(CHAR(STRING_ELT(_exprs, iexpr))).c_str() :
+					CHAR(STRING_ELT(_exprs, iexpr)) :
 					CHAR(STRING_ELT(_colnames, iexpr));
 				SET_STRING_ELT(fb_colnames, fb_interv_cols + iexpr, Rf_mkChar(cn));
 			}
@@ -1087,7 +1087,7 @@ SEXP C_gextract(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iterator_pol
 		}
 		for (unsigned iexpr = 0; iexpr < num_exprs; ++iexpr) {
 			if (Rf_isNull(_colnames))
-				SET_STRING_ELT(col_names, num_interv_cols + iexpr, Rf_mkChar(get_bounded_colname(CHAR(STRING_ELT(_exprs, iexpr))).c_str()));
+				SET_STRING_ELT(col_names, num_interv_cols + iexpr, STRING_ELT(_exprs, iexpr));
 			else
 				SET_STRING_ELT(col_names, num_interv_cols + iexpr, STRING_ELT(_colnames, iexpr));
 		}
@@ -1182,7 +1182,7 @@ SEXP gextract_multitask(SEXP _intervals, SEXP _exprs, SEXP _colnames, SEXP _iter
 				if (iexpr)
 					outfile << "\t";
 				if (Rf_isNull(_colnames))
-					outfile << get_bounded_colname(CHAR(STRING_ELT(_exprs, iexpr)));
+					outfile << CHAR(STRING_ELT(_exprs, iexpr));
 				else
 					outfile << CHAR(STRING_ELT(_colnames, iexpr));
 			}

--- a/src/rdbutils.cpp
+++ b/src/rdbutils.cpp
@@ -959,19 +959,6 @@ string rdb::create_track_dir(SEXP envir, const string &trackname)
 	return path;
 }
 
-string rdb::get_bounded_colname(const char *str, unsigned maxlen)
-{
-	string colname;
-
-	maxlen = max(maxlen, 4u);
-	if (strlen(str) > maxlen) {
-		colname.assign(str, maxlen - 3);
-		colname += "...";
-	} else
-		colname = str;
-	return colname;
-}
-
 SEXP rdb::eval_in_R(SEXP parsed_command, SEXP envir)
 {
 	int check_error;

--- a/src/rdbutils.h
+++ b/src/rdbutils.h
@@ -184,8 +184,6 @@ string interv2path(SEXP envir, const string &intervname);
 // Creates trackset and trackname directories using trackset.trackname. Verifies that the track name is valid.
 string create_track_dir(SEXP envir, const string &trackname);
 
-string get_bounded_colname(const char *str, unsigned maxlen = 40);
-
 // the result is already protected
 SEXP eval_in_R(SEXP parsed_command, SEXP envir);
 


### PR DESCRIPTION
## Summary

`gextract()` auto-generated column names (when `colnames` is not supplied) were
capped at 40 characters by `get_bounded_colname`, replacing the tail with `...`.
Two expressions sharing their first 37 characters therefore collapsed to the
same column name, so the returned data.frame carried two identically-named
columns and one was effectively hidden (`df$name` / `df[["name"]]` returns only
the first).

## Change

Remove `get_bounded_colname` entirely and name each auto-generated column after
the full expression string at all six call sites in `GenomeTrackExtract.cpp`
(in-memory and file-output paths, 1D and 2D). Also fixes a latent dangling
pointer in `C_gextract` (the ternary took `.c_str()` of a temporary
`std::string`).

R imposes no column-name length limit (verified: a 301-char name round-trips
through `gextract` unchanged), so removing the cap is safe.

## Compatibility

**Breaking:** long expressions now produce full-length column names instead of
`<first 37 chars>...`. MINOR bump (5.11.0) per the versioning policy
(default column-naming change). NEWS updated.