### PR TITLE
fix(C++): gtrack.liftover aggregates all distinct source bins per target bin (5.11.6)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.5
+Version: 5.11.6
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.6
+
+* **Behavior fix:** `gtrack.liftover()` aggregation (`multi_target_agg`) now combines all distinct source bins that map to a target bin, instead of keeping only the first when several come from the same chain. Previously, with a chain whose blocks are not aligned to the bin grid (i.e. most real liftovers), `max`/`sum`/`mean`/`count` reflected only the first contributing source bin. (`gintervals.liftover` was already correct.) Lifted track values change accordingly.
+
 # misha 5.11.5
 
 * **Behavior fix:** `gtrack.liftover()` / `gintervals.liftover()` with a minus-strand chain that the target-overlap sweep truncates or splits (e.g. under `tgt_overlap_policy = "auto"`) now keep the correct reversed source coordinates for the surviving slice instead of the coordinates of the discarded half.

--- a/src/GTrackLiftover.cpp
+++ b/src/GTrackLiftover.cpp
@@ -545,8 +545,16 @@ SEXP gtrack_liftover(SEXP _track,
 						hint = chain_intervs.map_interval(src_interval, tgt_intervals, hint, &mapping_meta);
 						if (!tgt_intervals.empty() && mapping_meta.size() != tgt_intervals.size())
 							TGLError("Metadata size mismatch: %zu vs %zu", mapping_meta.size(), tgt_intervals.size());
-						for (size_t idx = 0; idx < tgt_intervals.size(); ++idx)
-							chrom_intervals[tgt_intervals[idx].chromid].push_back(GIntervalVal(tgt_intervals[idx], val, mapping_meta[idx].chain_id));
+						for (size_t idx = 0; idx < tgt_intervals.size(); ++idx) {
+							// Aggregation dedup key = (chain id, source bin index i). Pieces of
+							// the SAME source bin split by "agg" target segmentation share the key
+							// (counted once), while DIFFERENT source bins of the same chain that
+							// land in one target bin stay distinct and are aggregated. Keying by
+							// chain_id alone collapsed them, returning only the first bin's value.
+							// (Mirrors IntervalsLiftover's (chain_id, interval_id) key.)
+							int64_t agg_key = ((int64_t)mapping_meta[idx].chain_id << 32) ^ (int64_t)i;
+							chrom_intervals[tgt_intervals[idx].chromid].push_back(GIntervalVal(tgt_intervals[idx], val, agg_key));
+						}
 
 						src_interval.start += src_track.get_bin_size();
 						src_interval.end += src_track.get_bin_size();
@@ -601,8 +609,12 @@ SEXP gtrack_liftover(SEXP _track,
 						ChainIntervals::const_iterator hint = chain_intervs.begin();
 						mapping_meta.clear();
 						hint = chain_intervs.map_interval(remapped_interval, tgt_intervals, hint, &mapping_meta);
-						for (size_t idx = 0; idx < tgt_intervals.size(); ++idx)
-							chrom_intervals[tgt_intervals[idx].chromid].push_back(GIntervalVal(tgt_intervals[idx], vals[i], mapping_meta[idx].chain_id));
+						for (size_t idx = 0; idx < tgt_intervals.size(); ++idx) {
+							// Dedup key = (chain id, source interval index i); see the FIXED_BIN
+							// path above. Keeps distinct source intervals of one chain separate.
+							int64_t agg_key = ((int64_t)mapping_meta[idx].chain_id << 32) ^ (int64_t)i;
+							chrom_intervals[tgt_intervals[idx].chromid].push_back(GIntervalVal(tgt_intervals[idx], vals[i], agg_key));
+						}
 						check_interrupt();
 					}
 

--- a/tests/testthat/test-gtrack.liftover-agg.R
+++ b/tests/testthat/test-gtrack.liftover-agg.R
@@ -900,3 +900,41 @@ test_that("gtrack.liftover 2D: a multi-block chain does not drop rects", {
     expect_equal(nrow(res), 2L) # both rects survive; pre-fix the low-x rect was dropped
     expect_setequal(res[["lh2d"]], c(11, 31))
 })
+
+# Regression: distinct source bins of ONE chain that land in the same target bin
+# (via a phase-offset chain) must be aggregated, not collapsed to the first bin's
+# value. The aggregation deduped contributions by chain_id alone, which correctly
+# folds the pieces of a single source bin split by "agg" segmentation but wrongly
+# also folded different source bins of the same chain. The key now includes the
+# source bin index. Verified against UCSC liftOver: both source bins map into the
+# output bin.
+test_that("gtrack.liftover agg: distinct source bins of one chain are aggregated, not collapsed to the first", {
+    local_db_state()
+
+    source_db <- setup_source_db(list(paste0(">source1\n", paste(rep("A", 80), collapse = ""), "\n")))
+    # dense 20bp: three distinct values
+    gtrack.create_dense(
+        "multibin_src", "distinct-value source bins",
+        data.frame(chrom = "chrsource1", start = c(0L, 20L, 40L), end = c(20L, 40L, 60L), stringsAsFactors = FALSE),
+        c(5, 7, 9), 20, NaN
+    )
+    src_dir <- file.path(source_db, "tracks", "multibin_src.track")
+
+    setup_db(list(paste0(">chrA\n", paste(rep("T", 80), collapse = ""), "\n")))
+
+    # One chain, 1:1, offset 10: src[0,60)->tgt[10,70). Output bin chrA[20,40) gets
+    # source bin0 (value 5, piece tgt[20,30)) AND source bin1 (value 7, piece tgt[30,40)),
+    # both via the SAME chain_id.
+    chain <- new_chain_file()
+    write_chain_entry(chain, "chrsource1", 80, "+", 0, 60, "chrA", 80, "+", 10, 70, 1)
+
+    lifted <- "multibin_lifted"
+    withr::defer(if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE))
+    expected <- list(max = 7, sum = 12, mean = 6, count = 2, min = 5)
+    for (agg in names(expected)) {
+        if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE)
+        gtrack.liftover(lifted, "x", src_dir, chain, tgt_overlap_policy = "agg", multi_target_agg = agg)
+        v <- gextract(lifted, gintervals("chrA", 20, 40), iterator = 20)[[lifted]]
+        expect_equal(v, expected[[agg]], info = agg)
+    }
+})


### PR DESCRIPTION
## Problem

`gtrack.liftover()` aggregation (`multi_target_agg`) kept only the **first** source bin's value when several distinct source bins of the **same chain** land in one target bin. With a chain whose blocks aren't aligned to the output bin grid - i.e. essentially every real liftover - `max`/`sum`/`mean`/`count` reflected only the first contributing source bin.

The aggregation dedups contributions by `chain_id`. That dedup is needed to fold the multiple target pieces a single source bin is split into by `"agg"` target-overlap segmentation (so the bin counts once). But `chain_id` is too coarse: it also collapsed **different** source bins sharing a chain.

## Validation (UCSC liftOver)

For a 1:1 chain with a 10bp offset, source bins `[0,20)=5` and `[20,40)=7` both map into target bin `[20,40)` - `liftOver` maps the pieces to `chrA[20,30)` and `chrA[30,40)`. So both values genuinely contribute; `max` must be `7`, not `5`. Pre-fix misha returned `5` (and `sum=5`, `count=1`); post-fix `7`/`12`/`2`.

## Fix

The dedup key now combines `chain_id` with the source bin/interval index (`(chain_id << 32) ^ i`), mirroring `IntervalsLiftover`, which already keys by `(chain_id, interval_id)` and was therefore correct (`gintervals.liftover` was not affected). Pieces of the same source bin split by segmentation still share the key (folded); distinct source bins stay separate and aggregate. `gtrack.create_dense` was unaffected (it already passes a unique id per contribution).

## Behavior change

Lifted **track** values from `gtrack.liftover` change for chains whose blocks are not bin-aligned. Classified PATCH per the project policy (bug fix even when output changes); flagged prominently in NEWS.

Regression test (red pre-fix, green after) in `test-gtrack.liftover-agg.R`; all existing liftover tests pass.

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt