### PR TITLE
fix(R): gintervals.load_chain restores full session after src_groot (5.11.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.1
+Version: 5.11.2
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.2
+
+* **Behavior fix:** `gintervals.load_chain(..., src_groot=)` no longer leaves the session pointing at the source database after validation. It now fully restores the active database - the working directory (`GWD`), loaded datasets and virtual tracks included, not just the genome root.
+
 # misha 5.11.1
 
 * **Behavior fix:** `gquantiles()` / `gintervals.quantiles()` name percentile columns with the shortest decimal that round-trips each percentile, so nearby percentiles no longer collapse to the same name - e.g. `0.123456789` and `0.1234567891` previously both became `"0.123457"`, and `0.9999999` became `"1"` (colliding with the `1.0` quantile). Common percentiles (`0.5`, `0.95`, ...) are unchanged.

--- a/R/intervals-liftover.R
+++ b/R/intervals-liftover.R
@@ -265,50 +265,6 @@ gintervals.load <- function(intervals.set = NULL, chrom = NULL, chrom1 = NULL, c
     .gintervals.load_ext(intervals.set, chrom, chrom1, chrom2, TRUE)
 }
 
-#' Validate source chromosomes against source genome
-#'
-#' @param chain Chain data frame with source chromosome information
-#' @param src_groot Path to source genome database
-#' @return NULL (stops with error if validation fails)
-#' @keywords internal
-#' @noRd
-.validate_source_chromosomes <- function(chain, src_groot) {
-    # Save current genome state
-    old_groot <- .misha$GROOT
-    old_allgenome <- .misha$ALLGENOME
-    old_chrom_alias <- if (exists("CHROM_ALIAS", envir = .misha)) .misha$CHROM_ALIAS else NULL
-
-    # Ensure genome is restored even if error occurs
-    on.exit(
-        {
-            .misha$GROOT <- old_groot
-            .misha$ALLGENOME <- old_allgenome
-            if (!is.null(old_chrom_alias)) {
-                .misha$CHROM_ALIAS <- old_chrom_alias
-            } else if (exists("CHROM_ALIAS", envir = .misha)) {
-                rm("CHROM_ALIAS", envir = .misha)
-            }
-        },
-        add = TRUE
-    )
-
-    # Temporarily switch to source genome for validation
-    gdb.init(src_groot)
-
-    # Create source intervals data frame
-    src_intervals <- data.frame(
-        chrom = chain$chromsrc,
-        start = chain$startsrc,
-        end = chain$endsrc,
-        stringsAsFactors = FALSE
-    )
-
-    validated <- .gintervals(chain$chromsrc, chain$startsrc, chain$endsrc, chain$strandsrc)
-
-    # Genome will be restored by on.exit
-}
-
-
 #' Loads assembly conversion table from a chain file
 #'
 #' Loads assembly conversion table from a chain file.
@@ -537,37 +493,22 @@ gintervals.as_chain <- function(intervals = NULL, src_overlap_policy = "error", 
 }
 
 .validate_source_chromosomes <- function(chain, src_groot) {
-    # Save current genome state
-    old_groot <- .misha$GROOT
-    old_allgenome <- .misha$ALLGENOME
-    old_chrom_alias <- if (exists("CHROM_ALIAS", envir = .misha)) .misha$CHROM_ALIAS else NULL
-
-    # Ensure genome is restored even if error occurs
+    # gdb.init() rewrites the whole misha session (GROOT, GWD, ALLGENOME,
+    # CHROM_ALIAS, GTRACKS, datasets, autocompletion symbols, ...). Snapshot
+    # every binding and restore it on exit so the user's session is left
+    # exactly as found - restoring a hand-picked subset previously left GWD
+    # (and other vars) dangling at the source database.
+    old_vars <- as.list(.misha, all.names = TRUE)
     on.exit(
         {
-            .misha$GROOT <- old_groot
-            .misha$ALLGENOME <- old_allgenome
-            if (!is.null(old_chrom_alias)) {
-                .misha$CHROM_ALIAS <- old_chrom_alias
-            } else if (exists("CHROM_ALIAS", envir = .misha)) {
-                rm("CHROM_ALIAS", envir = .misha)
-            }
+            rm(list = ls(.misha, all.names = TRUE), envir = .misha)
+            list2env(old_vars, envir = .misha)
         },
         add = TRUE
     )
 
-    # Temporarily switch to source genome for validation
+    # Temporarily switch to source genome; .gintervals() errors if any source
+    # chromosome is missing or any coordinate is out of bounds.
     gdb.init(src_groot)
-
-    # Create source intervals data frame
-    src_intervals <- data.frame(
-        chrom = chain$chromsrc,
-        start = chain$startsrc,
-        end = chain$endsrc,
-        stringsAsFactors = FALSE
-    )
-
-    validated <- .gintervals(chain$chromsrc, chain$startsrc, chain$endsrc, chain$strandsrc)
-
-    # Genome will be restored by on.exit
+    .gintervals(chain$chromsrc, chain$startsrc, chain$endsrc, chain$strandsrc)
 }

--- a/tests/testthat/test-liftover.R
+++ b/tests/testthat/test-liftover.R
@@ -672,6 +672,29 @@ test_that("gintervals.load_chain with src_groot validates source chromosomes", {
     expect_equal(.misha$GROOT, target_db)
 })
 
+test_that("gintervals.load_chain with src_groot fully restores the session (GWD etc.)", {
+    local_db_state()
+
+    setup_db(list(">chr1\nACTGACTGACTGACTGACTGACTGACTGACTG\n"))
+    target_db <- .misha$GROOT
+
+    source_db <- setup_source_db(list(">source1\nTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT\n"))
+
+    chain_file <- new_chain_file()
+    write_chain_entry(chain_file, "source1", 100, "+", 0, 20, "chr1", 32, "+", 0, 20, 1)
+
+    gdb.init(target_db)
+    before <- as.list(.misha, all.names = TRUE)
+
+    gintervals.load_chain(chain_file, src_groot = source_db)
+
+    # The whole session must be untouched - GWD in particular must not be left
+    # pointing at the source database (the original bug).
+    expect_equal(.misha$GWD, before$GWD)
+    expect_equal(.misha$GROOT, target_db)
+    expect_setequal(ls(.misha, all.names = TRUE), names(before))
+})
+
 test_that("gintervals.load_chain with src_groot rejects invalid source chromosomes", {
     local_db_state()
 


### PR DESCRIPTION
## Problem

Reported by Roy Elzur: `gintervals.load_chain(..., src_groot=)` temporarily switches to the source database to validate source coordinates, then restores the original. It restores `GROOT` but leaves `.misha$GWD` (the genome-db working directory) pointing at the source DB, which breaks downstream calls.

## Root cause

The validation helper calls `gdb.init(src_groot)`, which rewrites the **entire** misha session (`GROOT`, `GWD`, `ALLGENOME`, `CHROM_ALIAS`, `GTRACKS`, loaded datasets, virtual tracks, autocompletion symbols). The `on.exit` handler only put back `GROOT`, `ALLGENOME` and `CHROM_ALIAS`, so `GWD` and the rest were left dangling at the source database.

The existing `src_groot` tests only asserted `GROOT` was restored, which is why this went unnoticed.

## Fix

- Snapshot the whole `.misha` environment with `as.list()` and restore it wholesale on exit, instead of hand-listing a subset of vars - it can no longer miss a variable.
- Deleted a dead, byte-identical duplicate definition of `.validate_source_chromosomes` (the second shadowed the first).
- Added a regression test asserting `GWD` and the full set of session bindings are restored.

Patch release: 5.11.2.

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt