### PR TITLE
Return NaN from every vtrack whose shifted iterator left the chromosome

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.15
+Version: 5.11.17
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# misha 5.11.17
+
+* **Bug fix:** a virtual track whose `gvtrack.iterator()` `sshift`/`eshift` pushes the iterator interval off the chromosome now returns `NaN`, whatever the function. `pwm*`, `kmer*` and `masked*` returned `0` or `-Inf`, or a value that depended on the database format, and errored out ("start coordinate must be lesser than end coordinate") when four or more sequence virtual tracks were extracted in one call; `coverage` and `neighbor.count` returned `0`, indistinguishable from a real answer. An interval that only partly leaves the chromosome is still clamped to it, as before.
+
 # misha 5.11.15
 
 * **Bug fix:** `gintervals.import_bed()`, `gintervals.import_gff()` and `gintervals.import_vcf()` now import gzipped files, and error on a truncated or corrupt `.gz` instead of importing whatever happened to decompress.

--- a/R/vtrack.R
+++ b/R/vtrack.R
@@ -1314,6 +1314,10 @@ gvtrack.info <- function(vtrack = NULL) {
 #' Iterator interval's 'start' coordinate is modified by adding 'sshift'.
 #' Similarly 'end' coordinate is altered by adding 'eshift'.
 #'
+#' A shifted interval that runs past a chromosome boundary is clamped to it. If
+#' nothing is left of it - it falls entirely outside the chromosome, or the
+#' shifts collapse it to zero length - the virtual track returns 'NaN'.
+#'
 #' @param vtrack virtual track name
 #' @param dim use 'NULL' or '0' for 1D iterators. '1' converts 2D iterator to
 #' (chrom1, start1, end1) , '2' converts 2D iterator to (chrom2, start2, end2)
@@ -1364,6 +1368,10 @@ gvtrack.iterator <- function(vtrack = NULL, dim = NULL, sshift = 0, eshift = 0) 
 #' Iterator interval's 'start1' coordinate is modified by adding 'sshift1'.
 #' Similarly 'end1', 'start2', 'end2' coordinates are altered by adding
 #' 'eshift1', 'sshift2' and 'eshift2' accordingly.
+#'
+#' A shifted interval that runs past a chromosome boundary is clamped to it. If
+#' nothing is left of it - it falls entirely outside the chromosome, or the
+#' shifts collapse it to zero length - the virtual track returns 'NaN'.
 #'
 #' @param vtrack virtual track name
 #' @param sshift1 shift of 'start1' coordinate

--- a/man/gvtrack.iterator.2d.Rd
+++ b/man/gvtrack.iterator.2d.Rd
@@ -37,6 +37,10 @@ intervals in a virtual track.
 Iterator interval's 'start1' coordinate is modified by adding 'sshift1'.
 Similarly 'end1', 'start2', 'end2' coordinates are altered by adding
 'eshift1', 'sshift2' and 'eshift2' accordingly.
+
+A shifted interval that runs past a chromosome boundary is clamped to it. If
+nothing is left of it - it falls entirely outside the chromosome, or the
+shifts collapse it to zero length - the virtual track returns 'NaN'.
 }
 \examples{
 \dontshow{

--- a/man/gvtrack.iterator.Rd
+++ b/man/gvtrack.iterator.Rd
@@ -35,6 +35,10 @@ or '0' (meaning: no conversion is made).
 
 Iterator interval's 'start' coordinate is modified by adding 'sshift'.
 Similarly 'end' coordinate is altered by adding 'eshift'.
+
+A shifted interval that runs past a chromosome boundary is clamped to it. If
+nothing is left of it - it falls entirely outside the chromosome, or the
+shifts collapse it to zero length - the virtual track returns 'NaN'.
 }
 \examples{
 \dontshow{

--- a/src/IntervVarProcessor.cpp
+++ b/src/IntervVarProcessor.cpp
@@ -163,7 +163,7 @@ void IntervVarProcessor::process_neighbor_count(
 	const GInterval &eval_interval = var.imdf1d ? var.imdf1d->interval : interval;
 
 	if (var.imdf1d && var.imdf1d->out_of_range) {
-		var.var[idx] = 0;
+		var.var[idx] = numeric_limits<double>::quiet_NaN();
 		return;
 	}
 
@@ -247,7 +247,7 @@ void IntervVarProcessor::process_coverage(
 	const GInterval &eval_interval = var.imdf1d ? var.imdf1d->interval : interval;
 
 	if (var.imdf1d && var.imdf1d->out_of_range) {
-		var.var[idx] = 0;
+		var.var[idx] = numeric_limits<double>::quiet_NaN();
 		return;
 	}
 

--- a/src/SequenceVarProcessor.cpp
+++ b/src/SequenceVarProcessor.cpp
@@ -166,6 +166,17 @@ void SequenceVarProcessor::classify_track_vars(
 	m_classification_done = true;
 }
 
+// A shifted iterator (gvtrack.iterator sshift/eshift) that fell off the chromosome
+// leaves no sequence to score: report NaN, like every other virtual track type does.
+static inline bool seq_var_out_of_range(TrackExpressionVars::Track_var *var, unsigned idx)
+{
+	if (var->seq_imdf1d && var->seq_imdf1d->out_of_range) {
+		var->var[idx] = numeric_limits<double>::quiet_NaN();
+		return true;
+	}
+	return false;
+}
+
 void SequenceVarProcessor::process_sequence_vars(
 	TrackExpressionVars::Track_vars &track_vars,
 	const GInterval &interval,
@@ -182,11 +193,17 @@ void SequenceVarProcessor::process_sequence_vars(
 		batch_process_sequence_vtracks(m_kmer_vtracks, m_pwm_vtracks, interval, idx);
 		// Process masked vtracks individually even in batch mode (simpler than batching)
 		for (TrackExpressionVars::Track_var* ivar : m_masked_vtracks) {
+			if (seq_var_out_of_range(ivar, idx))
+				continue;
+
 			const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 			ivar->var[idx] = ivar->masked_counter->score_interval(seq_interval, m_iu.get_chromkey());
 		}
 		// Process edit distance vtracks individually (no batching support)
 		for (TrackExpressionVars::Track_var* ivar : m_pwm_edit_distance_vtracks) {
+			if (seq_var_out_of_range(ivar, idx))
+				continue;
+
 			const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 			if (!ivar->pwm_edit_distance_scorer) {
@@ -228,6 +245,9 @@ void SequenceVarProcessor::process_sequence_vars(
 		}
 		// Process LSE edit distance vtracks individually (no batching support)
 		for (TrackExpressionVars::Track_var* ivar : m_pwm_lse_edit_distance_vtracks) {
+			if (seq_var_out_of_range(ivar, idx))
+				continue;
+
 			const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 			if (!ivar->pwm_lse_edit_distance_scorer) {
@@ -285,6 +305,8 @@ void SequenceVarProcessor::batch_process_sequence_vtracks(
 
 	for (TrackExpressionVars::Track_var* var : kmer_vtracks) {
 		if (!var->kmer_counter) continue;
+		if (seq_var_out_of_range(var, idx))
+			continue;
 
 		const GInterval &base_interval = var->seq_imdf1d ? var->seq_imdf1d->interval : interval;
 		char strand = var->kmer_counter->get_strand();
@@ -379,6 +401,9 @@ void SequenceVarProcessor::batch_process_sequence_vtracks(
 	// Process PWM vtracks using score_interval
 	// The shared cache prevents redundant disk I/O
 	for (TrackExpressionVars::Track_var* var : pwm_vtracks) {
+		if (seq_var_out_of_range(var, idx))
+			continue;
+
 		const GInterval &seq_interval = var->seq_imdf1d ? var->seq_imdf1d->interval : interval;
 		var->var[idx] = var->pwm_scorer->score_interval(seq_interval, m_iu.get_chromkey());
 	}
@@ -395,6 +420,9 @@ void SequenceVarProcessor::process_individual_sequence_vars(
 {
 	// Process PWM vtracks
 	for (TrackExpressionVars::Track_var* ivar : pwm_vtracks) {
+		if (seq_var_out_of_range(ivar, idx))
+			continue;
+
 		const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 		// Check if filter applies
@@ -446,6 +474,9 @@ void SequenceVarProcessor::process_individual_sequence_vars(
 
 	// Process kmer vtracks
 	for (TrackExpressionVars::Track_var* ivar : kmer_vtracks) {
+		if (seq_var_out_of_range(ivar, idx))
+			continue;
+
 		const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 		if (ivar->kmer_counter) {
@@ -495,6 +526,9 @@ void SequenceVarProcessor::process_individual_sequence_vars(
 
 	// Process masked vtracks
 	for (TrackExpressionVars::Track_var* ivar : masked_vtracks) {
+		if (seq_var_out_of_range(ivar, idx))
+			continue;
+
 		const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 		if (ivar->masked_counter) {
@@ -544,6 +578,9 @@ void SequenceVarProcessor::process_individual_sequence_vars(
 
 	// Process PWM edit distance vtracks
 	for (TrackExpressionVars::Track_var* ivar : pwm_edit_distance_vtracks) {
+		if (seq_var_out_of_range(ivar, idx))
+			continue;
+
 		const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 		if (!ivar->pwm_edit_distance_scorer) {
@@ -590,6 +627,9 @@ void SequenceVarProcessor::process_individual_sequence_vars(
 
 	// Process LSE edit distance vtracks
 	for (TrackExpressionVars::Track_var* ivar : pwm_lse_edit_distance_vtracks) {
+		if (seq_var_out_of_range(ivar, idx))
+			continue;
+
 		const GInterval &seq_interval = ivar->seq_imdf1d ? ivar->seq_imdf1d->interval : interval;
 
 		if (!ivar->pwm_lse_edit_distance_scorer) {

--- a/tests/testthat/test-vtrack-shift-out-of-range.R
+++ b/tests/testthat/test-vtrack-shift-out-of-range.R
@@ -1,0 +1,77 @@
+# gvtrack.iterator() sshift/eshift can push the iterator interval off the
+# chromosome. Partially: the window is clamped to the chromosome. Completely
+# (or into an empty window): every virtual track function returns NaN.
+
+shift_pssm <- function() {
+    data.frame(
+        A = c(0.7, 0.1, 0.1, 0.1),
+        C = c(0.1, 0.7, 0.1, 0.1),
+        G = c(0.1, 0.1, 0.7, 0.1),
+        T = c(0.1, 0.1, 0.1, 0.7)
+    )
+}
+
+# Create every vtrack flavor that has its own out-of-range path, and return the
+# extracted values for the given shift.
+shifted_values <- function(sshift, eshift, scope) {
+    remove_all_vtracks()
+    src <- gintervals("chr1", c(3000100, 3000500), c(3000200, 3000600))
+
+    gvtrack.create("s_pwm", NULL, func = "pwm", pssm = shift_pssm(), prior = 0.01)
+    gvtrack.create("s_pwm_max", NULL, func = "pwm.max", pssm = shift_pssm(), prior = 0.01)
+    gvtrack.create("s_kmer", NULL, func = "kmer.count", kmer = "ACGT", strand = 1)
+    gvtrack.create("s_masked", NULL, func = "masked.count")
+    gvtrack.create("s_coverage", src, func = "coverage")
+    gvtrack.create("s_neighbor", src, func = "neighbor.count")
+    gvtrack.create("s_distance", src, func = "distance")
+    gvtrack.create("s_track", "test.fixedbin", "avg")
+    vtracks <- c(
+        "s_pwm", "s_pwm_max", "s_kmer", "s_masked",
+        "s_coverage", "s_neighbor", "s_distance", "s_track"
+    )
+
+    for (v in vtracks) {
+        gvtrack.iterator(v, sshift = sshift, eshift = eshift)
+    }
+
+    # 4+ sequence vtracks in one call also exercises the batched sequence path
+    r <- gextract(vtracks, scope, iterator = scope)
+    unlist(r[1, vtracks])
+}
+
+test_that("a shift that leaves the chromosome yields NaN for every vtrack function", {
+    withr::defer(remove_all_vtracks())
+    scope <- gintervals("chr1", 3000000, 3001000)
+
+    baseline <- shifted_values(0, 0, scope)
+    expect_false(any(is.na(baseline)))
+
+    # window pushed 5Mb to the left of the chromosome start
+    expect_true(all(is.na(shifted_values(-5e6, -5e6, scope))))
+
+    # window pushed past the chromosome end
+    chr1_end <- gintervals.all()$end[gintervals.all()$chrom == "chr1"]
+    tail_scope <- gintervals("chr1", chr1_end - 1000, chr1_end)
+    expect_true(all(is.na(shifted_values(10000, 10000, tail_scope))))
+
+    # sshift/eshift that collapse the window to nothing
+    expect_true(all(is.na(shifted_values(500, -500, scope))))
+})
+
+test_that("a shift that only partly leaves the chromosome clamps the window", {
+    remove_all_vtracks()
+    withr::defer(remove_all_vtracks())
+    scope <- gintervals("chr1", c(0, 1000), c(1000, 2000))
+
+    gvtrack.create("clamped", "test.fixedbin", "avg")
+    unshifted <- gextract("clamped", scope, iterator = scope)$clamped
+
+    gvtrack.iterator("clamped", sshift = -1000, eshift = 0)
+    shifted <- gextract("clamped", scope, iterator = scope)$clamped
+
+    # the first bin has nothing to its left, so it keeps its unshifted value;
+    # the second one widens to [0, 2000) and changes
+    expect_equal(shifted[1], unshifted[1])
+    expect_false(isTRUE(all.equal(shifted[2], unshifted[2])))
+    expect_false(any(is.na(shifted)))
+})


### PR DESCRIPTION
`gvtrack.iterator()`'s `sshift`/`eshift` clamp the iterator interval to the chromosome, and `Iterator_modifier1D::transform` flags what is left over - a window entirely off the chromosome, or one the shifts collapsed to zero length - as `out_of_range`. Track, value and `distance*` variables honored that flag and reported `NaN`. Two families did not.

**Sequence vtracks never read the flag.** `SequenceVarProcessor` passes `seq_imdf1d->interval` to the scorers at 11 sites without checking it, so `pwm*`, `kmer*` and `masked*` scored whatever degenerate interval `transform()` produced:

| vtrack | fully off chrom | window collapsed (`sshift=+500, eshift=-500`) |
|---|---|---|
| `pwm` | NaN | **-Inf** |
| `kmer.count` | 0 | 0 |
| `masked.count` | NaN | **NaN on a per-chromosome DB, 0 on an indexed DB** |

The format dependence comes from `GenomeSeqFetch::read_interval`: the per-chromosome path calls `GInterval::verify()`, which throws on `start >= end`, while the indexed path bumps a zero-length read to 1 bp and returns a base.

Worse, with **four or more sequence vtracks in one call** the batched path reaches `MaskedBpCounter` -> `GInterval::verify()` and aborts the whole `gextract` with `Interval (chr1, 0, -1998997): start coordinate must be lesser than end coordinate`.

**`coverage` and `neighbor.count` read the flag but answered `0`**, a value a real window can also produce, so the caller could not tell the two apart.

All of them now answer `NaN`. A window that only partly leaves the chromosome is still clamped to it, as before - that part is unchanged, and now documented on `gvtrack.iterator`.

## Verification

- New `tests/testthat/test-vtrack-shift-out-of-range.R` covers all four degenerate shapes (off the left end, past the right end, collapsed window, partial overhang) across `pwm`, `pwm.max`, `kmer.count`, `masked.count`, `coverage`, `neighbor.count`, `distance` and a plain track vtrack, extracted together so the batched sequence path is exercised. It errors on master and passes here.
- Manually checked identical results on the per-chromosome and indexed test databases.
- Full suite: 3 failures, the same three `test-pwm-sliding-window.R` MOTIF_COUNT regressions that already fail on master (fixed by #156). No new failures.