### PR TITLE
fix(C++/R): liftover map_interval slow-path drop + clear error for cluster policies (5.11.7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.6
+Version: 5.11.7
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# misha 5.11.7
+
+* **Behavior fix:** `gintervals.liftover()` no longer silently drops an interval whose start coincides with its leftmost overlapping chain when it is lifted in the same call after a wider interval (a `map_interval` slow-path miss; the carried hint had advanced past the chain). Affected multi-interval lifts under any target policy.
+* `gtrack.liftover()` now rejects the cluster target-overlap policies (`best_source_cluster`, `best_cluster_union`, `best_cluster_sum`, `best_cluster_max`) with a clear error - they are implemented only for `gintervals.liftover()`; previously they failed with a confusing internal message.
+
 # misha 5.11.6
 
 * **Behavior fix:** `gtrack.liftover()` aggregation (`multi_target_agg`) now combines all distinct source bins that map to a target bin, instead of keeping only the first when several come from the same chain. Previously, with a chain whose blocks are not aligned to the bin grid (i.e. most real liftovers), `max`/`sum`/`mean`/`count` reflected only the first contributing source bin. (`gintervals.liftover` was already correct.) Lifted track values change accordingly.

--- a/R/track-liftover.R
+++ b/R/track-liftover.R
@@ -174,6 +174,14 @@ gtrack.liftover <- function(track = NULL,
         }
     }
 
+    # Cluster target-overlap policies are implemented only for gintervals.liftover
+    # (the union-find clustering in IntervalsLiftover.cpp). gtrack.liftover would
+    # otherwise fail deep in C++ with a confusing "Invalid target overlap policy"
+    # message, so reject them here with an actionable error.
+    if (tgt_overlap_policy %in% c("best_source_cluster", "best_cluster_union", "best_cluster_sum", "best_cluster_max")) {
+        stop(sprintf("tgt_overlap_policy = '%s' is only supported by gintervals.liftover(), not gtrack.liftover(). Use 'auto', 'agg', 'keep', or 'discard'.", tgt_overlap_policy), call. = FALSE)
+    }
+
     .gconfirmtrackcreate(trackstr)
 
     .gtrack.create_atomic(trackstr, function() {

--- a/src/rdbinterval.cpp
+++ b/src/rdbinterval.cpp
@@ -1241,9 +1241,13 @@ ChainIntervals::const_iterator ChainIntervals::map_interval(const GInterval &src
 		}
 	}
 
-	// No left overlap exists; check the right neighbor (iend_interval)
-	if (iend_interval != end() && iend_interval->do_overlap_src(src_interval))
-		return add2tgt(iend_interval, src_interval, tgt_intervs, metadata);
+	// No chain starting before the query reaches into it. The leftmost overlap, if
+	// any, is then the first chain whose start_src >= query.start (lb). The previous
+	// code checked iend_interval here, which after the binary search need not equal
+	// lb, so a query that starts at or before its only overlapping chain was dropped
+	// (e.g. a carried hint had advanced past that chain).
+	if (lb != slice_end && lb->do_overlap_src(src_interval))
+		return add2tgt(lb, src_interval, tgt_intervs, metadata);
 
 	// Nothing overlaps
 	return istart_interval;

--- a/tests/testthat/test-gintervals.liftover-agg.R
+++ b/tests/testthat/test-gintervals.liftover-agg.R
@@ -622,3 +622,28 @@ test_that("gintervals.liftover auto_score: truncated minus-strand chain keeps re
     expect_equal(s1$startsrc, 150)
     expect_equal(s1$endsrc, 200)
 })
+
+# Regression: map_interval's slow path, when no chain starts before the query
+# (query.start <= the leftmost overlapping chain's start_src), checked only
+# iend_interval and missed the leftmost chain. With a carried hint advanced by an
+# earlier (wider) interval, a narrow interval was silently dropped. Confirmed
+# against UCSC liftOver.
+test_that("gintervals.liftover: narrow interval starting at its leftmost chain is not dropped after a wide one", {
+    local_db_state()
+
+    setup_db(list(paste0(">chrA\n", paste(rep("T", 5000), collapse = ""), "\n")))
+    chain <- new_chain_file()
+    write_chain_entry(chain, "src", 5000, "+", 100, 200, "chrA", 5000, "+", 1000, 1100, 1)
+    write_chain_entry(chain, "src", 5000, "+", 400, 600, "chrA", 5000, "+", 2000, 2200, 2)
+    ch <- gintervals.load_chain(chain) # defaults: src=error, tgt=auto
+
+    # The wide [0,1000) is processed first and advances the carried hint; the narrow
+    # [100,200) starts exactly at chain 1's start_src (100).
+    inp <- data.frame(chrom = "src", start = c(0, 100), end = c(1000, 200), stringsAsFactors = FALSE)
+    res <- gintervals.liftover(inp, ch, include_metadata = TRUE)
+
+    r2 <- res[res$intervalID == 2, ]
+    expect_equal(nrow(r2), 1L) # was dropped pre-fix
+    expect_equal(r2$start, 1000)
+    expect_equal(r2$end, 1100)
+})

--- a/tests/testthat/test-gtrack.liftover-agg.R
+++ b/tests/testthat/test-gtrack.liftover-agg.R
@@ -938,3 +938,28 @@ test_that("gtrack.liftover agg: distinct source bins of one chain are aggregated
         expect_equal(v, expected[[agg]], info = agg)
     }
 })
+
+# Cluster target-overlap policies are implemented only for gintervals.liftover.
+# gtrack.liftover used to fail deep in C++ with a confusing message; it now rejects
+# them up front with an actionable error.
+test_that("gtrack.liftover rejects cluster target-overlap policies with a clear error", {
+    local_db_state()
+
+    source_db <- setup_source_db(list(paste0(">source1\n", paste(rep("A", 100), collapse = ""), "\n")))
+    gtrack.create_dense(
+        "cl_src", "x",
+        data.frame(chrom = "chrsource1", start = 0L, end = 100L, stringsAsFactors = FALSE),
+        1, 20, NaN
+    )
+    src_dir <- file.path(source_db, "tracks", "cl_src.track")
+    setup_db(list(paste0(">chrA\n", paste(rep("T", 100), collapse = ""), "\n")))
+    chain <- new_chain_file()
+    write_chain_entry(chain, "chrsource1", 100, "+", 0, 100, "chrA", 100, "+", 0, 100, 1)
+
+    for (pol in c("best_source_cluster", "best_cluster_union", "best_cluster_sum", "best_cluster_max")) {
+        expect_error(
+            gtrack.liftover("cl_lift", "x", src_dir, chain, tgt_overlap_policy = pol),
+            "only supported by gintervals.liftover"
+        )
+    }
+})


### PR DESCRIPTION
Two issues found while auditing the cluster target-overlap policies.

### 1. `map_interval` slow-path silently dropped a mapping (`rdbinterval.cpp`)
When no chain starts before the query (`query.start <=` the leftmost overlapping chain's `start_src`, so the prefix-max "left overlap" branch is skipped), the fallback only checked `iend_interval` - which after the binary search need not be the leftmost overlapping chain. With a carried hint advanced by an earlier (wider) interval, a narrow interval was **dropped**. This is a second defect in `map_interval`, distinct from the 5.11.4 fast-path fix.

**Validated against UCSC `liftOver`:** `src[100,200)` maps to `chr1[1000,1100)` but was dropped when lifted in a batch after a wider interval. **Fix:** the fallback now checks `lb` (the first chain with `start_src >= query.start`) and enumerates from there. Affects multi-interval `gintervals.liftover` under any target policy.

### 2. `gtrack.liftover` cluster policies failed with a confusing error
`gtrack.liftover` advertised `best_source_cluster` / `best_cluster_union` / `best_cluster_sum` / `best_cluster_max`, but the clustering is implemented only in `IntervalsLiftover` (`gintervals.liftover`); `gtrack.liftover` failed deep in C++ with `Invalid target overlap policy`. It now rejects them in R with an actionable error.

Regression tests for both (the dropped-mapping one red pre-fix, green after; the cluster one asserts the clear error). All liftover tests pass.

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt