### PR TITLE
fix: never persist one database's track listing into another's .db.cache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.13
+Version: 5.11.14
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# misha 5.11.14
+
+* **Database corruption fix:** creating or removing a track/interval set wrote the in-memory listing into `<groot>/.db.cache` without checking which database that listing came from. If `GROOT` and the listing had drifted apart - `gsetroot()` interrupted with Ctrl-C mid-reload, or `misha.ext::gset_genome(force = FALSE)` restoring a memoized session - one database's inventory was published into another's cache, and every subsequent session on that database saw the wrong tracks until someone ran `gdb.reload(rescan = TRUE)`. The cache is now only written when the listing provably came from that database; otherwise it is marked dirty and rescanned.
+* Ctrl-C during `gsetroot()` is no longer swallowed: it unloads the session instead of returning as if it had succeeded.
+
 # misha 5.11.13
 
 * **Data corruption fix:** `gtrack.create_pwm_energy()` (and, for sequence-based virtual tracks, `gtrack.smooth()`, `glookup()` and `gcis_decay()`) opened the genome sequence before forking. Forked workers share the file offset of an inherited descriptor, so on an indexed database they read each other's bytes - producing a small fraction of silently wrong values, varying run to run. Measured at 0.2% of bins on a 120 Mb scope.

--- a/R/db-cache.R
+++ b/R/db-cache.R
@@ -39,6 +39,7 @@ gdb.reload <- function(rescan = TRUE) {
 
     assign("GTRACKS", NULL, envir = .misha)
     assign("GINTERVS", NULL, envir = .misha)
+    assign("GTRACKS_SRC", NULL, envir = .misha)
     assign("GTRACK_DATASET", NULL, envir = .misha)
     assign("GINTERVALS_DATASET", NULL, envir = .misha)
 
@@ -292,6 +293,11 @@ gdb.reload <- function(rescan = TRUE) {
 
     assign("GTRACKS", tracks, envir = .misha)
     assign("GINTERVS", intervals, envir = .misha)
+    # Provenance stamp: which database set this listing was actually scanned
+    # from. .gdb.cache_update_lists() refuses to persist the in-memory listing
+    # to <groot>/.db.cache unless the stamp still matches, so a listing that
+    # belongs to another database can never be published to this one.
+    assign("GTRACKS_SRC", groots, envir = .misha)
     if (length(gdatasets) > 0) {
         assign("GTRACK_DATASET", track_db, envir = .misha)
         assign("GINTERVALS_DATASET", intervals_db, envir = .misha)
@@ -623,6 +629,24 @@ gdb.reload <- function(rescan = TRUE) {
         groot <- working_db
     }
     if (is.null(groot) || groot == "") {
+        return(invisible(FALSE))
+    }
+
+    # GTRACKS/GINTERVS may describe a *different* database than the one we are
+    # about to persist. gdb.reload() is the only thing that scans a database and
+    # it stamps GTRACKS_SRC with the groots it scanned; if GROOT moved on without
+    # a completed reload - gsetroot() interrupted mid-reload, or a caller that
+    # restores a memoized session snapshot (misha.ext::gset_genome) - the stamp
+    # no longer matches. Writing anyway would publish one database's inventory
+    # into another's .db.cache, where every other user then reads it. Mark dirty
+    # instead and let the next gsetroot()/gdb.reload() rescan from disk.
+    src <- if (exists("GTRACKS_SRC", envir = .misha, inherits = FALSE)) {
+        get("GTRACKS_SRC", envir = .misha)
+    } else {
+        NULL
+    }
+    if (!identical(src, groots)) {
+        .gdb.cache_mark_dirty(groot)
         return(invisible(FALSE))
     }
 

--- a/R/db-root.R
+++ b/R/db-root.R
@@ -38,9 +38,11 @@
             setwd(oldwd)
             gdb.reload(rescan)
         },
-        interrupt = function(interrupt) {
-            setwd(oldwd)
-        },
+        # No interrupt handler: Ctrl-C during gdb.reload() used to be swallowed
+        # here, so gsetroot() reported success while GROOT pointed at the new
+        # database and GTRACKS still listed the old one. Let it propagate so
+        # gsetroot()'s cleanup unloads the session instead. `finally` already
+        # restores the working directory.
         finally = {
             setwd(oldwd)
         }
@@ -108,6 +110,7 @@ gsetroot <- function(groot = NULL, dir = NULL, rescan = FALSE) {
     assign("GROOT", NULL, envir = .misha)
     assign("CHROM_ALIAS", NULL, envir = .misha)
     .refresh_chrom_alias_env()
+    assign("GTRACKS_SRC", NULL, envir = .misha)
     assign("GTRACK_DATASET", NULL, envir = .misha)
     assign("GINTERVALS_DATASET", NULL, envir = .misha)
     assign("GDATASETS", character(0), envir = .misha)
@@ -260,6 +263,7 @@ gsetroot <- function(groot = NULL, dir = NULL, rescan = FALSE) {
                 assign("CHROM_ALIAS", NULL, envir = .misha)
                 .refresh_chrom_alias_env()
                 assign("DB_IS_PER_CHROMOSOME", NULL, envir = .misha)
+                assign("GTRACKS_SRC", NULL, envir = .misha)
                 assign("GTRACK_DATASET", NULL, envir = .misha)
                 assign("GINTERVALS_DATASET", NULL, envir = .misha)
                 assign("GDATASETS", character(0), envir = .misha)
@@ -312,7 +316,7 @@ gdb.unload <- function() {
 
     session_vars <- c(
         "GROOT", "GWD", "ALLGENOME", "GINTERVID", "GITERATOR.INTERVALS",
-        "GVTRACKS", "GDATASETS", "GTRACK_DATASET", "GINTERVALS_DATASET",
+        "GVTRACKS", "GDATASETS", "GTRACK_DATASET", "GINTERVALS_DATASET", "GTRACKS_SRC",
         "CHROM_ALIAS", "DB_IS_PER_CHROMOSOME"
     )
     for (v in session_vars) {

--- a/tests/testthat/test-db-cache-provenance.R
+++ b/tests/testthat/test-db-cache-provenance.R
@@ -1,0 +1,98 @@
+read_db_cache <- function(db) {
+    p <- file.path(db, ".db.cache")
+    if (!file.exists(p)) {
+        return(NULL)
+    }
+    f <- file(p, "rb")
+    on.exit(close(f))
+    unserialize(f)
+}
+
+# Build two independent single-chromosome databases, each with one track.
+make_two_dbs <- function(env = parent.frame()) {
+    tmp <- tempfile("cacheprov_")
+    dir.create(tmp)
+    withr::defer(unlink(tmp, recursive = TRUE), envir = env)
+
+    dbs <- lapply(c("A", "B"), function(tag) {
+        db <- file.path(tmp, paste0("db", tag))
+        fa <- file.path(tmp, paste0(tag, ".fasta"))
+        cat(sprintf(">chr%s\nACGTACGTAC\n", tag), file = fa)
+        suppressMessages(gdb.create(groot = db, fasta = fa, verbose = FALSE))
+        suppressMessages(gsetroot(db))
+        gtrack.create(paste0("track", tag), "t", "1",
+            iterator = gintervals(paste0("chr", tag), 0, 10)
+        )
+        db
+    })
+    names(dbs) <- c("A", "B")
+    dbs
+}
+
+test_that("track listing of one database is never persisted to another's .db.cache", {
+    local_db_state()
+    dbs <- make_two_dbs()
+
+    expect_equal(read_db_cache(dbs$A)[[1]], "trackA")
+    expect_equal(read_db_cache(dbs$B)[[1]], "trackB")
+
+    # Reproduces the state left behind when gsetroot() is interrupted mid-reload,
+    # or when a caller restores a memoized session snapshot (misha.ext::gset_genome
+    # with force = FALSE): GROOT/GWD point at one database while GTRACKS still
+    # holds the listing of another.
+    suppressMessages(gsetroot(dbs$A))
+    stale_tracks <- get("GTRACKS", envir = .misha)
+    suppressMessages(gsetroot(dbs$B))
+    assign("GTRACKS", stale_tracks, envir = .misha)
+    assign("GTRACKS_SRC", dbs$A, envir = .misha)
+
+    gtrack.create("newB", "t", "1", iterator = gintervals("chrB", 0, 10))
+
+    # dbB's cache must not have been rewritten from dbA's listing
+    expect_false("trackA" %in% read_db_cache(dbs$B)[[1]])
+    expect_true(.gdb.cache_is_dirty(dbs$B))
+
+    # ... and the next session rescans from disk and sees the truth
+    suppressMessages(gsetroot(dbs$B))
+    expect_setequal(gtrack.ls(), c("trackB", "newB"))
+    expect_setequal(read_db_cache(dbs$B)[[1]], c("trackB", "newB"))
+})
+
+test_that("interrupting gsetroot() unloads the session instead of reporting success", {
+    local_db_state()
+    dbs <- make_two_dbs()
+
+    suppressMessages(gsetroot(dbs$A))
+
+    real_reload <- misha::gdb.reload
+    assignInNamespace("gdb.reload", function(rescan = TRUE) {
+        stop(structure(class = c("interrupt", "condition"), list(message = "", call = NULL)))
+    }, ns = "misha")
+    withr::defer(assignInNamespace("gdb.reload", real_reload, ns = "misha"))
+
+    # Catch it here rather than with expect_condition(): testthat's runner
+    # treats a real `interrupt` condition as Ctrl-C and aborts the file.
+    caught <- FALSE
+    tryCatch(suppressMessages(gsetroot(dbs$B)), interrupt = function(e) caught <<- TRUE)
+    expect_true(caught)
+    expect_null(get("GROOT", envir = .misha))
+
+    assignInNamespace("gdb.reload", real_reload, ns = "misha")
+    suppressMessages(gsetroot(dbs$B))
+    expect_equal(gtrack.ls(), "trackB")
+})
+
+test_that("cache is still written incrementally in the normal single-database flow", {
+    local_db_state()
+    dbs <- make_two_dbs()
+
+    suppressMessages(gsetroot(dbs$A))
+    gtrack.create("extraA", "t", "1", iterator = gintervals("chrA", 0, 10))
+
+    expect_setequal(read_db_cache(dbs$A)[[1]], c("trackA", "extraA"))
+    expect_false(.gdb.cache_is_dirty(dbs$A))
+
+    gintervals.save("ivA", gintervals("chrA", 0, 10))
+    expect_setequal(read_db_cache(dbs$A)[[2]], "ivA")
+    expect_false(.gdb.cache_is_dirty(dbs$A))
+})


### PR DESCRIPTION
## The incident

A few weeks ago, a user switching genomes with `misha.ext::gset_genome()` ended up with one database's track list written into another database's `.db.cache`. Everyone working in that database then saw the wrong tracks - persistently, across sessions, until someone happened to run `gdb.reload(rescan = TRUE)`.

## Root cause

`.gdb.cache_update_lists()` serializes the in-memory `GTRACKS`/`GINTERVS` vectors into `<groot>/.db.cache` on every track or interval-set add/remove. It never checked that those vectors had actually been scanned from that groot. Any way to desynchronize `GROOT` from `GTRACKS` therefore publishes one database's inventory into another's on-disk cache, where every subsequent session - for every user - reads it back as truth.

Two ways to desynchronize, both reproduced on temporary databases:

**1. Ctrl-C during `gsetroot()`.** `.gdir.cd()` caught the `interrupt` condition and returned normally, so `gsetroot()` reported success with `GROOT` already moved to the new database and `GTRACKS` still holding the old one's listing. One `gtrack.create()` later:

```
B/.db.cache                      = [newB, trackA]     # trackA lives in database A
fresh session, gtrack.ls() in B  =  newB, trackA
actually on disk in B            =  newB, trackB
```

**2. `misha.ext::gset_genome(force = FALSE)`,** which restores a partial session snapshot straight into `.misha`. Its stale `GTRACKS` got flushed to disk, and a track that existed on disk disappeared from `gtrack.ls()` for everyone.

## Fix

Two layers.

**Blast radius.** `gdb.reload()` stamps `GTRACKS_SRC` with the groots it actually scanned. `.gdb.cache_update_lists()` writes only while that stamp still matches `c(GROOT, GDATASETS)`; on a mismatch it marks the cache dirty so the next `gsetroot()`/`gdb.reload()` rescans from disk instead. Normal single- and multi-database flows keep the stamp valid, so no rescan cost is added - the incremental cache write still happens exactly as before.

**Trigger.** `.gdir.cd()` no longer swallows interrupts. Ctrl-C during `gsetroot()` now unloads the session instead of leaving it half-initialized. `finally` already restored the working directory, so the handler only ever suppressed the condition.

## Tests

New `tests/testthat/test-db-cache-provenance.R`, 13 expectations: desynced state cannot poison a cache and the next session self-heals from disk; an interrupt unloads the session; the normal incremental write still lands and leaves the cache clean.

## Verification

`alutil::tst(parallel = TRUE)` on this branch vs. `master` (same machine, same reporter, results captured programmatically):

| | tests | failed | errored |
|---|---|---|---|
| master | 19344 | 0 | 27 |
| this branch | 19379 | 0 | 27 |

The 27 errored tests are pre-existing and flaky - the *set* of erroring tests shuffles between runs on both sides (they allocate randomly-named temp tracks on the shared test database under 40 parallel workers). Not touched by this change.

## Companion

`tanaylab/misha.ext` branch `fix/gset-genome-memo` removes the memoized fast path from `gset_genome()`, which is the trigger. It restored only `ALLGENOME`/`GROOT`/`GWD`/`GTRACKS`/`GINTERVS`, leaving `CHROM_ALIAS`, `DB_IS_PER_CHROMOSOME`, `GDATASETS` and `GTRACK_DATASET` pointing at the previously loaded genome - so a restored genome could carry the wrong chromosome aliases. `gsetroot()` reads the on-disk `.db.cache` anyway, so the memo bought nothing.

https://claude.ai/code/session_01GAEMstkQFr1xu1drZ75juv
