### PR TITLE
test: extend liftover/kent differential fuzz with gapped + multi-mapping modes

### DIFF
--- a/tests/testthat/test-liftover-kent-differential.R
+++ b/tests/testthat/test-liftover-kent-differential.R
@@ -142,3 +142,190 @@ test_that("gintervals.liftover matches UCSC liftOver on randomized single-block 
 
     expect_equal(total_mismatch, 0L)
 })
+
+# Convex-hull mode for GAPPED (multi-block) chains. misha fragments a query at
+# internal chain gaps while liftOver bridges them, so exact coverage differs by
+# design; the convex hull (min start, max end of the per-query target coverage)
+# must still agree. Queries are confined within a single chain's source span so a
+# query maps to one chain (one hull). This catches extent/edge-coordinate/strand
+# errors and whole-mapping drops on gapped chains; its blind spot is a dropped
+# *interior* fragment (which leaves the hull unchanged) - that case is covered by
+# the exact single-block test above and the targeted regression tests.
+test_that("gintervals.liftover matches UCSC liftOver convex hull on gapped multi-block chains", {
+    skip_if_not(has_liftover_binary(), "liftOver binary not found")
+    local_db_state()
+
+    SRC <- 200000L
+    TGT <- 600000L
+    gdir <- tempfile("kentdiff2_")
+    dir.create(gdir)
+    fa <- file.path(gdir, "chr1.fasta")
+    cat(">chr1\n", paste(rep("A", TGT), collapse = ""), "\n", sep = "", file = fa)
+    tdb <- tempfile("kentdiff2_db_")
+    suppressMessages(gdb.create(groot = tdb, fasta = fa))
+    withr::defer(
+        {
+            unlink(tdb, recursive = TRUE)
+            unlink(gdir, recursive = TRUE)
+        },
+        envir = testthat::teardown_env()
+    )
+    gdb.init(tdb)
+
+    hull <- function(df) {
+        if (is.null(df) || nrow(df) == 0) {
+            return(data.frame(start = integer(), end = integer()))
+        }
+        data.frame(start = min(df$start), end = max(df$end))
+    }
+    # multi-block + strand chain: blocks with target/source gaps between them
+    write_mb <- function(con, id, score, ss, ts, blocks, gt, gq) {
+        se <- ss + sum(blocks) + sum(gt)
+        te <- ts + sum(blocks) + sum(gq)
+        hdr <- sprintf("chain %d source1 %d + %d %d chr1 %d + %d %d %d", score, SRC, ss, se, TGT, ts, te, id)
+        body <- if (length(blocks) == 1) {
+            sprintf("%d", blocks[1])
+        } else {
+            paste(c(sprintf("%d %d %d", blocks[-length(blocks)], gt, gq), sprintf("%d", blocks[length(blocks)])), collapse = "\n")
+        }
+        cat(hdr, "\n", body, "\n\n", sep = "", file = con, append = file.exists(con) && file.info(con)$size > 0)
+        c(ss, se)
+    }
+
+    total_mismatch <- 0L
+    for (seed in 1:20) {
+        set.seed(seed)
+        cf <- new_chain_file()
+        ss <- 1000L
+        ts <- 1000L
+        ranges <- list()
+        for (k in seq_len(sample(2:4, 1))) {
+            nb <- sample(2:5, 1)
+            blocks <- as.integer(sample(30:300, nb, replace = TRUE))
+            gt <- as.integer(sample(1:40, nb - 1, replace = TRUE))
+            gq <- as.integer(sample(1:40, nb - 1, replace = TRUE))
+            ranges[[k]] <- write_mb(cf, k, sample(1000:9000, 1), ss, ts, blocks, gt, gq)
+            ss <- ranges[[k]][2] + sample(500:3000, 1)
+            ts <- ts + sum(blocks) + sum(gq) + sample(500:3000, 1)
+        }
+        q <- do.call(rbind, lapply(ranges, function(r) {
+            st <- as.integer(sample(r[1]:(r[2] - 5), 3))
+            data.frame(chrom = "source1", start = st, end = pmin(st + as.integer(sample(5:(r[2] - r[1]), 3)), r[2]), stringsAsFactors = FALSE)
+        }))
+        q <- q[q$end > q$start, , drop = FALSE]
+        q$qid <- seq_len(nrow(q))
+
+        ch <- gintervals.load_chain(cf)
+        mish <- gintervals.liftover(q[, c("chrom", "start", "end")], ch, include_metadata = TRUE)
+
+        bed <- tempfile(fileext = ".bed")
+        cat(sprintf("source1\t%d\t%d\tq%d\n", q$start, q$end, q$qid), file = bed)
+        outf <- tempfile()
+        unf <- tempfile()
+        system2("liftOver", c("-multiple", "-minMatch=0.0000001", bed, cf, outf, unf), stdout = FALSE, stderr = FALSE)
+        kent <- if (file.exists(outf) && file.info(outf)$size > 0) {
+            read.table(outf, col.names = c("chrom", "start", "end", "name", "val"), stringsAsFactors = FALSE)
+        } else {
+            data.frame(chrom = character(), start = integer(), end = integer(), name = character())
+        }
+        unlink(c(bed, outf, unf))
+
+        for (id in q$qid) {
+            m <- if (!is.null(mish) && nrow(mish)) mish[mish$intervalID == id, c("start", "end"), drop = FALSE] else data.frame()
+            k <- if (nrow(kent)) kent[kent$name == paste0("q", id), c("start", "end"), drop = FALSE] else data.frame()
+            if (!isTRUE(all.equal(hull(m), hull(k), check.attributes = FALSE))) {
+                total_mismatch <- total_mismatch + 1L
+            }
+        }
+    }
+    expect_equal(total_mismatch, 0L)
+})
+
+# keep / multi-mapping policy vs `liftOver -multiple`. Several chains map the SAME
+# source range to disjoint target regions (overlapping-source, src_overlap_policy =
+# "keep"); a query in that range must map to ALL of them. Both tools should produce
+# the same multi-target coverage. This exercises the keep path and the
+# overlapping-source handling in map_interval.
+test_that("gintervals.liftover keep matches UCSC liftOver -multiple on overlapping-source chains", {
+    skip_if_not(has_liftover_binary(), "liftOver binary not found")
+    local_db_state()
+
+    SRC <- 200000L
+    TGT <- 600000L
+    gdir <- tempfile("kentdiff3_")
+    dir.create(gdir)
+    fa <- file.path(gdir, "chr1.fasta")
+    cat(">chr1\n", paste(rep("A", TGT), collapse = ""), "\n", sep = "", file = fa)
+    tdb <- tempfile("kentdiff3_db_")
+    suppressMessages(gdb.create(groot = tdb, fasta = fa))
+    withr::defer(
+        {
+            unlink(tdb, recursive = TRUE)
+            unlink(gdir, recursive = TRUE)
+        },
+        envir = testthat::teardown_env()
+    )
+    gdb.init(tdb)
+
+    total_mismatch <- 0L
+    for (seed in 1:20) {
+        set.seed(100L + seed)
+        cf <- new_chain_file()
+        id <- 0L
+        ss <- 1000L
+        tnext <- 1000L
+        clusters <- list()
+        for (cl in seq_len(sample(2:3, 1))) {
+            width <- as.integer(sample(80:400, 1))
+            for (j in seq_len(sample(2:3, 1))) { # several chains share this source range
+                id <- id + 1L
+                strand <- sample(c("+", "-"), 1)
+                tf <- tnext
+                if (strand == "+") {
+                    qs <- tf
+                    qe <- tf + width
+                } else {
+                    qs <- TGT - (tf + width)
+                    qe <- TGT - tf
+                }
+                cat(sprintf(
+                    "chain %d source1 %d + %d %d chr1 %d %s %d %d %d\n%d\n\n",
+                    sample(1000:9000, 1), SRC, ss, ss + width, TGT, strand, qs, qe, id, width
+                ), file = cf, append = file.exists(cf) && file.info(cf)$size > 0)
+                tnext <- tf + width + sample(500:3000, 1)
+            }
+            clusters[[length(clusters) + 1]] <- c(ss, ss + width)
+            ss <- ss + width + sample(500:3000, 1)
+        }
+        q <- do.call(rbind, lapply(clusters, function(r) {
+            st <- as.integer(sample(r[1]:(r[2] - 5), 4))
+            data.frame(chrom = "source1", start = st, end = pmin(st + as.integer(sample(5:80, 4)), r[2]), stringsAsFactors = FALSE)
+        }))
+        q <- q[q$end > q$start, , drop = FALSE]
+        q$qid <- seq_len(nrow(q))
+
+        ch <- gintervals.load_chain(cf, src_overlap_policy = "keep", tgt_overlap_policy = "keep")
+        mish <- gintervals.liftover(q[, c("chrom", "start", "end")], ch, include_metadata = TRUE)
+
+        bed <- tempfile(fileext = ".bed")
+        cat(sprintf("source1\t%d\t%d\tq%d\n", q$start, q$end, q$qid), file = bed)
+        outf <- tempfile()
+        unf <- tempfile()
+        system2("liftOver", c("-multiple", "-minMatch=0.0000001", bed, cf, outf, unf), stdout = FALSE, stderr = FALSE)
+        kent <- if (file.exists(outf) && file.info(outf)$size > 0) {
+            read.table(outf, col.names = c("chrom", "start", "end", "name", "val"), stringsAsFactors = FALSE)
+        } else {
+            data.frame(chrom = character(), start = integer(), end = integer(), name = character())
+        }
+        unlink(c(bed, outf, unf))
+
+        for (id2 in q$qid) {
+            m <- if (!is.null(mish) && nrow(mish)) mish[mish$intervalID == id2, c("start", "end"), drop = FALSE] else data.frame()
+            k <- if (nrow(kent)) kent[kent$name == paste0("q", id2), c("start", "end"), drop = FALSE] else data.frame()
+            if (!isTRUE(all.equal(.canon_cov(m), .canon_cov(k), check.attributes = FALSE))) {
+                total_mismatch <- total_mismatch + 1L
+            }
+        }
+    }
+    expect_equal(total_mismatch, 0L)
+})


### PR DESCRIPTION
Extends the randomized differential test (PR #145) with the two modes flagged as follow-ups:

1. **Convex-hull comparison on gapped (multi-block) chains.** misha fragments at internal chain gaps while `liftOver` bridges them (legitimate difference), so the per-query convex hull is compared instead of exact coverage. Catches extent/edge-coordinate/strand errors and whole-mapping drops on gapped chains.
2. **`keep` / multi-mapping vs `liftOver -multiple`.** Several chains map the same source range to disjoint targets (overlapping-source, `src_overlap_policy="keep"`); a query must map to all. Compares canonicalized multi-target coverage; exercises the keep path and overlapping-source `map_interval` handling.

Both validated: **0 mismatches on correct code**; a deliberate 1bp mapping offset yields **222** (hull) and **164** (multi-mapping) mismatches - they have teeth. Whole file ~4s; skips without `liftOver`. Test-only.

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt