### PR TITLE
fix(C++): quantile percentile column names round-trip (5.11.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.0
+Version: 5.11.1
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.1
+
+* **Behavior fix:** `gquantiles()` / `gintervals.quantiles()` name percentile columns with the shortest decimal that round-trips each percentile, so nearby percentiles no longer collapse to the same name - e.g. `0.123456789` and `0.1234567891` previously both became `"0.123457"`, and `0.9999999` became `"1"` (colliding with the `1.0` quantile). Common percentiles (`0.5`, `0.95`, ...) are unchanged.
+
 # misha 5.11.0
 
 * **Breaking:** `gextract()` no longer truncates auto-generated column names to 40 characters - columns are named after the full expression (the complete track name) instead of `<first 37 chars>...`. Long names that previously collapsed to the same truncated name, hiding a column, are now distinct. Pass `colnames=` to set names explicitly.

--- a/src/GenomeTrackQuantiles.cpp
+++ b/src/GenomeTrackQuantiles.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstdint>
+#include <cstdlib>
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -39,6 +40,19 @@ struct Percentile {
 	bool operator<(const Percentile &p) const { return percentile < p.percentile; }
 };
 
+// Write into buf the shortest decimal string that round-trips v, so nearby
+// percentiles don't collapse to the same column name the way a fixed "%g"
+// (6 significant digits) would (e.g. 0.123456789 and 0.1234567891 both ->
+// "0.123457", and 0.9999999 -> "1" colliding with the 1.0 quantile).
+static void format_percentile(char *buf, size_t bufsize, double v)
+{
+	for (int prec = 1; prec <= 17; ++prec) {
+		snprintf(buf, bufsize, "%.*g", prec, v);
+		if (strtod(buf, NULL) == v)
+			return;
+	}
+}
+
 static SEXP build_rintervals_quantiles(GIntervalsFetcher1D *out_intervals1d, GIntervalsFetcher2D *out_intervals2d,
 									   const vector<Percentile> &percentiles, const vector<double> &quantiles,
 									   IntervUtils &iu, bool use_original_index)
@@ -70,7 +84,7 @@ static SEXP build_rintervals_quantiles(GIntervalsFetcher1D *out_intervals1d, GIn
 	for (vector<Percentile>::const_iterator ip = percentiles.begin(); ip != percentiles.end(); ++ip) {
 		char buf[100];
 
-		snprintf(buf, sizeof(buf), "%g", ip->percentile);
+		format_percentile(buf, sizeof(buf), ip->percentile);
 		SET_STRING_ELT(colnames, num_interv_cols + ip->index, Rf_mkChar(buf));
 	}
 
@@ -240,7 +254,7 @@ SEXP C_gquantiles(SEXP _intervals, SEXP _expr, SEXP _percentiles, SEXP _iterator
 
 			REAL(answer)[ip->index] = medians[ip->index];
 
-			snprintf(buf, sizeof(buf), "%g", ip->percentile);
+			format_percentile(buf, sizeof(buf), ip->percentile);
 			SET_STRING_ELT(colnames, ip->index, Rf_mkChar(buf));
 		}
 
@@ -562,7 +576,7 @@ SEXP gquantiles_multitask(SEXP _intervals, SEXP _expr, SEXP _percentiles, SEXP _
 
 			REAL(answer)[ip->index] = medians[ip->index];
 
-			snprintf(buf, sizeof(buf), "%g", ip->percentile);
+			format_percentile(buf, sizeof(buf), ip->percentile);
 			SET_STRING_ELT(colnames, ip->index, Rf_mkChar(buf));
 		}
 
@@ -1285,7 +1299,7 @@ SEXP gbins_quantiles(SEXP _track_exprs, SEXP _breaks, SEXP _include_lowest, SEXP
 		for (vector<Percentile>::const_iterator ip = percentiles.begin(); ip != percentiles.end(); ++ip) {
 			char buf[100];
 
-			snprintf(buf, sizeof(buf), "%g", ip->percentile);
+			format_percentile(buf, sizeof(buf), ip->percentile);
 			SET_STRING_ELT(dimname, ip->index, Rf_mkChar(buf));
 		}
 		SET_VECTOR_ELT(dimnames, bins_manager.get_num_bin_finders(), dimname);


### PR DESCRIPTION
## Problem

`gquantiles()` / `gintervals.quantiles()` named percentile columns with `%g` (6 significant digits) in C++. Nearby percentiles collapsed to the same column name, and large ones were mislabeled:

- `0.123456789` and `0.1234567891` both became `"0.123457"`
- `0.9999999` became `"1"`, colliding with the actual `1.0` quantile

In a `data.frame` the columns survive but with duplicate/ambiguous names. (The sibling bug in pymisha, where a dict silently *dropped* a column, prompted this; see pymisha v0.8.16.)

## Fix

Name percentile columns with the shortest decimal that round-trips each value (`%.Ng` with the smallest `N` that `strtod`-parses back). Common percentiles (`0.5`, `0.95`, ...) are unchanged. Applied at all four naming sites in `GenomeTrackQuantiles.cpp`: the per-interval data.frame, the `gquantiles` vector (single + multitask), and the binned 2D path.

## Testing

Compiles clean. `test-gquantiles` (5), `test-gintervals.quantiles` (7), `test-gsummary` (12), `test-gintervals.summary` (28) all pass. Verified live that all distinct percentiles now get distinct names in both `gintervals.quantiles` and `gquantiles`.