### PR TITLE
fix(C++): gtrack.liftover agg no longer drops boundary-spanning contributions (5.11.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.2
+Version: 5.11.3
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.3
+
+* **Behavior fix:** `gtrack.liftover(tgt_overlap_policy = "agg")` no longer drops a lifted contribution that spans a target bin boundary when an overlapping chain shares its interval. The per-bin sweep over-advanced its cursor, losing the spanning contribution for the next bin and producing spurious `NaN`s (or wrong aggregates) in bins fed by multiple overlapping chains.
+
 # misha 5.11.2
 
 * **Behavior fix:** `gintervals.load_chain(..., src_groot=)` no longer leaves the session pointing at the source database after validation. It now fully restores the active database - the working directory (`GWD`), loaded datasets and virtual tracks included, not just the genome root.

--- a/src/GTrackLiftover.cpp
+++ b/src/GTrackLiftover.cpp
@@ -718,14 +718,25 @@ SEXP gtrack_liftover(SEXP _track,
 
 					for (int64_t bin = 0; bin < end_bin; ++bin) {
 						agg_state.reset();
-						bool intersect = false;
 
-						vector<GIntervalVal>::const_iterator iter = iinterv_val;
-						for (; iter != interv_vals.end(); ++iter) {
+						// Advance the persistent cursor past contributions that end at or before this
+						// bin's start. interv_vals is sorted by start, so a contribution with end <=
+						// coord1 cannot overlap this bin or any later one (coord1 only increases).
+						// Contributions with end > coord1 may still overlap a later bin, so we must NOT
+						// advance past them here: doing so dropped a contribution that spanned a bin
+						// boundary whenever an overlapping sibling (e.g. a parallel chain kept by the
+						// "agg" target-overlap policy) shared its interval.
+						while (iinterv_val != interv_vals.end() && iinterv_val->interval.end <= coord1)
+							++iinterv_val;
+
+						// Collect every contribution overlapping [coord1, coord2). Sorted by start, so
+						// stop as soon as a contribution starts at or after coord2.
+						for (vector<GIntervalVal>::const_iterator iter = iinterv_val; iter != interv_vals.end(); ++iter) {
+							if (iter->interval.start >= coord2)
+								break;
 							int64_t overlap_start = max(coord1, iter->interval.start);
 							int64_t overlap_end = min(coord2, iter->interval.end);
 							if (overlap_start < overlap_end) {
-								intersect = true;
 								double overlap_len = static_cast<double>(overlap_end - overlap_start);
 								int64_t bin_end_clamped = std::min<int64_t>(coord2, chrom_size);
 								double locus_len = static_cast<double>(std::max<int64_t>(0, bin_end_clamped - coord1));
@@ -740,15 +751,9 @@ SEXP gtrack_liftover(SEXP _track,
 									overlap_end,
 									iter->chain_id
 								);
-							} else if (iter->interval.end > coord1) {
-								if (intersect && iter->interval.start > coord2)
-									--iter;
-								break;
 							}
 							check_interrupt();
 						}
-
-						iinterv_val = iter;
 
 						double aggregated = aggregate_values(agg_cfg, agg_state);
 						float out_val = numeric_limits<float>::quiet_NaN();

--- a/tests/testthat/test-gtrack.liftover-agg.R
+++ b/tests/testthat/test-gtrack.liftover-agg.R
@@ -736,3 +736,88 @@ test_that("gtrack.liftover aggregation with partial overlaps and varying coverag
     # All values should be from our source track
     expect_true(all(result[[lifted_track]] %in% c(100, 200, 300)))
 })
+
+# Regression: under tgt_overlap_policy = "agg", a source contribution whose mapped
+# target interval spans a bin boundary must not be dropped when an overlapping
+# sibling (a parallel chain kept by "agg") shares that interval. The FIXED_BIN
+# sweep used to over-advance its cursor past the first of two overlapping
+# contributions, so the spanning contribution was lost for the *next* bin. With a
+# finite + NaN pair this surfaced as a spurious NaN; with two finite values it
+# silently dropped one. (Found via a mouse->human lift where a main-chrom chain and
+# an unplaced-scaffold chain mapped to the same target interval.)
+test_that("gtrack.liftover agg: boundary-spanning contribution survives an overlapping NaN sibling", {
+    local_db_state()
+
+    src_seq <- paste(rep("A", 60), collapse = "")
+    source_db <- setup_source_db(list(
+        paste0(">source1\n", src_seq, "\n"),
+        paste0(">source2\n", src_seq, "\n")
+    ))
+    # Dense binsize-20 source: source1 finite (5), source2 NaN.
+    gtrack.create_dense(
+        "agg_span_src", "boundary-span source",
+        data.frame(
+            chrom = c("chrsource1", "chrsource2"),
+            start = c(0L, 0L), end = c(60L, 60L), stringsAsFactors = FALSE
+        ),
+        c(5, NaN), 20, NaN
+    )
+    src_dir <- file.path(source_db, "tracks", "agg_span_src.track")
+
+    setup_db(list(paste0(">chrA\n", paste(rep("T", 60), collapse = ""), "\n")))
+
+    # Both source chroms map their first 20bp bin onto the SAME target interval
+    # [10,30), which straddles target bins [0,20) and [20,40). Distinct chain ids;
+    # chrsource1 (finite) sorts before chrsource2 (NaN).
+    chain <- new_chain_file()
+    write_chain_entry(chain, "chrsource1", 60, "+", 0, 20, "chrA", 60, "+", 10, 30, 1)
+    write_chain_entry(chain, "chrsource2", 60, "+", 0, 20, "chrA", 60, "+", 10, 30, 2)
+
+    lifted <- "agg_span_lifted"
+    withr::defer(if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE))
+    gtrack.liftover(lifted, "x", src_dir, chain,
+        tgt_overlap_policy = "agg", multi_target_agg = "max"
+    )
+    res <- gextract(lifted, gintervals("chrA", 0, 40), iterator = 20)
+    # Both bins overlapping [10,30) keep the finite value; pre-fix bin [20,40)
+    # collected only the NaN sibling and returned NaN.
+    expect_equal(res[res$start == 0, lifted], 5)
+    expect_equal(res[res$start == 20, lifted], 5)
+})
+
+test_that("gtrack.liftover agg: overlapping sibling does not drop a boundary-spanning finite value", {
+    local_db_state()
+
+    src_seq <- paste(rep("A", 60), collapse = "")
+    source_db <- setup_source_db(list(
+        paste0(">source1\n", src_seq, "\n"),
+        paste0(">source2\n", src_seq, "\n")
+    ))
+    # Two finite sources (5 and 9) mapping to the same boundary-spanning interval.
+    gtrack.create_dense(
+        "agg_span_src2", "boundary-span source 2",
+        data.frame(
+            chrom = c("chrsource1", "chrsource2"),
+            start = c(0L, 0L), end = c(60L, 60L), stringsAsFactors = FALSE
+        ),
+        c(5, 9), 20, NaN
+    )
+    src_dir <- file.path(source_db, "tracks", "agg_span_src2.track")
+
+    setup_db(list(paste0(">chrA\n", paste(rep("T", 60), collapse = ""), "\n")))
+
+    chain <- new_chain_file()
+    write_chain_entry(chain, "chrsource1", 60, "+", 0, 20, "chrA", 60, "+", 10, 30, 1)
+    write_chain_entry(chain, "chrsource2", 60, "+", 0, 20, "chrA", 60, "+", 10, 30, 2)
+
+    lifted <- "agg_span_lifted2"
+    withr::defer(if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE))
+    gtrack.liftover(lifted, "x", src_dir, chain,
+        tgt_overlap_policy = "agg", multi_target_agg = "max"
+    )
+    res <- gextract(lifted, gintervals("chrA", 0, 40), iterator = 20)
+    # max over both overlapping chains = 9 in BOTH bins; pre-fix the second bin
+    # dropped one contributor.
+    expect_equal(res[res$start == 0, lifted], 9)
+    expect_equal(res[res$start == 20, lifted], 9)
+})


### PR DESCRIPTION
## Problem

`gtrack.liftover(tgt_overlap_policy = "agg")` could return spurious `NaN` (or a wrong aggregate) for target bins fed by multiple overlapping chains.

The FIXED_BIN per-bin sweep advanced its cursor with `iinterv_val = iter`, which permanently skipped a contribution whose lifted target interval spanned a bin boundary whenever an overlapping sibling shared that interval (the single `--iter` back-up only rescued one trailing entry). `"agg"` keeps parallel overlapping chains, so e.g. a main-chromosome chain (finite) and an unplaced-scaffold chain (NaN) mapping to the same boundary-spanning target interval would collide: the finite contribution was consumed by one bin and lost for the next, leaving only the NaN. `"auto"`/`auto_score` was unaffected (one chain per region, no overlap).

## Root cause

Found on a mouse→human lift (`keep`/`agg`/`max`) where a "short" source track (omits 218 unplaced contigs) and the same track with those contigs materialized as `NaN` produced NaN footprints differing by 12,797 bins. Instrumentation showed the finite contributor was *available* but not *collected* for the affected bin. Not NaN-specific - it can silently drop a finite value too.

## Fix

The cursor now only advances past contributions that end at/before the bin start (sorted by start, those cannot overlap this or any later bin); each bin re-scans the contributions that still overlap it. The SPARSE path uses a separate monotonic cluster-merge and is unaffected.

## Verification

- Minimal repro RED → GREEN
- Two new regression tests in `test-gtrack.liftover-agg.R` are RED on the unfixed code (`passed=2 failed=2`) and GREEN after
- All existing liftover tests pass
- Real mouse→human re-lift now reports `diff_bins = 0` (was 12,797)

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt