### PR TITLE
fix: symmetric N/* handling across strands in PWM energy routines (5.11.11)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.10
+Version: 5.11.11
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.11
+
+* **Internal consistency:** `N`/`*` are now scored the same on both strands in the PWM energy routines (reverse used `log(0.25)`, forward used the column average; both now use the average). No behavior change for genomic scoring, where `N`-windows are masked to `-Inf`; keeps `DnaPSSM` in sync with the `prego` package.
+
 # misha 5.11.10
 
 * **Behavior fix:** non-multitask `gintervals.quantiles()` (`options(gmultitasking = FALSE)`) no longer truncates the result to the first ~1000 intervals on a large scope; the streaming (`intervals.set.out=`) and in-memory results now match the multitasking output (#149).

--- a/src/DnaPSSM.cpp
+++ b/src/DnaPSSM.cpp
@@ -915,7 +915,7 @@ void DnaPSSM::integrate_energy(const string &target, float &energy, vector<float
 					break;
 				}
 				if(DnaLookupTables::NEUTRAL_CHAR[(unsigned char)*j]) {
-					logp += c_log_quarter;
+					logp += p->get_avg_log_prob();
 				} else {
 					int code = DnaLookupTables::COMPLEMENT_ENCODE[(unsigned char)*j];
 					if(code >= 0) {
@@ -986,7 +986,7 @@ void DnaPSSM::integrate_energy_logspat(const string &target, float &energy, vect
 					break;
 				}
 				if(DnaLookupTables::NEUTRAL_CHAR[(unsigned char)*j]) {
-					logp += c_log_quarter;
+					logp += p->get_avg_log_prob();
 				} else {
 					int code = DnaLookupTables::COMPLEMENT_ENCODE[(unsigned char)*j];
 					if(code >= 0) {
@@ -1058,7 +1058,7 @@ void DnaPSSM::integrate_energy_max_logspat(const string &target, float &energy, 
 					break;
 				}
 				if(DnaLookupTables::NEUTRAL_CHAR[(unsigned char)*j]) {
-					logp_rev += c_log_quarter;
+					logp_rev += p->get_avg_log_prob();
 				} else {
 					int code = DnaLookupTables::COMPLEMENT_ENCODE[(unsigned char)*j];
 					if(code >= 0) {


### PR DESCRIPTION
## Context

Companion to a `prego` fix (tanaylab/prego#40). A user asked why `prego::compute_pwm` treats `N` differently on the two strands. It turned out the shared `DnaPSSM` scan code uses the column average (`get_avg_log_prob()`) for `N`/`*` on the forward strand but a flat `log(0.25)` on the reverse strand. In prego this is an observable ~1.6 nat strand-dependent error, because `compute_pwm` feeds ambiguous bases straight through the scan.

misha carries the same asymmetry in `integrate_energy`, `integrate_energy_logspat`, and `integrate_energy_max_logspat` (the PWM-energy vtrack path).

## This change

Reverse-strand `N`/`*` now uses `get_avg_log_prob()`, matching the forward branch, the already-symmetric routines (`max_like_match`, `integrate_like_seg`), and prego's copy of the shared code.

## Scope / caveat (please read)

**This is a consistency fix with no observable behavior change for genomic scoring.** In misha, a genomic `N` reaches the scorer as a masked 0-byte and the window returns `-Inf` at the `if(!(*j))` guard *before* the `N`/`*` branch runs - verified empirically (flank windows score finitely, any `N`-containing window is `-Inf`, on both spatial and non-spatial paths). So:

- No user-visible change for PWM vtracks over real genomes.
- No positive regression test is possible (an `N`-window is always `-Inf`); correctness of the branch itself is covered by the prego test, which exercises the identical logic through an unmasked path.
- The existing PWM suite passes unchanged (no regression) - that is what CI green confirms here.

The value is keeping the two near-identical `DnaPSSM.cpp` copies from drifting, and correctness for the `*` wildcard / any future path that scores ambiguous bases without masking.

Left as-is (different, out-of-scope asymmetries): `integrate_like` / `update_like_vec` (forward `log(0.25)`, reverse `avg`); `like_thresh_match` is intentionally symmetric on `log(0.25)`.

https://claude.ai/code/session_01PK3qefBGDoBwd9w5226FEq