### PR TITLE
fix(C++): 2D gtrack.liftover aggregates overlapping mapped rects (5.11.8)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.7
+Version: 5.11.8
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.8
+
+* **Behavior fix:** 2D `gtrack.liftover()` now aggregates overlapping mapped rectangles instead of inserting them as overlapping objects (which corrupted read-back and double-counted). `multi_target_agg`, `na.rm`, and `min_n` now apply to 2D tracks too, matching the 1D path. Overlaps arise when a chain maps disjoint source rectangles onto overlapping target rectangles; lifted 2D track values change accordingly.
+
 # misha 5.11.7
 
 * **Behavior fix:** `gintervals.liftover()` no longer silently drops an interval whose start coincides with its leftmost overlapping chain when it is lifted in the same call after a wider interval (a `map_interval` slow-path miss; the carried hint had advanced past the chain). Affected multi-interval lifts under any target policy.

--- a/src/GTrackLiftover.cpp
+++ b/src/GTrackLiftover.cpp
@@ -297,6 +297,81 @@ struct GIntervalVal {
 	}
 };
 
+// Aggregate possibly-overlapping mapped rectangles into DISJOINT rectangles before
+// inserting them into a StatQuadTree (which requires non-overlapping objects -
+// overlapping inserts corrupt read-back and double-count). Disjoint source rects can
+// map onto overlapping target rects because the chain shifts x and y independently, so
+// the 2D path needs the same collect -> segment -> aggregate treatment the 1D path has.
+//
+// We coordinate-compress the x and y boundaries into a grid and, for every grid cell,
+// aggregate (via agg_cfg) the values of all source rects covering it. Each cell carries
+// a unique contribution id so aggregate_values never folds distinct sources together.
+// Cells are emitted one rect each (no run merging).
+//
+// ponytail: per-cell cost is O(active rects per x-slab); for grid-aligned data
+// (Hi-C points / uniform bins, each rect == one cell) that is ~O(N), but it is O(N^2)
+// worst case for pathological nested/offset rectangles, and a non-grid-aligned disjoint
+// rect gets split at a neighbour's boundary (more rects, identical values). Upgrade path
+// if it ever bites: decompose per overlap-cluster and merge equal-value runs.
+struct RectVal2D { int64_t x1, y1, x2, y2; float v; };
+
+static void aggregate_2d_rects(vector<RectVal2D> &rects, const AggregationConfig &agg_cfg, RectsQuadTree &qtree)
+{
+	if (rects.empty())
+		return;
+
+	vector<int64_t> xs, ys;
+	xs.reserve(rects.size() * 2);
+	ys.reserve(rects.size() * 2);
+	for (vector<RectVal2D>::const_iterator r = rects.begin(); r != rects.end(); ++r) {
+		xs.push_back(r->x1); xs.push_back(r->x2);
+		ys.push_back(r->y1); ys.push_back(r->y2);
+	}
+	sort(xs.begin(), xs.end()); xs.erase(unique(xs.begin(), xs.end()), xs.end());
+	sort(ys.begin(), ys.end()); ys.erase(unique(ys.begin(), ys.end()), ys.end());
+
+	vector<size_t> by_x1(rects.size()), by_x2(rects.size());
+	for (size_t i = 0; i < rects.size(); ++i) { by_x1[i] = i; by_x2[i] = i; }
+	sort(by_x1.begin(), by_x1.end(), [&](size_t a, size_t b) { return rects[a].x1 < rects[b].x1; });
+	sort(by_x2.begin(), by_x2.end(), [&](size_t a, size_t b) { return rects[a].x2 < rects[b].x2; });
+
+	set<size_t> active;
+	size_t ia = 0, ir = 0;
+	int64_t encounter = 0; // unique id per contribution -> aggregate_values never merges them
+
+	for (size_t xi = 0; xi + 1 < xs.size(); ++xi) {
+		int64_t xa = xs[xi], xb = xs[xi + 1];
+
+		while (ir < by_x2.size() && rects[by_x2[ir]].x2 <= xa) { active.erase(by_x2[ir]); ++ir; }
+		while (ia < by_x1.size() && rects[by_x1[ia]].x1 <= xa) { active.insert(by_x1[ia]); ++ia; }
+
+		if (active.empty())
+			continue;
+
+		// Per y-band aggregation over the rects active in this x-slab. Every active rect
+		// fully covers each cell it touches, so all contributors weigh equally (len = 1).
+		map<int, AggregationState> band_states;
+		for (set<size_t>::const_iterator it = active.begin(); it != active.end(); ++it) {
+			const RectVal2D &r = rects[*it];
+			int b_lo = (int)(lower_bound(ys.begin(), ys.end(), r.y1) - ys.begin());
+			int b_hi = (int)(lower_bound(ys.begin(), ys.end(), r.y2) - ys.begin());
+			for (int b = b_lo; b < b_hi; ++b) {
+				aggregation_state_add(band_states[b], (double)r.v, 1.0, 1.0, encounter, encounter, encounter);
+				++encounter;
+			}
+		}
+
+		for (map<int, AggregationState>::iterator kv = band_states.begin(); kv != band_states.end(); ++kv) {
+			double aggregated = aggregate_values(agg_cfg, kv->second);
+			float out_val = numeric_limits<float>::quiet_NaN();
+			if (!std::isnan(aggregated))
+				out_val = (float)aggregated;
+			qtree.insert(RectsQuadTree::ValueType(xa, ys[kv->first], xb, ys[kv->first + 1], out_val));
+		}
+		check_interrupt();
+	}
+}
+
 extern "C" {
 
 SEXP gtrack_liftover(SEXP _track,
@@ -976,8 +1051,18 @@ SEXP gtrack_liftover(SEXP _track,
 					ibuffered_interv->flush();
 					ibuffered_interv->seek(0, SEEK_SET);
 
-					while (ibuffered_interv->read_interval())
-						qtree.insert(RectsQuadTree::ValueType(ibuffered_interv->last_interval(), ibuffered_interv->last_val()));
+					// Collect the mapped rects, then aggregate overlaps into disjoint
+					// rects before inserting (the quadtree forbids overlapping objects).
+					vector<RectVal2D> rects;
+					while (ibuffered_interv->read_interval()) {
+						const GInterval2D &gi = ibuffered_interv->last_interval();
+						RectVal2D rv;
+						rv.x1 = gi.start1(); rv.x2 = gi.end1();
+						rv.y1 = gi.start2(); rv.y2 = gi.end2();
+						rv.v = ibuffered_interv->last_val();
+						rects.push_back(rv);
+					}
+					aggregate_2d_rects(rects, agg_cfg, qtree);
 
 					if (!qtree.empty()) {
 						GenomeTrackRectsRects gtrack(iu.get_track_chunk_size(), iu.get_track_num_chunks());

--- a/tests/testthat/test-gtrack.liftover-agg.R
+++ b/tests/testthat/test-gtrack.liftover-agg.R
@@ -901,6 +901,63 @@ test_that("gtrack.liftover 2D: a multi-block chain does not drop rects", {
     expect_setequal(res[["lh2d"]], c(11, 31))
 })
 
+# Regression for #142: 2D liftover must aggregate OVERLAPPING mapped rectangles.
+# Disjoint source rects can map onto overlapping target rects (x and y are shifted
+# independently by a multi-block "keep" chain). Pre-fix those overlapping rects were
+# inserted straight into the StatQuadTree (corruption / double-counting) and
+# multi_target_agg was a no-op for 2D. Now the 2D path coordinate-compresses into
+# disjoint cells and aggregates per cell, like the 1D path.
+test_that("gtrack.liftover 2D: overlapping mapped rects are aggregated", {
+    local_db_state()
+
+    SZ <- 1000L
+    mk_pc_db <- function(nm) {
+        d <- tempfile("lift2dagg_")
+        dir.create(d)
+        fa <- file.path(d, paste0(nm, ".fasta"))
+        cat(sprintf(">%s\n%s\n", nm, paste(rep("A", SZ), collapse = "")), file = fa)
+        db <- tempfile("lift2dagg_db_")
+        suppressMessages(gdb.create(groot = db, fasta = fa, format = "per-chromosome"))
+        withr::defer(
+            {
+                unlink(db, recursive = TRUE)
+                unlink(d, recursive = TRUE)
+            },
+            envir = testthat::teardown_env()
+        )
+        db
+    }
+
+    src_db <- mk_pc_db("source1")
+    gdb.init(src_db)
+    # R1 = x[0,10] x y[100,110] (val 10); R2 = x[100,110] x y[0,10] (val 20). Disjoint.
+    intervs <- gintervals.2d("source1", c(0, 100), c(10, 110), "source1", c(100, 0), c(110, 10))
+    gtrack.2d.create("src2d", "x", intervs, c(10, 20))
+    src_dir <- file.path(src_db, "tracks", "src2d.track")
+
+    tgt_db <- mk_pc_db("chr1")
+    gdb.init(tgt_db)
+    # Chain: src[0,10]->tgt[0,10] and src[100,110]->tgt[5,15] (overlapping targets, kept).
+    # => R1 -> x[0,10] x y[5,15]; R2 -> x[5,15] x y[0,10]; overlap = x[5,10] x y[5,10].
+    chain <- new_chain_file()
+    write_chain_entry(chain, "source1", SZ, "+", 0, 10, "chr1", SZ, "+", 0, 10, 1)
+    write_chain_entry(chain, "source1", SZ, "+", 100, 110, "chr1", SZ, "+", 5, 15, 2)
+
+    overlap_val <- function(agg) {
+        lifted <- paste0("lh2d_", agg)
+        withr::defer(if (gtrack.exists(lifted)) gtrack.rm(lifted, force = TRUE))
+        gtrack.liftover(lifted, "x", src_dir, chain, tgt_overlap_policy = "keep", multi_target_agg = agg)
+        res <- gextract(lifted, gintervals.2d.all())
+        hit <- res[res$start1 <= 7 & res$end1 > 7 & res$start2 <= 7 & res$end2 > 7, ]
+        expect_equal(nrow(hit), 1L) # disjoint output: exactly one rect covers the overlap centre
+        hit[[lifted]]
+    }
+
+    expect_equal(overlap_val("mean"), 15)
+    expect_equal(overlap_val("sum"), 30)
+    expect_equal(overlap_val("max"), 20)
+})
+
 # Regression: distinct source bins of ONE chain that land in the same target bin
 # (via a phase-offset chain) must be aggregated, not collapsed to the first bin's
 # value. The aggregation deduped contributions by chain_id alone, which correctly


### PR DESCRIPTION
Fixes #142.

## Problem

The 2D branch of `gtrack.liftover()` wrote every mapped rectangle straight into the target `StatQuadTree` with no overlap resolution or value aggregation - `multi_target_agg`, `na.rm`, and `min_n` were honored only by the 1D path. When a chain maps **disjoint** source rects onto **overlapping** target rects (x and y are shifted independently), the result was overlapping objects in a `StatQuadTree`, which the structure forbids: read-back was corrupted (area-weighted blending, double-counting) and `multi_target_agg` was a silent no-op.

## Fix

Route the per-chrom-pair read-back through a new `aggregate_2d_rects()`: collect the mapped rects, coordinate-compress the x/y boundaries into a grid, and for each disjoint cell aggregate (via the shared `AggregationHelpers` machinery, same as 1D) the values of every rect covering it. Each contribution gets a unique id so distinct sources are never folded together. Output is always disjoint, so the quadtree is valid and 1D/2D aggregation behaviour matches.

## Performance / scope

Grid-aligned data (Hi-C points / uniform bins) stays ~O(N) with one cell per rect and unchanged output for disjoint input. Pathological nested/offset rectangles are O(N²) and non-grid-aligned disjoint rects may split at neighbours' boundaries (more rects, identical values) - named in a code comment with the upgrade path (per-cluster decomposition + equal-value run merging).

## Tests

- New red→green regression test in `test-gtrack.liftover-agg.R`: disjoint source rects mapped onto overlapping targets via a multi-block `keep` chain; the overlap cell returns `mean`=15, `sum`=30, `max`=20, and exactly one rect covers it.
- All 714 existing liftover tests pass.

https://claude.ai/code/session_01MBVCQNU56dwsyhn9iw3bdt
