### PR TITLE
fix(C++): three liftover correctness bugs found auditing 5.11.3/5.11.4 (5.11.5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.4
+Version: 5.11.5
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# misha 5.11.5
+
+* **Behavior fix:** `gtrack.liftover()` / `gintervals.liftover()` with a minus-strand chain that the target-overlap sweep truncates or splits (e.g. under `tgt_overlap_policy = "auto"`) now keep the correct reversed source coordinates for the surviving slice instead of the coordinates of the discarded half.
+* **Behavior fix:** `gtrack.liftover()` / `gintervals.liftover()` no longer drop a chain's finite contribution to a target locus when the same chain also maps a `NaN` source bin there with `na.rm = TRUE`; NaN pieces are now removed before the per-chain merge.
+* **Behavior fix:** 2D `gtrack.liftover()` no longer drops rectangles when the chain has multiple blocks (the quadtree's spatial iteration order defeated a carried mapping cursor).
+
 # misha 5.11.4
 
 * **Behavior fix:** `gintervals.liftover()` / `gtrack.liftover()` no longer drop a mapping through a wider earlier source chain when source chains overlap (`src_overlap_policy = "keep"`). The `map_interval` fast path trusted a carried cursor as the leftmost overlap after checking only its immediate predecessor; it now confirms leftmost-ness via the per-chromosome prefix-max, falling back to the full search otherwise.

--- a/src/AggregationHelpers.h
+++ b/src/AggregationHelpers.h
@@ -124,10 +124,25 @@ inline void aggregation_state_add(AggregationState &state,
 }
 
 inline double aggregate_values(const AggregationConfig &cfg, const AggregationState &state) {
+	// Under na.rm = FALSE, any NaN contribution makes the whole locus NaN.
+	if (!cfg.na_rm) {
+		for (const auto &contrib : state.contributions) {
+			if (contrib.is_na)
+				return numeric_limits<double>::quiet_NaN();
+		}
+	}
+
+	// Merge contributions by chain_id so a single chain (possibly split into several
+	// pieces over this locus - parallel slices under "agg", or several source bins
+	// mapping in) counts once. NaN pieces are dropped FIRST (na.rm) so that a chain
+	// mapping both finite and NaN source bins into this locus keeps its finite value
+	// instead of being discarded wholesale by an is_na carried over the whole chain.
 	vector<Contribution> merged;
 	merged.reserve(state.contributions.size());
 
 	for (const auto &contrib : state.contributions) {
+		if (contrib.is_na)
+			continue; // na.rm == true here (the na.rm == false case already returned)
 		bool found = false;
 		for (auto &existing : merged) {
 			if (existing.chain_id == contrib.chain_id) {
@@ -135,7 +150,6 @@ inline double aggregate_values(const AggregationConfig &cfg, const AggregationSt
 				existing.coverage_frac += contrib.coverage_frac;
 				existing.start = std::min(existing.start, contrib.start);
 				existing.end = std::max(existing.end, contrib.end);
-				existing.is_na = existing.is_na || contrib.is_na;
 				found = true;
 				break;
 			}
@@ -144,19 +158,10 @@ inline double aggregate_values(const AggregationConfig &cfg, const AggregationSt
 			merged.push_back(contrib);
 	}
 
-	const vector<Contribution> &contribs = merged.empty() ? state.contributions : merged;
-
 	vector<const Contribution *> valid;
-	valid.reserve(contribs.size());
-
-	for (const auto &contrib : contribs) {
-		if (contrib.is_na) {
-			if (!cfg.na_rm)
-				return numeric_limits<double>::quiet_NaN();
-			continue;
-		}
+	valid.reserve(merged.size());
+	for (const auto &contrib : merged)
 		valid.push_back(&contrib);
-	}
 
 	if (cfg.min_n >= 0 && (int)valid.size() < cfg.min_n)
 		return numeric_limits<double>::quiet_NaN();

--- a/src/GTrackLiftover.cpp
+++ b/src/GTrackLiftover.cpp
@@ -885,7 +885,10 @@ SEXP gtrack_liftover(SEXP _track,
 						continue;
 					}
 
-					ChainIntervals::const_iterator hints[2] = { chain_intervs.begin(), chain_intervs.begin() };
+					// The quadtree iterates rects/points in spatial (not coordinate) order,
+					// so a carried map_interval hint is not a monotonically advancing lower
+					// bound and would drop mappings. Map each axis from begin() every time
+					// (the same per-interval reset the 1D sparse path uses).
 					GInterval src_intervals[2];
 
 					src_intervals[0].chromid = chromid1;
@@ -902,8 +905,8 @@ SEXP gtrack_liftover(SEXP _track,
 							src_intervals[1].start = iqtree->y1;
 							src_intervals[1].end = iqtree->y2;
 
-							hints[0] = chain_intervs.map_interval(src_intervals[0], tgt_intervals[0], hints[0]);
-							hints[1] = chain_intervs.map_interval(src_intervals[1], tgt_intervals[1], hints[1]);
+							chain_intervs.map_interval(src_intervals[0], tgt_intervals[0], chain_intervs.begin());
+							chain_intervs.map_interval(src_intervals[1], tgt_intervals[1], chain_intervs.begin());
 
 							for (GIntervals::const_iterator iinterv1 = tgt_intervals[0].begin(); iinterv1 != tgt_intervals[0].end(); ++iinterv1) {
 								for (GIntervals::const_iterator iinterv2 = tgt_intervals[1].begin(); iinterv2 != tgt_intervals[1].end(); ++iinterv2) {
@@ -928,8 +931,8 @@ SEXP gtrack_liftover(SEXP _track,
 							src_intervals[1].start = iqtree->y;
 							src_intervals[1].end = iqtree->y + 1;
 
-							hints[0] = chain_intervs.map_interval(src_intervals[0], tgt_intervals[0], hints[0]);
-							hints[1] = chain_intervs.map_interval(src_intervals[1], tgt_intervals[1], hints[1]);
+							chain_intervs.map_interval(src_intervals[0], tgt_intervals[0], chain_intervs.begin());
+							chain_intervs.map_interval(src_intervals[1], tgt_intervals[1], chain_intervs.begin());
 
 							for (GIntervals::const_iterator iinterv1 = tgt_intervals[0].begin(); iinterv1 != tgt_intervals[0].end(); ++iinterv1) {
 								for (GIntervals::const_iterator iinterv2 = tgt_intervals[1].begin(); iinterv2 != tgt_intervals[1].end(); ++iinterv2) {

--- a/src/rdbinterval.cpp
+++ b/src/rdbinterval.cpp
@@ -880,11 +880,22 @@ void ChainIntervals::handle_tgt_overlaps(const string &policy, const GenomeChrom
 			return;
 
 		ChainInterval slice = interval;
-		const int64_t delta = seg_start - interval.start;
 		slice.start = seg_start;
 		slice.end = seg_end;
-		slice.start_src = interval.start_src + delta;
-		slice.end_src = slice.start_src + (seg_end - seg_start);
+		if (slice.strand == 0) {
+			// Plus strand: target and source run in the same direction.
+			const int64_t delta = seg_start - interval.start;
+			slice.start_src = interval.start_src + delta;
+			slice.end_src = slice.start_src + (seg_end - seg_start);
+		} else {
+			// Minus strand: target and source run in OPPOSITE directions, so a
+			// target slice maps to the mirrored source range. Computing the source
+			// coords with the forward formula (the previous behaviour) gave a
+			// truncated/split minus chain the source coordinates of the discarded
+			// half, inverting the lifted source<->target correspondence.
+			slice.start_src = interval.start_src + (interval.end - seg_end);
+			slice.end_src = interval.start_src + (interval.end - seg_start);
+		}
 
 		if (allow_merge && !out.empty()) {
 			ChainInterval &prev = out.back();

--- a/tests/testthat/test-gintervals.liftover-agg.R
+++ b/tests/testthat/test-gintervals.liftover-agg.R
@@ -595,3 +595,30 @@ test_that("gintervals.liftover: carried hint does not skip a wider earlier overl
     expect_setequal(b2$chain_id, c(1, 3))
     expect_setequal(b2$start, c(35, 305))
 })
+
+# Regression: when the target-overlap sweep truncates/splits a MINUS-strand chain,
+# append_slice recomputed the source coordinates with the forward formula, giving the
+# surviving slice the source coords of the discarded half (inverting the lifted
+# source<->target correspondence). Confirmed against UCSC liftOver.
+test_that("gintervals.liftover auto_score: truncated minus-strand chain keeps reversed source coords", {
+    local_db_state()
+
+    setup_db(list(paste0(">chrT\n", paste(rep("T", 1000), collapse = ""), "\n")))
+
+    # chain1 (minus target): src chrS[100,200) -> forward tgt chrT[600,700)
+    #   (minus coords 300..400 over size 1000 -> forward 600..700).
+    # chain2 (plus, higher score) covers tgt[650,700), forcing chain1's target to be
+    # truncated to [600,650).
+    chain <- new_chain_file()
+    write_chain_entry(chain, "chrS", 100000, "+", 100, 200, "chrT", 1000, "-", 300, 400, 1, score = 100)
+    write_chain_entry(chain, "chrS", 100000, "+", 2000, 2050, "chrT", 1000, "+", 650, 700, 2, score = 900)
+    ch <- gintervals.load_chain(chain, tgt_overlap_policy = "auto_score")
+
+    s1 <- ch[ch$chain_id == 1, ]
+    expect_equal(nrow(s1), 1L)
+    expect_equal(s1$start, 600)
+    expect_equal(s1$end, 650)
+    # minus correspondence: fwd tgt700<->src100, tgt600<->src200; kept tgt[600,650)<->src[150,200)
+    expect_equal(s1$startsrc, 150)
+    expect_equal(s1$endsrc, 200)
+})

--- a/tests/testthat/test-gtrack.liftover-agg.R
+++ b/tests/testthat/test-gtrack.liftover-agg.R
@@ -821,3 +821,82 @@ test_that("gtrack.liftover agg: overlapping sibling does not drop a boundary-spa
     expect_equal(res[res$start == 0, lifted], 9)
     expect_equal(res[res$start == 20, lifted], 9)
 })
+
+# Regression: under na.rm=TRUE, when ONE chain maps both a finite and a NaN source
+# bin into the same target bin (common with phase-offset chains), aggregate_values
+# used to OR-merge is_na over the whole chain and drop the finite value too.
+test_that("gtrack.liftover agg: na.rm keeps a chain's finite piece when the same chain also maps a NaN piece into the bin", {
+    local_db_state()
+
+    source_db <- setup_source_db(list(paste0(">source1\n", paste(rep("A", 80), collapse = ""), "\n")))
+    # dense 20bp: bin0=5 (finite), bin1=NaN, bin2=5
+    gtrack.create_dense(
+        "isna_src", "mixed finite/NaN source",
+        data.frame(chrom = "chrsource1", start = c(0L, 20L, 40L), end = c(20L, 40L, 60L), stringsAsFactors = FALSE),
+        c(5, NaN, 5), 20, NaN
+    )
+    src_dir <- file.path(source_db, "tracks", "isna_src.track")
+
+    setup_db(list(paste0(">chrA\n", paste(rep("T", 80), collapse = ""), "\n")))
+
+    # One chain, 1:1, offset 10: src[0,60)->tgt[10,70). So src bin0[0,20)->tgt[10,30),
+    # bin1[20,40)(NaN)->tgt[30,50). Target bin [20,40) then gets a finite piece (bin0,
+    # tgt[20,30)) and a NaN piece (bin1, tgt[30,40)) from the SAME chain.
+    chain <- new_chain_file()
+    write_chain_entry(chain, "chrsource1", 80, "+", 0, 60, "chrA", 80, "+", 10, 70, 1)
+
+    lifted <- "isna_lifted"
+    withr::defer(if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE))
+    for (agg in c("mean", "max")) {
+        if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE)
+        gtrack.liftover(lifted, "x", src_dir, chain, tgt_overlap_policy = "agg", multi_target_agg = agg, na.rm = TRUE)
+        v <- gextract(lifted, gintervals("chrA", 20, 40), iterator = 20)[[lifted]]
+        expect_equal(v, 5, info = agg) # finite piece survives; NaN piece must not poison the bin
+    }
+})
+
+# Regression: the 2D liftover walked source rects in quadtree (spatial) order while
+# carrying a map_interval hint, which is only valid for coordinate-sorted access. A
+# multi-block chain then dropped rects whose iteration order moved the hint backward.
+test_that("gtrack.liftover 2D: a multi-block chain does not drop rects", {
+    local_db_state()
+
+    SZ <- 10000L
+    mk_pc_db <- function(nm) {
+        d <- tempfile("liftagg2d_")
+        dir.create(d)
+        fa <- file.path(d, paste0(nm, ".fasta")) # chrom name derives from the file name
+        cat(sprintf(">%s\n%s\n", nm, paste(rep("A", SZ), collapse = "")), file = fa)
+        db <- tempfile("liftagg2d_db_")
+        suppressMessages(gdb.create(groot = db, fasta = fa, format = "per-chromosome"))
+        withr::defer(
+            {
+                unlink(db, recursive = TRUE)
+                unlink(d, recursive = TRUE)
+            },
+            envir = testthat::teardown_env()
+        )
+        db
+    }
+
+    src_db <- mk_pc_db("source1")
+    gdb.init(src_db)
+    # two rects: one at high x, one at low x, so spatial iteration moves the hint backward
+    intervs <- gintervals.2d("source1", c(5000, 750), c(5050, 800), "source1", c(5000, 0), c(5050, 50))
+    gtrack.2d.create("src2d", "x", intervs, c(11, 31))
+    src_dir <- file.path(src_db, "tracks", "src2d.track")
+
+    tgt_db <- mk_pc_db("chr1")
+    gdb.init(tgt_db)
+    chain <- new_chain_file()
+    for (s in seq(0L, SZ - 200L, by = 200L)) {
+        write_chain_entry(chain, "source1", SZ, "+", s, s + 200, "chr1", SZ, "+", s, s + 200, s / 200 + 1)
+    }
+
+    lifted <- "lh2d"
+    withr::defer(if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE))
+    gtrack.liftover(lifted, "x", src_dir, chain, tgt_overlap_policy = "keep")
+    res <- gextract(lifted, gintervals.2d.all())
+    expect_equal(nrow(res), 2L) # both rects survive; pre-fix the low-x rect was dropped
+    expect_setequal(res[["lh2d"]], c(11, 31))
+})


### PR DESCRIPTION
Auditing the liftover subsystem (after the 5.11.3/5.11.4 fixes) for the cursor/overlap bug class surfaced **three more independent, verified correctness bugs**. Each has a regression test that is red pre-fix and green after; all existing liftover tests pass.

### 1. Minus-strand truncation gives wrong source coords (`rdbinterval.cpp`, `append_slice`)
When the target-overlap sweep truncates/splits a **minus-strand** chain, the surviving slice's source coordinates were computed with the forward formula, so it got the source coords of the **discarded** half - inverting the lifted source↔target correspondence. Now reversed for `strand != 0`. Confirmed against UCSC `liftOver`. Affects `gintervals.liftover`/`gtrack.liftover` (1D+2D) under any truncating policy (`auto`/`auto_score`/`auto_longer`/`auto_first`).

### 2. `na.rm` drops a chain's finite data (`AggregationHelpers.h`, `aggregate_values`)
Contributions were merged by `chain_id` with `is_na` OR-ed **before** `na.rm` filtering, so a chain mapping both a finite and a NaN source bin into one locus was discarded wholesale (spurious NaN / wrong aggregate). NaN pieces are now dropped before the per-chain merge; `na.rm=FALSE` still yields NaN if any piece is NaN.

### 3. 2D liftover drops rectangles (`GTrackLiftover.cpp`, 2D branch)
It carried a `map_interval` hint across the quadtree's **spatial** (non-coordinate) iteration; a multi-block chain then moved the hint backward and lost mappings. Each axis is now mapped from `begin()` per rect (the safe pattern the 1D sparse path uses).

### Known limitation (NOT addressed here)
2D liftover still inserts overlapping mapped rectangles into the target quadtree **without aggregation** (`multi_target_agg`/`na.rm` are 1D-only), which can corrupt read-back when a chain maps disjoint sources onto overlapping targets. Fixing that needs routing the 2D path through the 1D collect-sort-aggregate machinery - left as separate work.

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt