### PR TITLE
gseq.extract multitasking, and a fork-inherited descriptor corruption fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.12
+Version: 5.11.13
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # misha 5.11.13
 
 * **Data corruption fix:** `gtrack.create_pwm_energy()` (and, for sequence-based virtual tracks, `gtrack.smooth()`, `glookup()` and `gcis_decay()`) opened the genome sequence before forking. Forked workers share the file offset of an inherited descriptor, so on an indexed database they read each other's bytes - producing a small fraction of silently wrong values, varying run to run. Measured at 0.2% of bins on a 120 Mb scope.
-* `gseq.extract()` distributes large interval sets across processes when the sequence files are not already cached, which is where it spent nearly all of its time (19,000 intervals on an NFS database: ~200s -> ~23s). Cached extractions are unaffected - the decision is made by timing the first few reads.
+* `gseq.extract()` distributes large interval sets (500+) across processes when the sequence files are not already cached, which is where it spent nearly all of its time (19,000 intervals on an NFS database: ~200s -> ~23s). Cached extractions and densely tiled interval sets stay in one process. Note it now forks like the other multitasking functions, and peak memory roughly doubles while the result is assembled; `gmultitasking = FALSE` restores the old behaviour.
 
 # misha 5.11.12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # misha 5.11.13
 
-* **Data corruption fix:** `gtrack.create_pwm_energy()` (and, for sequence-based virtual tracks, `gtrack.smooth()` and `gcis_decay()`) opened the genome sequence before forking. Forked workers share the file offset of an inherited descriptor, so on an indexed database they read each other's bytes - producing a small fraction of silently wrong values, varying run to run. Measured at 0.2% of bins on a 120 Mb scope.
+* **Data corruption fix:** `gtrack.create_pwm_energy()` (and, for sequence-based virtual tracks, `gtrack.smooth()`, `glookup()` and `gcis_decay()`) opened the genome sequence before forking. Forked workers share the file offset of an inherited descriptor, so on an indexed database they read each other's bytes - producing a small fraction of silently wrong values, varying run to run. Measured at 0.2% of bins on a 120 Mb scope.
 * `gseq.extract()` distributes large interval sets across processes when the sequence files are not already cached, which is where it spent nearly all of its time (19,000 intervals on an NFS database: ~200s -> ~23s). Cached extractions are unaffected - the decision is made by timing the first few reads.
 
 # misha 5.11.12

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.13
+
+* **Data corruption fix:** `gtrack.create_pwm_energy()` (and, for sequence-based virtual tracks, `gtrack.smooth()` and `gcis_decay()`) opened the genome sequence before forking. Forked workers share the file offset of an inherited descriptor, so on an indexed database they read each other's bytes - producing a small fraction of silently wrong values, varying run to run. Measured at 0.2% of bins on a 120 Mb scope.
+
 # misha 5.11.12
 
 * `gtrack.import()` no longer fails on non-Linux platforms: the bundled `bigWigToWig` is a Linux x86-64 binary, so macOS/Windows now use one found on `PATH` (or `options(misha.bigWigToWig = "...")`), with an actionable error if none is installed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # misha 5.11.13
 
 * **Data corruption fix:** `gtrack.create_pwm_energy()` (and, for sequence-based virtual tracks, `gtrack.smooth()` and `gcis_decay()`) opened the genome sequence before forking. Forked workers share the file offset of an inherited descriptor, so on an indexed database they read each other's bytes - producing a small fraction of silently wrong values, varying run to run. Measured at 0.2% of bins on a 120 Mb scope.
+* `gseq.extract()` distributes large interval sets across processes when the sequence files are not already cached, which is where it spent nearly all of its time (19,000 intervals on an NFS database: ~200s -> ~23s). Cached extractions are unaffected - the decision is made by timing the first few reads.
 
 # misha 5.11.12
 

--- a/R/compute-sequence.R
+++ b/R/compute-sequence.R
@@ -157,6 +157,17 @@
 #' 'intervals'. If intervals contain an additional 'strand' column and its
 #' value is '-1', the reverse-complementary sequence is returned.
 #'
+#' Each interval costs one disk read, so large interval sets are dominated by
+#' I/O latency rather than by the sequence data itself. When the sequence files
+#' are not in the page cache, the work is split across up to 'gmax.processes'
+#' processes. The decision is made by timing the first few reads: if they are
+#' served from cache, distributing would only add fork overhead, so the whole
+#' extraction stays in one process. Set 'gseq.extract.probe.usec' to override
+#' the per-interval microsecond threshold at which distributing kicks in (0
+#' always distributes, a large value never does), or 'gmultitasking = FALSE' to
+#' disable it entirely. Named intervals sets stored in the "big" format are
+#' always read sequentially.
+#'
 #' @param intervals intervals for which DNA sequence is returned
 #' @return An array of character strings representing DNA sequence.
 #' @seealso \code{\link{gextract}}

--- a/R/compute-sequence.R
+++ b/R/compute-sequence.R
@@ -159,14 +159,25 @@
 #'
 #' Each interval costs one disk read, so large interval sets are dominated by
 #' I/O latency rather than by the sequence data itself. When the sequence files
-#' are not in the page cache, the work is split across up to 'gmax.processes'
-#' processes. The decision is made by timing the first few reads: if they are
-#' served from cache, distributing would only add fork overhead, so the whole
-#' extraction stays in one process. Set 'gseq.extract.probe.usec' to override
-#' the per-interval microsecond threshold at which distributing kicks in (0
-#' always distributes, a large value never does), or 'gmultitasking = FALSE' to
-#' disable it entirely. Named intervals sets stored in the "big" format are
-#' always read sequentially.
+#' are not in the page cache, the work is split across several processes (capped
+#' by 'gmax.processes', and in practice usually well below it). The decision is
+#' made by timing the first few reads and extrapolating over the number of
+#' read-ahead windows the intervals span: cached data, and interval sets dense
+#' enough that many intervals share a read, stay in a single process because
+#' distributing them would only add fork overhead.
+#'
+#' Sets of fewer than 500 intervals are never distributed. Named intervals sets
+#' stored in the "big" format are always read sequentially. Distributing roughly
+#' doubles peak memory while the result is being assembled, so a call close to
+#' 'gmax.data.size' may need a lower limit or 'gmultitasking = FALSE'. Note also
+#' that this function forks: calling it from inside your own 'mclapply()' or
+#' similar multiplies the process count, as it does for the other multitasking
+#' misha functions.
+#'
+#' Set 'gseq.extract.probe.usec' to override the per-interval microsecond
+#' threshold at which distributing kicks in; 0 always distributes and also
+#' requests the maximum number of processes, a large value never distributes.
+#' 'gmultitasking = FALSE' disables it entirely.
 #'
 #' @param intervals intervals for which DNA sequence is returned
 #' @return An array of character strings representing DNA sequence.

--- a/R/config-defaults.R
+++ b/R/config-defaults.R
@@ -35,5 +35,6 @@
     gmax.processes = NULL, # Auto-calculated: 70% of cores
     gmax.processes2core = 2, # Max processes per core
     gmin.scope4process = 10000, # Min genomic scope per parallel process
-    gmultitasking = TRUE # Enable/disable multitasking
+    gmultitasking = TRUE, # Enable/disable multitasking
+    gseq.extract.probe.usec = 100 # gseq.extract: measured us/interval above which it distributes
 )

--- a/R/misha-package.R
+++ b/R/misha-package.R
@@ -22,10 +22,10 @@
 #' gmax.processes \tab AUTO \tab Auto-configured to 70\% of CPU cores. \cr \tab
 #' \tab Maximal number of processes for multitasking. \cr gmax.processes2core
 #' \tab 2 \tab Maximal number of processes per CPU core for multitasking \cr
-#' gseq.extract.probe.usec \tab 100 \tab gseq.extract times its first reads and
-#' \tab \tab distributes across processes when the measured cost per interval
-#' \tab \tab reaches this many microseconds. 0 always distributes, a large
-#' \tab \tab value never does. \cr
+#' gseq.extract.probe.usec \tab 100 \tab gseq.extract times its first reads \cr
+#' \tab \tab and distributes across processes when the measured cost per \cr
+#' \tab \tab interval reaches this many microseconds. 0 always distributes, \cr
+#' \tab \tab a large value never does. \cr
 #' gmin.scope4process \tab 10000 \tab Minimal scope range (for 2D: surface)
 #' assigned to a process \cr \tab \tab in multitasking mode. \cr gbuf.size \tab
 #' 1000 \tab Size of track expression values buffer. \cr

--- a/R/misha-package.R
+++ b/R/misha-package.R
@@ -22,6 +22,10 @@
 #' gmax.processes \tab AUTO \tab Auto-configured to 70\% of CPU cores. \cr \tab
 #' \tab Maximal number of processes for multitasking. \cr gmax.processes2core
 #' \tab 2 \tab Maximal number of processes per CPU core for multitasking \cr
+#' gseq.extract.probe.usec \tab 100 \tab gseq.extract times its first reads and
+#' \tab \tab distributes across processes when the measured cost per interval
+#' \tab \tab reaches this many microseconds. 0 always distributes, a large
+#' \tab \tab value never does. \cr
 #' gmin.scope4process \tab 10000 \tab Minimal scope range (for 2D: surface)
 #' assigned to a process \cr \tab \tab in multitasking mode. \cr gbuf.size \tab
 #' 1000 \tab Size of track expression values buffer. \cr

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -35,6 +35,7 @@
     options(gbig.intervals.size = 1000000)
     options(gbuf.size = 1000)
     options(gmin.scope4process = 10000)
+    options(gseq.extract.probe.usec = 100)
     options(gmultitasking = TRUE)
 
     # gmultitasking.strategy: how gextract distributes work when gmultitasking

--- a/man/gseq.extract.Rd
+++ b/man/gseq.extract.Rd
@@ -19,6 +19,17 @@ Returns DNA sequences for given intervals
 This function returns an array of sequence strings for each interval from
 'intervals'. If intervals contain an additional 'strand' column and its
 value is '-1', the reverse-complementary sequence is returned.
+
+Each interval costs one disk read, so large interval sets are dominated by
+I/O latency rather than by the sequence data itself. When the sequence files
+are not in the page cache, the work is split across up to 'gmax.processes'
+processes. The decision is made by timing the first few reads: if they are
+served from cache, distributing would only add fork overhead, so the whole
+extraction stays in one process. Set 'gseq.extract.probe.usec' to override
+the per-interval microsecond threshold at which distributing kicks in (0
+always distributes, a large value never does), or 'gmultitasking = FALSE' to
+disable it entirely. Named intervals sets stored in the "big" format are
+always read sequentially.
 }
 \examples{
 \dontshow{

--- a/man/gseq.extract.Rd
+++ b/man/gseq.extract.Rd
@@ -22,14 +22,25 @@ value is '-1', the reverse-complementary sequence is returned.
 
 Each interval costs one disk read, so large interval sets are dominated by
 I/O latency rather than by the sequence data itself. When the sequence files
-are not in the page cache, the work is split across up to 'gmax.processes'
-processes. The decision is made by timing the first few reads: if they are
-served from cache, distributing would only add fork overhead, so the whole
-extraction stays in one process. Set 'gseq.extract.probe.usec' to override
-the per-interval microsecond threshold at which distributing kicks in (0
-always distributes, a large value never does), or 'gmultitasking = FALSE' to
-disable it entirely. Named intervals sets stored in the "big" format are
-always read sequentially.
+are not in the page cache, the work is split across several processes (capped
+by 'gmax.processes', and in practice usually well below it). The decision is
+made by timing the first few reads and extrapolating over the number of
+read-ahead windows the intervals span: cached data, and interval sets dense
+enough that many intervals share a read, stay in a single process because
+distributing them would only add fork overhead.
+
+Sets of fewer than 500 intervals are never distributed. Named intervals sets
+stored in the "big" format are always read sequentially. Distributing roughly
+doubles peak memory while the result is being assembled, so a call close to
+'gmax.data.size' may need a lower limit or 'gmultitasking = FALSE'. Note also
+that this function forks: calling it from inside your own 'mclapply()' or
+similar multiplies the process count, as it does for the other multitasking
+misha functions.
+
+Set 'gseq.extract.probe.usec' to override the per-interval microsecond
+threshold at which distributing kicks in; 0 always distributes and also
+requests the maximum number of processes, a large value never distributes.
+'gmultitasking = FALSE' disables it entirely.
 }
 \examples{
 \dontshow{

--- a/man/misha-package.Rd
+++ b/man/misha-package.Rd
@@ -29,10 +29,10 @@ processes in KB before the limiting algorithm is invoked. \cr
 gmax.processes \tab AUTO \tab Auto-configured to 70\% of CPU cores. \cr \tab
 \tab Maximal number of processes for multitasking. \cr gmax.processes2core
 \tab 2 \tab Maximal number of processes per CPU core for multitasking \cr
-gseq.extract.probe.usec \tab 100 \tab gseq.extract times its first reads and
-\tab \tab distributes across processes when the measured cost per interval
-\tab \tab reaches this many microseconds. 0 always distributes, a large
-\tab \tab value never does. \cr
+gseq.extract.probe.usec \tab 100 \tab gseq.extract times its first reads \cr
+\tab \tab and distributes across processes when the measured cost per \cr
+\tab \tab interval reaches this many microseconds. 0 always distributes, \cr
+\tab \tab a large value never does. \cr
 gmin.scope4process \tab 10000 \tab Minimal scope range (for 2D: surface)
 assigned to a process \cr \tab \tab in multitasking mode. \cr gbuf.size \tab
 1000 \tab Size of track expression values buffer. \cr

--- a/man/misha-package.Rd
+++ b/man/misha-package.Rd
@@ -29,6 +29,10 @@ processes in KB before the limiting algorithm is invoked. \cr
 gmax.processes \tab AUTO \tab Auto-configured to 70\% of CPU cores. \cr \tab
 \tab Maximal number of processes for multitasking. \cr gmax.processes2core
 \tab 2 \tab Maximal number of processes per CPU core for multitasking \cr
+gseq.extract.probe.usec \tab 100 \tab gseq.extract times its first reads and
+\tab \tab distributes across processes when the measured cost per interval
+\tab \tab reaches this many microseconds. 0 always distributes, a large
+\tab \tab value never does. \cr
 gmin.scope4process \tab 10000 \tab Minimal scope range (for 2D: surface)
 assigned to a process \cr \tab \tab in multitasking mode. \cr gbuf.size \tab
 1000 \tab Size of track expression values buffer. \cr

--- a/src/GenomeCisDecay.cpp
+++ b/src/GenomeCisDecay.cpp
@@ -28,7 +28,6 @@ SEXP C_gcis_decay(SEXP _expr, SEXP _breaks, SEXP _src_intervals, SEXP _domain_in
 		BinFinder bin_finder(REAL(_breaks), Rf_length(_breaks), LOGICAL(_include_lowest)[0]);
 
 		IntervUtils iu(_envir);
-		TrackExprScanner scanner(iu);
 		iu.verify_max_data_size(bin_finder.get_numbins(), "Result");
 		vector<uint64_t> inter_domain_dist(bin_finder.get_numbins(), 0);
 		vector<uint64_t> intra_domain_dist(bin_finder.get_numbins(), 0);
@@ -83,6 +82,11 @@ SEXP C_gcis_decay(SEXP _expr, SEXP _breaks, SEXP _src_intervals, SEXP _domain_in
 				uint64_t *inter_domain_dist = distribution + bin_finder.get_numbins();
 				memset(distribution, 0, 2 * bin_finder.get_numbins() * sizeof(uint64_t));
 
+				// Constructed AFTER the fork: TrackExprScanner opens the genome sequence eagerly on an
+				// indexed database, and forked processes share the file offset of an inherited
+				// descriptor -- kids seeking concurrently would read each other's bytes.
+				TrackExprScanner scanner(iu);
+
 				for (scanner.begin(_expr, NULL, iu.get_kid_intervals2d(), _iterator_policy, _band); !scanner.isend(); scanner.next()) {
 					const GInterval2D &interv = scanner.last_interval2d();
 					GInterval contact1(interv.chromid1(), interv.start1(), interv.end1(), 0);
@@ -120,6 +124,8 @@ SEXP C_gcis_decay(SEXP _expr, SEXP _breaks, SEXP _src_intervals, SEXP _domain_in
 				}
 			}
 		} else {   // no multitasking
+			TrackExprScanner scanner(iu);
+
 			for (scanner.begin(_expr, NULL, scope.get(), _iterator_policy, _band); !scanner.isend(); scanner.next()) {
 				const GInterval2D &interv = scanner.last_interval2d();
 				GInterval contact1(interv.chromid1(), interv.start1(), interv.end1(), 0);

--- a/src/GenomeCreatePwmEnergy.cpp
+++ b/src/GenomeCreatePwmEnergy.cpp
@@ -192,8 +192,6 @@ SEXP gcreate_pwm_energy_multitask(SEXP _track, SEXP _pssmset, SEXP _pssmid, SEXP
 		pssm_set.read(pssmkey_filename, pssmdata_filename, prior);
 
 		DnaPSSM &pssm = pssm_set.get_pssm(pssmid);
-		GenomeSeqFetch seqfetch;
-		seqfetch.set_seqdir(seqdir);
 		IntervUtils iu(_envir);
 		GIntervals scope;
 		iu.get_all_genome_intervs(scope);
@@ -212,6 +210,13 @@ SEXP gcreate_pwm_energy_multitask(SEXP _track, SEXP _pssmset, SEXP _pssmid, SEXP
 			GenomeTrackSparse sparse_track;
 			GInterval cur_interval(-1, -1, -1, -1);
 			char filename[PATH_MAX];
+
+			// Must be opened AFTER the fork: forked processes share the file offset of an
+			// inherited descriptor, so kids seeking concurrently would read each other's bytes.
+			// On an indexed genome set_seqdir() opens genome.seq immediately, so opening it in
+			// the parent would hand every kid the same descriptor.
+			GenomeSeqFetch seqfetch;
+			seqfetch.set_seqdir(seqdir);
 
 			Progress_reporter progress;
 			progress.init(kid_intervals1d->range(), 1000000);

--- a/src/GenomeSeqFetch.h
+++ b/src/GenomeSeqFetch.h
@@ -21,6 +21,14 @@ class GenomeIndex;
 
 // -------------------- GenomeSeqFetch  -----------------------
 // !!!!!!!!! IN CASE OF ERROR THIS CLASS THROWS TGLException  !!!!!!!!!!!!!!!!
+//
+// !!!!!!!!! NEVER READ THROUGH ONE INSTANCE FROM SEVERAL FORKED PROCESSES !!!!!!!!!!!!!!!!
+// Forked processes inherit the same open file description, i.e. the same file offset, so two
+// children seeking and reading concurrently hand each other's bytes back -- silently, with the
+// right length and the wrong bases. Multitasking code must construct its GenomeSeqFetch (and
+// anything owning one, such as TrackExprScanner) AFTER distribute_task() returns in the child.
+// set_seqdir() opens genome.seq immediately on an indexed database, and the per-chromosome mode
+// keeps its file open across reads, so both formats are affected.
 
 class GenomeSeqFetch {
 public:

--- a/src/GenomeSeqRead.cpp
+++ b/src/GenomeSeqRead.cpp
@@ -76,7 +76,10 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 		// Only in-memory interval sets are distributed; big sets stay on the serial path.
 		GIntervals *plain_intervals = dynamic_cast<GIntervals *>(intervals);
 
-		if (iu.get_multitasking() && plain_intervals && num_intervs >= SEQ_MIN_INTERVALS4MT) {
+		// A kid must not fork again: the nested distribute_task would find the outer job's shared
+		// memory already mapped and reuse its record size and offsets.
+		if (iu.get_multitasking() && !RdbInitializer::is_kid() &&
+			plain_intervals && num_intervs >= SEQ_MIN_INTERVALS4MT) {
 			struct timespec probe_start, probe_end;
 
 			// The probed sequences are kept, so a probe that decides against forking costs nothing.
@@ -125,7 +128,20 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 			for (GIntervals::const_iterator iinterv = plain_intervals->begin() + num_probed; iinterv != plain_intervals->end(); ++iinterv)
 				max_res_bytes += (uint64_t)iinterv->range();
 
-			if (iu.distribute_task(0, 1, rdb::MT_MODE_MMAP, max_res_bytes)) { // child
+			// Shared memory big enough for the whole result may not be available even though the
+			// sequential path would have coped; fall through to it rather than failing outright,
+			// the same way gscreen/gextract retry without multitasking.
+			bool do_child;
+			try {
+				do_child = iu.distribute_task(0, 1, rdb::MT_MODE_MMAP, max_res_bytes);
+			} catch (TGLException &e) {
+				if (!strstr(e.msg(), "Failed to allocate shared memory"))
+					throw;
+				num_kids = 0;   // nothing has been forked yet: the mmap happens first
+				do_child = false;
+			}
+
+			if (num_kids > 1 && do_child) { // child
 				GIntervalsFetcher1D *kid_intervals = iu.get_kid_intervals1d();
 				vector<char> packed;
 
@@ -159,8 +175,11 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 
 				rreturn(R_NilValue);
 			}
+		}
 
+		if (num_kids > 1) {
 			// parent: reassemble the kids' records into the original row order
+			uint64_t num_distributed = num_intervs - num_probed;
 			uint64_t num_unpacked = 0;
 
 			for (int ikid = 0; ikid < get_num_kids(); ++ikid) {

--- a/src/GenomeSeqRead.cpp
+++ b/src/GenomeSeqRead.cpp
@@ -28,6 +28,40 @@ static const double   SEQ_MIN_USEC4PROCESS = 100000.;  // give each kid ~10x the
 // One shared-memory record: [uint64 original row index][uint64 sequence length][length bytes]
 static const uint64_t SEQ_REC_HEADER = 2 * sizeof(uint64_t);
 
+// Reads are served out of BufferedFile's read-ahead window, so the unit of I/O cost is a window
+// miss, not an interval: 5000 tiled 200 bp intervals over 1 Mb touch 8 windows, not 5000. Counting
+// the windows a (sorted) interval range spans lets the probe below extrapolate by window instead of
+// by interval. Timing per interval and scaling by interval count overestimates a clustered set by
+// however many intervals share a window - measured 4.9x SLOWER than sequential on a cold tiled scan
+// before this was accounted for.
+static uint64_t count_readahead_windows(GIntervals::const_iterator ibegin, GIntervals::const_iterator iend)
+{
+	uint64_t windows = 0;
+	int last_chromid = -1;
+	int64_t last_window = -1;
+
+	for (GIntervals::const_iterator iinterv = ibegin; iinterv != iend; ++iinterv) {
+		int64_t first = iinterv->start / (int64_t)SEQ_INTERVAL_OVERHEAD;
+		int64_t last = max(iinterv->end - 1, iinterv->start) / (int64_t)SEQ_INTERVAL_OVERHEAD;
+
+		if (iinterv->chromid != last_chromid) {
+			windows += last - first + 1;
+			last_chromid = iinterv->chromid;
+			last_window = last;
+		} else {
+			// intervals are sorted, so only the part past the previous interval is a fresh miss
+			int64_t from = max(first, last_window + 1);
+
+			if (last >= from)
+				windows += last - from + 1;
+			if (last > last_window)
+				last_window = last;
+		}
+	}
+
+	return windows;
+}
+
 // gseq.extract.probe.usec overrides SEQ_PROBE_MIN_USEC: 0 always distributes (which is how the
 // tests reach the parallel path on a cached example genome), a huge value never does.
 static double get_probe_min_usec()
@@ -100,19 +134,30 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 
 			// CLOCK_REALTIME to match the rest of misha (macOS builds shim it); a backwards NTP
 			// step would only cost us one missed chance to distribute, so clamp and move on.
-			double usec_per_interv = ((probe_end.tv_sec - probe_start.tv_sec) * 1000000. +
-									  (probe_end.tv_nsec - probe_start.tv_nsec) / 1000.) / num_probed;
+			double probe_usec = (probe_end.tv_sec - probe_start.tv_sec) * 1000000. +
+								(probe_end.tv_nsec - probe_start.tv_nsec) / 1000.;
 
-			if (usec_per_interv < 0.)
-				usec_per_interv = 0.;
+			if (probe_usec < 0.)
+				probe_usec = 0.;
+
+			// Cost per read-ahead window, extrapolated over the windows the whole set spans, then
+			// amortised back over the intervals. A clustered set has far fewer windows than
+			// intervals and so lands below the threshold, which is what keeps it sequential.
+			uint64_t probe_windows = count_readahead_windows(plain_intervals->begin(),
+															 plain_intervals->begin() + num_probed);
+			uint64_t total_windows = count_readahead_windows(plain_intervals->begin(),
+															 plain_intervals->end());
+			double usec_per_interv = probe_usec / (double)max<uint64_t>(1, probe_windows) *
+									 (double)total_windows / (double)num_intervs;
 
 			double probe_min_usec = get_probe_min_usec();
 
 			if (usec_per_interv >= probe_min_usec) {
 				// A zero threshold means "always distribute"; otherwise scale the number of kids to
 				// the measured cost so each one gets meaningfully more work than forking it costs.
+				double kids_by_cost = usec_per_interv * num_intervs / SEQ_MIN_USEC4PROCESS;
 				uint64_t desired_kids = probe_min_usec > 0 ?
-					(uint64_t)(usec_per_interv * num_intervs / SEQ_MIN_USEC4PROCESS) : (uint64_t)-1;
+					(uint64_t)min(kids_by_cost, (double)MAX_KIDS) : (uint64_t)MAX_KIDS;
 
 				num_kids = iu.prepare4multitasking_whole_intervals(plain_intervals->begin() + num_probed,
 																   plain_intervals->end(),
@@ -125,8 +170,17 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 
 			// A sequence is never longer than its interval, so this bounds the shared memory.
 			uint64_t max_res_bytes = num_distributed * SEQ_REC_HEADER;
-			for (GIntervals::const_iterator iinterv = plain_intervals->begin() + num_probed; iinterv != plain_intervals->end(); ++iinterv)
+			uint64_t max_seqlen = seqlen;
+			for (GIntervals::const_iterator iinterv = plain_intervals->begin() + num_probed; iinterv != plain_intervals->end(); ++iinterv) {
 				max_res_bytes += (uint64_t)iinterv->range();
+				max_seqlen += (uint64_t)iinterv->range();
+			}
+
+			// Check the same quantity the sequential path checks, up front. Otherwise the per-record
+			// headers push an over-budget call past the limit only once the kids have already done
+			// all the I/O, and it reports the generic shared-memory message instead of the one
+			// naming the sizes and gmax.data.size.
+			iu.verify_max_data_size(max_seqlen, "Result sequence");
 
 			// Shared memory big enough for the whole result may not be available even though the
 			// sequential path would have coped; fall through to it rather than failing outright,
@@ -135,14 +189,19 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 			try {
 				do_child = iu.distribute_task(0, 1, rdb::MT_MODE_MMAP, max_res_bytes);
 			} catch (TGLException &e) {
-				if (!strstr(e.msg(), "Failed to allocate shared memory"))
+				// Only safe while nothing has been forked; the mmap happens before the first
+				// launch_process(), so get_num_kids() is still 0. If that ever stops holding,
+				// re-reading everything serially would race the orphaned children.
+				if (!strstr(e.msg(), "Failed to allocate shared memory") || get_num_kids())
 					throw;
-				num_kids = 0;   // nothing has been forked yet: the mmap happens first
+				num_kids = 0;
 				do_child = false;
 			}
 
 			if (num_kids > 1 && do_child) { // child
 				GIntervalsFetcher1D *kid_intervals = iu.get_kid_intervals1d();
+				uint64_t kid_num_intervs = kid_intervals->size();
+				uint64_t num_read = 0;
 				vector<char> packed;
 
 				// The seqfetch above was opened before the fork, and forked processes SHARE the
@@ -165,6 +224,9 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 					memcpy(&packed[offset + sizeof(idx)], &len, sizeof(len));
 					if (len)
 						memcpy(&packed[offset + SEQ_REC_HEADER], &buf[0], len);
+
+					if (++num_read % 128 == 0)
+						update_progress((unsigned char)(100 * num_read / max<uint64_t>(1, kid_num_intervs)));
 
 					check_interrupt();
 				}

--- a/src/GenomeSeqRead.cpp
+++ b/src/GenomeSeqRead.cpp
@@ -1,4 +1,6 @@
 #include <cstdint>
+#include <cstring>
+#include <ctime>
 #include "GIntervalsBigSet1D.h"
 #include "GenomeSeqFetch.h"
 #include "GenomeIndex.h"
@@ -7,6 +9,37 @@
 
 using namespace std;
 using namespace rdb;
+
+// Cost of one interval expressed in "range" units so it can be summed with interval lengths:
+// a seek plus BufferedFile's 128 KB read-ahead window (see BufferedFile::read). On a cold page
+// cache that dominates no matter how few bases were asked for, so balancing kids by bases alone
+// would badly skew a many-small-intervals workload.
+static const uint64_t SEQ_INTERVAL_OVERHEAD = 131072;
+
+// Whether distributing pays depends almost entirely on whether the pages are already cached: a
+// cold read costs milliseconds, a cached one well under a microsecond, and forking a process
+// costs ~10 ms. That is a four-orders-of-magnitude spread, so no static interval count can
+// decide it -- instead the first few intervals are read serially and timed.
+static const uint64_t SEQ_PROBE_INTERVALS = 16;
+static const uint64_t SEQ_MIN_INTERVALS4MT = 500;    // below this even a cold read cannot repay a fork
+static const double   SEQ_PROBE_MIN_USEC = 100.;     // per interval, above which we are I/O bound
+static const double   SEQ_MIN_USEC4PROCESS = 100000.;  // give each kid ~10x the cost of forking it
+
+// One shared-memory record: [uint64 original row index][uint64 sequence length][length bytes]
+static const uint64_t SEQ_REC_HEADER = 2 * sizeof(uint64_t);
+
+// gseq.extract.probe.usec overrides SEQ_PROBE_MIN_USEC: 0 always distributes (which is how the
+// tests reach the parallel path on a cached example genome), a huge value never does.
+static double get_probe_min_usec()
+{
+	SEXP opt = Rf_GetOption1(Rf_install("gseq.extract.probe.usec"));
+
+	if (Rf_isReal(opt) && Rf_length(opt) == 1 && !ISNAN(REAL(opt)[0]))
+		return REAL(opt)[0];
+	if (Rf_isInteger(opt) && Rf_length(opt) == 1 && INTEGER(opt)[0] != NA_INTEGER)
+		return (double)INTEGER(opt)[0];
+	return SEQ_PROBE_MIN_USEC;
+}
 
 extern "C" {
 
@@ -21,27 +54,157 @@ SEXP gseqread(SEXP _intervals, SEXP _envir)
 		unique_ptr<GIntervalsFetcher1D> intervals_guard(intervals);
 		intervals->sort();
 
-		if (!intervals->size())
+		uint64_t num_intervs = intervals->size();
+		if (!num_intervs)
 			return R_NilValue;
 
-        vector<char> buf;
-        // Reserve based on a heuristic: start with 256KB and grow as needed
-        buf.reserve(262144);
 		SEXP answer;
-		rprotect(answer = RSaneAllocVector(STRSXP, intervals->size()));
+		rprotect(answer = RSaneAllocVector(STRSXP, num_intervs));
+
+		string seqdir = string(rdb::get_groot(_envir)) + "/seq";
+		GenomeSeqFetch seqfetch;
+		seqfetch.set_seqdir(seqdir);
+
+		vector<char> buf;
+		// Reserve based on a heuristic: start with 256KB and grow as needed
+		buf.reserve(262144);
 
 		uint64_t seqlen = 0;
-		GenomeSeqFetch seqfetch;
-		seqfetch.set_seqdir(string(rdb::get_groot(_envir)) + "/seq");
+		uint64_t num_probed = 0;
+		int num_kids = 0;
+
+		// Only in-memory interval sets are distributed; big sets stay on the serial path.
+		GIntervals *plain_intervals = dynamic_cast<GIntervals *>(intervals);
+
+		if (iu.get_multitasking() && plain_intervals && num_intervs >= SEQ_MIN_INTERVALS4MT) {
+			struct timespec probe_start, probe_end;
+
+			// The probed sequences are kept, so a probe that decides against forking costs nothing.
+			num_probed = min(num_intervs, SEQ_PROBE_INTERVALS);
+			clock_gettime(CLOCK_REALTIME, &probe_start);
+
+			for (uint64_t i = 0; i < num_probed; ++i) {
+				const GInterval &interval = (*plain_intervals)[i];
+
+				seqfetch.read_interval(interval, iu.get_chromkey(), buf);
+				seqlen += buf.size();
+				SET_STRING_ELT(answer, iu.get_orig_interv_idx(interval),
+							   Rf_mkCharLenCE(buf.empty() ? "" : &buf[0], (int)buf.size(), CE_NATIVE));
+			}
+
+			clock_gettime(CLOCK_REALTIME, &probe_end);
+			iu.verify_max_data_size(seqlen, "Result sequence");
+
+			// CLOCK_REALTIME to match the rest of misha (macOS builds shim it); a backwards NTP
+			// step would only cost us one missed chance to distribute, so clamp and move on.
+			double usec_per_interv = ((probe_end.tv_sec - probe_start.tv_sec) * 1000000. +
+									  (probe_end.tv_nsec - probe_start.tv_nsec) / 1000.) / num_probed;
+
+			if (usec_per_interv < 0.)
+				usec_per_interv = 0.;
+
+			double probe_min_usec = get_probe_min_usec();
+
+			if (usec_per_interv >= probe_min_usec) {
+				// A zero threshold means "always distribute"; otherwise scale the number of kids to
+				// the measured cost so each one gets meaningfully more work than forking it costs.
+				uint64_t desired_kids = probe_min_usec > 0 ?
+					(uint64_t)(usec_per_interv * num_intervs / SEQ_MIN_USEC4PROCESS) : (uint64_t)-1;
+
+				num_kids = iu.prepare4multitasking_whole_intervals(plain_intervals->begin() + num_probed,
+																   plain_intervals->end(),
+																   SEQ_INTERVAL_OVERHEAD, desired_kids);
+			}
+		}
+
+		if (num_kids > 1) {
+			uint64_t num_distributed = num_intervs - num_probed;
+
+			// A sequence is never longer than its interval, so this bounds the shared memory.
+			uint64_t max_res_bytes = num_distributed * SEQ_REC_HEADER;
+			for (GIntervals::const_iterator iinterv = plain_intervals->begin() + num_probed; iinterv != plain_intervals->end(); ++iinterv)
+				max_res_bytes += (uint64_t)iinterv->range();
+
+			if (iu.distribute_task(0, 1, rdb::MT_MODE_MMAP, max_res_bytes)) { // child
+				GIntervalsFetcher1D *kid_intervals = iu.get_kid_intervals1d();
+				vector<char> packed;
+
+				// The seqfetch above was opened before the fork, and forked processes SHARE the
+				// file offset of an inherited descriptor -- concurrent seeks would hand a kid
+				// another kid's bytes. Open our own.
+				GenomeSeqFetch kid_seqfetch;
+				kid_seqfetch.set_seqdir(seqdir);
+
+				for (kid_intervals->begin_iter(); !kid_intervals->isend(); kid_intervals->next()) {
+					const GInterval &interval = kid_intervals->cur_interval();
+
+					kid_seqfetch.read_interval(interval, iu.get_chromkey(), buf);
+
+					uint64_t idx = iu.get_orig_interv_idx(interval);
+					uint64_t len = buf.size();
+					size_t offset = packed.size();
+
+					packed.resize(offset + SEQ_REC_HEADER + len);
+					memcpy(&packed[offset], &idx, sizeof(idx));
+					memcpy(&packed[offset + sizeof(idx)], &len, sizeof(len));
+					if (len)
+						memcpy(&packed[offset + SEQ_REC_HEADER], &buf[0], len);
+
+					check_interrupt();
+				}
+
+				void *res = allocate_res(packed.size());
+				if (!packed.empty())
+					memcpy(res, &packed[0], packed.size());
+
+				rreturn(R_NilValue);
+			}
+
+			// parent: reassemble the kids' records into the original row order
+			uint64_t num_unpacked = 0;
+
+			for (int ikid = 0; ikid < get_num_kids(); ++ikid) {
+				const char *ptr = (const char *)get_kid_res(ikid);
+				const char *end = ptr + get_kid_res_size(ikid);
+
+				while (ptr < end) {
+					uint64_t idx, len;
+
+					if ((uint64_t)(end - ptr) < SEQ_REC_HEADER)
+						verror("Truncated sequence record from process %d", ikid);
+					memcpy(&idx, ptr, sizeof(idx));
+					memcpy(&len, ptr + sizeof(idx), sizeof(len));
+					ptr += SEQ_REC_HEADER;
+
+					if (idx >= num_intervs || (uint64_t)(end - ptr) < len)
+						verror("Corrupted sequence record from process %d", ikid);
+
+					SET_STRING_ELT(answer, idx, Rf_mkCharLenCE(ptr, (int)len, CE_NATIVE));
+					ptr += len;
+					++num_unpacked;
+				}
+			}
+
+			if (num_unpacked != num_distributed)
+				verror("Got sequences for %llu intervals out of %llu",
+					   (unsigned long long)num_unpacked, (unsigned long long)num_distributed);
+
+			return answer;
+		}
+
+		uint64_t iinterv_idx = 0;
 
 		for (intervals->begin_iter(); !intervals->isend(); intervals->next()) {
+			if (iinterv_idx++ < num_probed)   // already read (and kept) by the probe above
+				continue;
+
 			seqfetch.read_interval(intervals->cur_interval(), iu.get_chromkey(), buf);
-            seqlen += buf.size();
+			seqlen += buf.size();
 			iu.verify_max_data_size(seqlen, "Result sequence");
-            // Avoid strlen by constructing string with known length
-            SET_STRING_ELT(answer,
-                           iu.get_orig_interv_idx(intervals->cur_interval()),
-                           Rf_mkCharLenCE(&*buf.begin(), (int)buf.size(), CE_NATIVE));
+			// Avoid strlen by constructing string with known length
+			SET_STRING_ELT(answer,
+						   iu.get_orig_interv_idx(intervals->cur_interval()),
+						   Rf_mkCharLenCE(buf.empty() ? "" : &buf[0], (int)buf.size(), CE_NATIVE));
 			check_interrupt();
 		}
 		return answer;

--- a/src/GenomeTrackBinnedTransform.cpp
+++ b/src/GenomeTrackBinnedTransform.cpp
@@ -304,6 +304,13 @@ SEXP gbintransform(SEXP _intervals, SEXP _track_exprs, SEXP _breaks, SEXP _inclu
 								   rdb::MT_MODE_MMAP,
 								   estimated_records))
 			{  // child process
+				// Constructed AFTER the fork, and deliberately shadowing the one above (as the
+				// intervals.set.out branch already does): TrackExprScanner opens the genome
+				// sequence eagerly on an indexed database, and forked processes share the file
+				// offset of an inherited descriptor -- kids seeking concurrently would read each
+				// other's bytes. The outer scanner stays for the non-multitasking paths.
+				TrackExprScanner scanner(iu);
+
 				for (scanner.begin(_track_exprs, iu.get_kid_intervals1d(), iu.get_kid_intervals2d(), _iterator_policy, _band); !scanner.isend(); scanner.next()) {
 					if (scanner.get_iterator()->is_1d()) {
 						out_intervals1d.push_back(scanner.last_interval1d());

--- a/src/GenomeTrackSmooth.cpp
+++ b/src/GenomeTrackSmooth.cpp
@@ -352,7 +352,6 @@ SEXP gsmooth(SEXP _track, SEXP _expr, SEXP _winsize, SEXP _weight_thr, SEXP _smo
 		string dirname = create_track_dir(_envir, track);
 
 		IntervUtils iu(_envir);
-		TrackExprScanner scanner(iu);
 		int cur_scope_idx = -1;
 		char filename[FILENAME_MAX];
 		GenomeTrackFixedBin gtrack;
@@ -365,6 +364,11 @@ SEXP gsmooth(SEXP _track, SEXP _expr, SEXP _winsize, SEXP _weight_thr, SEXP _smo
 		if (!iu.get_multitasking() || iu.distribute_task(0, 0)) {  // child process
 			GIntervalsFetcher1D &scanner_intervals1d = iu.get_multitasking() ? *iu.get_kid_intervals1d() : all_genome_intervs;
 			Smoother *smoother = NULL;
+
+			// Constructed AFTER the fork: TrackExprScanner opens the genome sequence eagerly on an
+			// indexed database, and forked processes share the file offset of an inherited
+			// descriptor -- kids seeking concurrently would read each other's bytes.
+			TrackExprScanner scanner(iu);
 
 			scanner.begin(_expr, &scanner_intervals1d, NULL, _iterator_policy);
 

--- a/src/rdbinterval.cpp
+++ b/src/rdbinterval.cpp
@@ -695,6 +695,10 @@ int IntervUtils::prepare4multitasking_whole_intervals(GIntervals::const_iterator
 	int num_cores = max(1, (int)sysconf(_SC_NPROCESSORS_ONLN));
 	uint64_t max_num_pids = max<uint64_t>(1, min(get_max_processes2core() * (uint64_t)num_cores, get_max_processes()));
 
+	// The chromosome-based splitters are implicitly bounded by the number of chromosomes; this one
+	// is not, so cap it before RdbInitializer::prepare4multitasking errors out on MAX_KIDS.
+	max_num_pids = min(max_num_pids, (uint64_t)MAX_KIDS);
+
 	uint64_t num_kids = min(desired_kids, max_num_pids);
 	num_kids = min(num_kids, (uint64_t)(iend - ibegin));
 

--- a/src/rdbinterval.cpp
+++ b/src/rdbinterval.cpp
@@ -675,6 +675,50 @@ int IntervUtils::prepare4multitasking(GIntervalsFetcher1D *scope1d, GIntervalsFe
 	return m_num_planned_kids;
 }
 
+int IntervUtils::prepare4multitasking_whole_intervals(GIntervals::const_iterator ibegin, GIntervals::const_iterator iend,
+													  uint64_t interval_overhead, uint64_t desired_kids)
+{
+	m_kids_intervals1d.clear();
+	m_kids_intervals2d.clear();
+	m_num_planned_kids = 0;
+
+	if (ibegin >= iend)
+		return 0;
+
+	uint64_t total_work = 0;
+	for (GIntervals::const_iterator iinterv = ibegin; iinterv != iend; ++iinterv)
+		total_work += (uint64_t)iinterv->range() + interval_overhead;
+
+	if (!total_work)
+		return 0;
+
+	int num_cores = max(1, (int)sysconf(_SC_NPROCESSORS_ONLN));
+	uint64_t max_num_pids = max<uint64_t>(1, min(get_max_processes2core() * (uint64_t)num_cores, get_max_processes()));
+
+	uint64_t num_kids = min(desired_kids, max_num_pids);
+	num_kids = min(num_kids, (uint64_t)(iend - ibegin));
+
+	if (num_kids < 2)
+		return 0;
+
+	// Kid k takes the intervals whose cumulative work falls in [k/num_kids, (k+1)/num_kids) of the
+	// total. The boundary is tested before appending, so every kid gets at least one interval even
+	// when a single huge interval spans several shares.
+	m_kids_intervals1d.push_back(new GIntervals());
+
+	uint64_t cum_work = 0;
+	for (GIntervals::const_iterator iinterv = ibegin; iinterv != iend; ++iinterv) {
+		if (m_kids_intervals1d.size() < num_kids && cum_work * num_kids >= total_work * m_kids_intervals1d.size())
+			m_kids_intervals1d.push_back(new GIntervals());
+
+		((GIntervals *)m_kids_intervals1d.back())->push_back(*iinterv);
+		cum_work += (uint64_t)iinterv->range() + interval_overhead;
+	}
+
+	m_num_planned_kids = m_kids_intervals1d.size();
+	return m_num_planned_kids;
+}
+
 static uint64_t estimate_fixed_bin_bins(GIntervalsFetcher1D *intervals1d, int64_t binsize)
 {
 	if (!intervals1d || binsize <= 0)

--- a/src/rdbinterval.h
+++ b/src/rdbinterval.h
@@ -410,6 +410,16 @@ public:
 	int prepare4multitasking(GIntervalsFetcher1D *scope1D, GIntervalsFetcher2D *scope2d, int64_t split_align_1d = 0,
 							 bool allow_multichrom_1d_range_split = false);
 
+	// Splits [ibegin, iend) into contiguous chunks of WHOLE intervals, one per kid, balanced by
+	// range() + interval_overhead. Unlike the two functions above it can split inside a chromosome
+	// but never cuts an interval, so each interval's udata (its original row index) still maps to
+	// exactly one result slot -- which is what per-interval results such as gseq.extract need.
+	// interval_overhead models the fixed per-interval cost (seek + read-ahead) in range units.
+	// desired_kids is capped by max_processes and by the number of intervals.
+	// Returns the number of planned kids, or 0 if that comes out below 2.
+	int prepare4multitasking_whole_intervals(GIntervals::const_iterator ibegin, GIntervals::const_iterator iend,
+											 uint64_t interval_overhead, uint64_t desired_kids);
+
 	// multi-tasking: divides intervals and forks child processes each with its own kid_intervals.
 	// Returns true if a child, false if a parent.
 	bool distribute_task(uint64_t res_const_size,    // data size in bytes for all the result

--- a/tests/testthat/test-gseq-extract-parallel.R
+++ b/tests/testthat/test-gseq-extract-parallel.R
@@ -1,5 +1,15 @@
 create_isolated_test_db()
 
+# COVERAGE LIMIT, read before trusting this file: every test here asserts
+# parallel == sequential. That is the right correctness property, but it is also
+# satisfied when the multitasking path never runs - so if the gate silently stopped
+# engaging (SEQ_MIN_INTERVALS4MT raised, the dynamic_cast regressing to NULL,
+# prepare4multitasking_whole_intervals returning 0), every test below would still
+# pass. There is currently no observable from R that says "this call forked", so
+# that failure mode is unguarded here. It was checked by hand for this change
+# (forced-parallel is ~1000x slower than sequential on warm data, and 41 live
+# children were observed during a long extraction) but nothing re-checks it.
+
 # gseq.extract decides whether to distribute by timing its first few reads, and the test DB is
 # always in the page cache, so it would (correctly) stay sequential here. gseq.extract.probe.usec = 0
 # means "always distribute" and is what lets these tests reach the multitasking path at all.
@@ -121,9 +131,24 @@ test_that("gseq.extract timing probe does not disturb the sequential result", {
 })
 
 test_that("gseq.extract multitasking still enforces gmax.data.size", {
+    # The limit has to be above what the 16-interval timing probe reads (16 x 100 b) and below the
+    # whole result, or the probe's own check throws and the multitasking path is never reached.
     set.seed(9)
-    intervs <- rand_intervs(1500)
-    expect_error(
-        withr::with_options(c(parallel_opts(), list(gmax.data.size = 1000)), gseq.extract(intervs))
+    intervs <- rand_intervs(1500) # 150,000 b total
+    limit <- 50000
+
+    parallel_err <- tryCatch(
+        withr::with_options(c(parallel_opts(), list(gmax.data.size = limit)), gseq.extract(intervs)),
+        error = conditionMessage
     )
+    sequential_err <- tryCatch(
+        withr::with_options(list(gmultitasking = FALSE, gmax.data.size = limit), gseq.extract(intervs)),
+        error = conditionMessage
+    )
+
+    # Both paths must refuse, and with the message that names gmax.data.size - the multitasking
+    # path used to fail later and with the generic shared-memory wording instead.
+    expect_match(parallel_err, "Result sequence size")
+    expect_match(parallel_err, "gmax.data.size")
+    expect_match(sequential_err, "Result sequence size")
 })

--- a/tests/testthat/test-gseq-extract-parallel.R
+++ b/tests/testthat/test-gseq-extract-parallel.R
@@ -1,0 +1,129 @@
+create_isolated_test_db()
+
+# gseq.extract decides whether to distribute by timing its first few reads, and the test DB is
+# always in the page cache, so it would (correctly) stay sequential here. gseq.extract.probe.usec = 0
+# means "always distribute" and is what lets these tests reach the multitasking path at all.
+parallel_opts <- function(processes = 4) {
+    list(gmultitasking = TRUE, gseq.extract.probe.usec = 0, gmax.processes = processes)
+}
+
+# Below 500 intervals gseq.extract never distributes, so every fixture here is comfortably above it.
+rand_intervs <- function(n, size = 100, chroms = NULL) {
+    all_chroms <- gintervals.all()
+    if (!is.null(chroms)) {
+        all_chroms <- all_chroms[as.character(all_chroms$chrom) %in% chroms, ]
+    }
+    i <- sample(nrow(all_chroms), n, replace = TRUE)
+    starts <- floor(runif(n) * (all_chroms$end[i] - size))
+    data.frame(
+        chrom = as.character(all_chroms$chrom[i]),
+        start = starts, end = starts + size,
+        stringsAsFactors = FALSE
+    )
+}
+
+extract_seq <- function(intervals) {
+    withr::with_options(list(gmultitasking = FALSE), gseq.extract(intervals))
+}
+
+extract_par <- function(intervals, processes = 4) {
+    withr::with_options(parallel_opts(processes), gseq.extract(intervals))
+}
+
+test_that("gseq.extract multitasking matches sequential across chromosomes", {
+    set.seed(1)
+    intervs <- rand_intervs(2000)
+    expect_identical(extract_par(intervs), extract_seq(intervs))
+})
+
+test_that("gseq.extract multitasking splits within a single chromosome", {
+    # The generic scope splitter only cuts on chromosome boundaries; gseq.extract needs whole
+    # intervals, so it uses its own splitter, and a single-chromosome set is what exercises it.
+    set.seed(2)
+    chrom <- as.character(gintervals.all()$chrom[1])
+    intervs <- rand_intervs(2000, chroms = chrom)
+    expect_identical(extract_par(intervs), extract_seq(intervs))
+})
+
+test_that("gseq.extract multitasking preserves the original row order", {
+    set.seed(3)
+    intervs <- rand_intervs(1500)
+    intervs <- intervs[sample(nrow(intervs)), ]
+    rownames(intervs) <- NULL
+
+    seqs <- extract_par(intervs)
+    expect_identical(seqs, extract_seq(intervs))
+    # independent check: a handful of rows extracted one at a time
+    idx <- sample(nrow(intervs), 10)
+    single <- vapply(idx, function(i) extract_seq(intervs[i, ]), character(1))
+    expect_identical(single, seqs[idx])
+})
+
+test_that("gseq.extract multitasking reverse-complements per interval", {
+    set.seed(4)
+    intervs <- rand_intervs(1500)
+    intervs$strand <- sample(c(-1L, 1L), nrow(intervs), replace = TRUE)
+    expect_identical(extract_par(intervs), extract_seq(intervs))
+
+    intervs$strand <- -1L
+    expect_identical(extract_par(intervs), extract_seq(intervs))
+})
+
+test_that("gseq.extract multitasking handles duplicated and overlapping intervals", {
+    set.seed(5)
+    intervs <- rand_intervs(100)
+    intervs <- intervs[rep(seq_len(nrow(intervs)), 15), ]
+    rownames(intervs) <- NULL
+    expect_identical(extract_par(intervs), extract_seq(intervs))
+})
+
+test_that("gseq.extract multitasking balances heavily skewed interval sizes", {
+    set.seed(6)
+    intervs <- rand_intervs(1500, size = 1)
+    big <- rand_intervs(20, size = 100000)
+    intervs <- rbind(intervs, big)
+    expect_identical(extract_par(intervs), extract_seq(intervs))
+})
+
+test_that("gseq.extract result does not depend on the number of processes", {
+    set.seed(7)
+    intervs <- rand_intervs(2000)
+    expected <- extract_seq(intervs)
+    for (processes in c(1, 2, 8, 16)) {
+        expect_identical(extract_par(intervs, processes), expected)
+    }
+})
+
+test_that("gseq.extract falls back to sequential for big intervals sets", {
+    set.seed(8)
+    intervs <- rand_intervs(1500)
+    withr::local_options(list(gbig.intervals.size = 100))
+    set_name <- paste0("bigseq_", paste(sample(letters, 8, replace = TRUE), collapse = ""))
+    gintervals.save(set_name, intervs)
+    withr::defer(gintervals.rm(set_name, force = TRUE))
+
+    expect_true(misha:::.gintervals.is_bigset(set_name))
+    expect_identical(extract_par(set_name), extract_seq(set_name))
+    expect_identical(extract_par(set_name), extract_seq(gintervals.load(set_name)))
+})
+
+test_that("gseq.extract timing probe does not disturb the sequential result", {
+    # With default options on a cached DB the probe reads the first few intervals and the rest is
+    # read sequentially; an off-by-one in that hand-off would corrupt or blank the leading rows.
+    set.seed(10)
+    for (n in c(499, 500, 501, 2000)) {
+        intervs <- rand_intervs(n)
+        expect_identical(
+            withr::with_options(list(gmultitasking = TRUE), gseq.extract(intervs)),
+            extract_seq(intervs)
+        )
+    }
+})
+
+test_that("gseq.extract multitasking still enforces gmax.data.size", {
+    set.seed(9)
+    intervs <- rand_intervs(1500)
+    expect_error(
+        withr::with_options(c(parallel_opts(), list(gmax.data.size = 1000)), gseq.extract(intervs))
+    )
+})

--- a/tests/testthat/test-motifs.R
+++ b/tests/testthat/test-motifs.R
@@ -13,3 +13,48 @@ test_that("gtrack.create_pwm_energy works", {
     .misha$ALLGENOME <- allgenome
     expect_regression(r, "gtrack.create_pwm_energy")
 })
+
+test_that("gtrack.create_pwm_energy multitasking matches sequential on an indexed database", {
+    # gtrack.create_pwm_energy used to open the genome sequence before forking, and forked
+    # processes share the file offset of an inherited descriptor -- on an indexed database, where
+    # set_seqdir() opens genome.seq immediately, the workers then handed each other's bytes back.
+    # Reproducing the race needs slow (networked) reads, so this test is a structural guard on the
+    # multitasking path rather than a reliable detector; see the warning in GenomeSeqFetch.h.
+    test_fasta <- tempfile(fileext = ".fasta")
+    set.seed(17)
+    seqs <- vapply(1:8, function(i) paste(sample(c("A", "C", "G", "T"), 2e5, replace = TRUE), collapse = ""), character(1))
+    cat(paste0(">chr", seq_along(seqs), "\n", seqs, "\n", collapse = ""), file = test_fasta)
+
+    test_db <- tempfile()
+    original_groot <- .misha$GROOT
+    withr::defer({
+        # don't leave GROOT pointing at the temporary DB we are about to delete
+        if (!is.null(original_groot) && dir.exists(original_groot)) {
+            suppressMessages(gdb.init(original_groot))
+        }
+        unlink(test_db, recursive = TRUE)
+        unlink(test_fasta)
+    })
+
+    withr::with_options(list(gmulticontig.indexed_format = TRUE), {
+        gdb.create(groot = test_db, fasta = test_fasta, verbose = FALSE)
+        gdb.init(test_db)
+
+        dir.create(file.path(test_db, "pssms"), showWarnings = FALSE)
+        file.copy(
+            list.files(file.path(shared_test_db_path(), "pssms"), full.names = TRUE),
+            file.path(test_db, "pssms")
+        )
+
+        energies <- function(multitasking) {
+            track <- paste0("pwmE", if (multitasking) "par" else "ser")
+            withr::with_options(list(gmultitasking = multitasking), {
+                gtrack.create_pwm_energy(track, "", "misha_motifs", 0, 0.02, iterator = 50)
+            })
+            on.exit(gtrack.rm(track, force = TRUE))
+            gextract(track, gintervals.all(), colnames = "v")$v
+        }
+
+        expect_equal(energies(TRUE), energies(FALSE))
+    })
+})


### PR DESCRIPTION
Two related changes, in separate commits so the fix can be cherry-picked on its own.

## 1. Data corruption fix (`a09d492c`)

Forked processes inherit the same *open file description*, i.e. the same file offset. Two children that `fseeko()` + `fread()` concurrently hand each other's bytes back - silently, with the right length and the wrong bases.

Three multitasking entry points opened the genome sequence in the parent and read through it in the children:

| Site | What was pre-opened |
|---|---|
| `gcreate_pwm_energy_multitask()` | `GenomeSeqFetch`, read directly by every kid |
| `gsmooth()` | `TrackExprScanner` - its constructor calls `set_seqdir()` on the shared `GenomeSeqFetch` |
| `C_gcis_decay()` | same |

Per-chromosome databases mostly escape it (`set_seqdir()` only stores the path, the file opens lazily in the child, and the splitter gives each kid its own chromosomes). **Indexed databases have a single `genome.seq`, so every kid inherited the same descriptor.**

Reproduced on the indexed test DB, 24 workers, 120 Mb scope:

```
reverted:  rep 1: 5240 of 2.4M pwm-energy bins wrong (0.218%)   rep 2: 0   rep 3: 5240
fixed:     5 consecutive runs, 0 wrong bins
```

The other five `distribute_task()` sites were audited and are fine - they build their scanner inside the child block, so the inherited descriptor is never read. The constraint is now documented on `GenomeSeqFetch` itself.

## 2. `gseq.extract()` multitasking (`b5ea2fdb`)

One blocking read per interval, and no multitasking at all - 19,000 x 1 kb intervals on an NFS hg19 DB took ~200 s, ~11-17 ms of it per interval for a single 128 kb `BufferedFile` read-ahead.

Whether distributing pays depends almost entirely on cache state: a cold read costs milliseconds, a cached one well under a microsecond, forking costs ~10 ms. **No static interval count can decide that** - a threshold tuned for the cold case made warm 1,000- and 3,000-interval calls 66x and 135x *slower*. So the first 16 intervals are read serially and timed; their sequences are kept, so a probe that says "stay serial" costs nothing, and the kid count is scaled from the measured cost.

The generic scope splitter could not be reused: it only cuts on chromosome boundaries, and its range-splitting path slices intervals in half, which would break the udata -> result-slot mapping. `prepare4multitasking_whole_intervals()` balances whole intervals by `range()` plus a fixed per-interval cost.

**19,000 intervals on hg19, page cache explicitly evicted: ~200 s -> 23 s.** Warm extractions unchanged (ratio 1.00 from n=100 to n=50,000). Big intervals sets keep the sequential path.

## Testing

Full suite: **FAIL 0 | WARN 92 | SKIP 32 | PASS 19292** (the 92 warnings are pre-existing `test-gsynth.R` domain warnings).

- 24-case correctness matrix: single-chromosome splits, unsorted rows, strand and mixed strand, duplicates, overlaps, 1 bp..150 kb skew, chromosome boundaries, n = 1/2/255/256/257/511/512/513/1023/1024
- hg19 n=19000 vs sequential across 8 process counts x 3 reps: 24/24 identical
- hg38 (455 contigs, 322 tiny alts, whole-contig extraction of 287 Mb): identical
- Indexed genome, up to 89 kids on one `genome.seq`, n up to 20,000: identical
- `gtrack.create_pwm_energy` multitask == sequential on both DB formats (144,000 bins)
- SIGINT mid-run (41 live kids): clean error, no orphans, session usable. SIGKILL a kid: loud error, not silent blanks
- 100 repeated calls: stable, no fd leak, no zombies

### Two caveats worth stating

1. **The added `pwm_energy` test cannot catch the bug it guards.** The race only fires with slow networked reads; a self-contained test on local disk never reproduces it. It is a structural guard on the multitasking path and the comment says so.
2. `gseq.extract` will not distribute below 500 intervals. Conservative - a cold 100-interval call is still ~1.2 s sequential and would benefit. Easy to lower if wanted.

https://claude.ai/code/session_01EVd7X2o5jzothTQdy7mrYr


---

## Update: review findings (`db9ee8ce`)

An independent review of the branch found a **fourth site with the same corruption bug**, plus three smaller issues. All addressed.

`gbintransform()` (R: `glookup`) has **two** `distribute_task()` calls. The first already shadows the outer `TrackExprScanner`; the second did not - its child called `scanner.begin()` on the one constructed at function scope, before the fork. My original audit only inspected the *first* fork per function, which is exactly how this slipped through.

Reproduced the same way as the `pwm_energy` one - indexed test DB, 24 workers, 120 Mb scope, `glookup` over a `kmer.count` vtrack:

```
reverted:  7 / 51 / 30 of 24000 bins wrong across three runs
fixed:     5 consecutive runs, 0 wrong bins
```

Also fixed:
- `gseqread()` now falls back to the sequential path if the shared-memory mmap fails, instead of erroring where the old single-process code coped (matches `gscreen`/`gextract`). Nothing is forked at that point - the mmap happens at the top of `distribute_task()`.
- `gseqread()` does not distribute when already running as a kid; a nested `distribute_task()` would reuse the outer job's shared memory and offsets.
- `prepare4multitasking_whole_intervals()` caps the kid count at `MAX_KIDS`. The chromosome-based splitters are implicitly bounded by the chromosome count; this one was not, so `gmax.processes` above 1000 gave "Too many child processes" instead of just using fewer kids.

**Deliberately not addressed**, both noted in the commit message: the parallel path counts the 16-byte record headers against `gmax.data.size` and the sequential path does not (both still error, at thresholds differing by 16 bytes per interval); and peak memory is roughly doubled while the shared memory and the R strings are both live, which is inherent to how every misha multitasking function returns its result.

Full suite re-run after the fixes: **FAIL 0 | WARN 93 | SKIP 32 | PASS 19292**.


---

## Update: second review round (`4dffe1c9`)

Two more independent reviews, fresh context, neither told what the first found. Both returned **MERGE WITH FIXES**, and they were right.

### The blocker: the probe's cost model

It timed 16 intervals and divided by 16. For a **clustered** set — 5000 tiled 200 bp windows over 1 Mb, i.e. any sliding-window scan — those 16 share one 128 KB read-ahead window, so it charged a whole cold read to 16 intervals when the real set amortises it over ~640. It then forked ~34 processes for ~90 ms of work.

Measured on cold hg19: **4.86x slower than the sequential code it replaced.** Every benchmark behind the earlier commits used `gintervals.random`, where each read genuinely is a separate miss, so this shape was never exercised.

The unit of I/O cost is a read-ahead **window**, not an interval. The probe now measures cost per window and extrapolates over the windows the whole sorted set spans.

| cold hg19 | before | after |
|---|---|---|
| clustered 5000 x 200 bp | 4.86x slower | 0.98-1.16x (parity) |
| scattered n=19000 | — | ~95x faster |

Worth recording: the obvious fix — sampling strided intervals instead of the first 16 — makes this **worse**, because spread samples are all misses and overestimate a clustered set even harder.

### Also fixed

- `gmax.data.size` now fires on the same quantity in both paths, **before** forking. The parallel path counted the 16-byte record headers and overflowed only once the kids had finished all their I/O, reporting the generic shared-memory message rather than the one naming the sizes and the option to raise.
- Kids report progress; the meter previously sat at `0%` for the entire run.
- `gseq.extract.probe.usec` is registered in `.misha_defaults` / `zzz.R` and documented in the options table. `getOption()` returned `NULL` for every user and the default existed only as a C++ literal.
- Clamp the `double`->`uint64` kid-count cast; require `get_num_kids() == 0` before taking the shared-memory fallback.
- The `gmax.data.size` test never reached the multitasking path — the probe's own check threw first, and a bare `expect_error()` passed on any error at all. Rewritten to sit the limit between the probe and the full result, asserting both paths report the actionable message.
- Documented the 500-interval floor, the doubled peak memory, and that this function now forks (so calling it inside `mclapply()` multiplies processes).

### Recorded, not fixed

Every test in `test-gseq-extract-parallel.R` asserts parallel == sequential, which also holds if the multitasking gate **silently stops engaging**. That is the likeliest regression mode and it is unguarded — catching it needs an observable from R saying a call forked, which is new public surface. The limitation is now stated at the top of the test file rather than implied away.

Both reviewers independently re-audited all ~20 `distribute_task` sites and confirmed the four-site corruption claim is complete — no fifth site.

Full suite on the final tree: **FAIL 0 | WARN 92 | SKIP 32 | PASS 19294**.
