### PR TITLE
fix: three out-of-bounds/silent-wrong-answer defects on >100-contig 2D databases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: misha
 Title: Toolkit for Analysis of Genomic Data
-Version: 5.11.18
+Version: 5.11.19
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# misha 5.11.19
+
+* **Crash fix:** `gtrack.liftover()` of a 2D track (`rects`/`points`) into a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs - which includes hg38 with scaffolds - wrote past the end of an internal per-chromosome-pair buffer, crashing R or corrupting the track it was writing. Any 2D track produced by `gtrack.liftover()` into such a database before this release should be regenerated.
+* **Bug fix:** 2D queries over an explicitly given 2D scope (a 2D track or a 2D intervals set) returned `NULL` on a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs while `gmultitasking` was on, and the correct result with it off. Every 2D entry point that multitasks was affected, including `gextract()`, `gsummary()`, `gquantiles()`, `gdist()`, `gcor()`, `gscreen()` and `gintervals.mapply()`.
+
 # misha 5.11.18
 
 * **Behavior fix:** passing overlapping intervals as a 1D iterator now warns that they were merged into wider blocks, naming one merged pair and the row it became. An interval nested inside another one counts as merged too: it widens no row, so it used to disappear silently. Exact duplicates stay silent - both copies come back as the same row, so no interval is missing from the output. Results are unchanged; to get one value per interval, call `gextract()` with the same intervals as its scope and map the rows back with the `intervalID` column.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * **Crash fix:** `gtrack.liftover()` of a 2D track (`rects`/`points`) into a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs - which includes hg38 with scaffolds - wrote past the end of an internal per-chromosome-pair buffer, crashing R or corrupting the track it was writing. Any 2D track produced by `gtrack.liftover()` into such a database before this release should be regenerated.
 * **Bug fix:** 2D queries over an explicitly given 2D scope (a 2D track or a 2D intervals set) returned `NULL` on a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs while `gmultitasking` was on, and the correct result with it off. Every 2D entry point that multitasks was affected, including `gextract()`, `gsummary()`, `gquantiles()`, `gdist()`, `gcor()`, `gscreen()` and `gintervals.mapply()`.
+* **Bug fix:** `gcis_decay()` returned an all-zero decay curve on a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs - and `NULL` (surfacing as "attempt to set an attribute on NULL") while `gmultitasking` was on - because it dropped every chromosome pair from its scope. Any cis-decay curve computed on such a database should be recomputed.
 
 # misha 5.11.18
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # misha 5.11.19
 
 * **Crash fix:** `gtrack.liftover()` of a 2D track (`rects`/`points`) into a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs - which includes hg38 with scaffolds - wrote past the end of an internal per-chromosome-pair buffer, crashing R or corrupting the track it was writing. Any 2D track produced by `gtrack.liftover()` into such a database before this release should be regenerated.
-* **Bug fix:** 2D queries over an explicitly given 2D scope (a 2D track or a 2D intervals set) returned `NULL` on a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs while `gmultitasking` was on, and the correct result with it off. Every 2D entry point that multitasks was affected, including `gextract()`, `gsummary()`, `gquantiles()`, `gdist()`, `gcor()`, `gscreen()` and `gintervals.mapply()`.
+* **Bug fix:** 2D queries over an explicitly given 2D scope - a 2D track, or a 2D intervals set big enough to be stored as a big set - returned `NULL` on a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs while `gmultitasking` was on, and the correct result with it off. Every 2D entry point that multitasks was affected, including `gextract()`, `gsummary()`, `gquantiles()`, `gdist()`, `gcor()`, `gscreen()` and `gintervals.mapply()`.
 * **Bug fix:** `gcis_decay()` returned an all-zero decay curve on a database with more than `getOption("gmulticontig.2d.threshold", 100)` contigs - and `NULL` (surfacing as "attempt to set an attribute on NULL") while `gmultitasking` was on - because it dropped every chromosome pair from its scope. Any cis-decay curve computed on such a database should be recomputed.
 
 # misha 5.11.18

--- a/src/GTrackLiftover.cpp
+++ b/src/GTrackLiftover.cpp
@@ -936,14 +936,19 @@ SEXP gtrack_liftover(SEXP _track,
 			if (src_track_type != GenomeTrack::RECTS && src_track_type != GenomeTrack::POINTS)
 				TGLError("Source track type %s is currently not supported in liftover", GenomeTrack::TYPE_NAMES[src_track_type]);
 
-			GIntervals2D all_genome_intervs;
-			iu.get_all_genome_intervs(all_genome_intervs);
-			vector<BufferedIntervals2D> buffered_intervs(all_genome_intervs.size());
+			// The buffers are keyed by target chrom-pair. Sizing this container from the
+			// whole-genome 2D intervals set was wrong twice over: that set is a deferred
+			// placeholder (length 0) on databases above gmulticontig.2d.threshold contigs,
+			// making every buffered_intervs[chromid1 * num_chroms + chromid2] access run off
+			// the end of an empty vector; and even when it is materialised it allocates
+			// num_chroms^2 objects (207,025 on hg38 with scaffolds) to open a handful of
+			// files. A sparse map creates a buffer only for the pairs that are written to.
+			map<ChromPair, BufferedIntervals2D> buffered_intervs;
 			char filename[FILENAME_MAX];
 			GIntervals tgt_intervals[2];
 
 			Progress_reporter progress;
-			progress.init(src_id2chrom.size() * src_id2chrom.size() + all_genome_intervs.size(), 1);
+			progress.init(src_id2chrom.size() * src_id2chrom.size(), 1);
 
 			// convert source intervals and write them to files
 			for (vector<string>::const_iterator ichrom1 = src_id2chrom.begin(); ichrom1 != src_id2chrom.end(); ++ichrom1) {
@@ -997,12 +1002,12 @@ SEXP gtrack_liftover(SEXP _track,
 
 							for (GIntervals::const_iterator iinterv1 = tgt_intervals[0].begin(); iinterv1 != tgt_intervals[0].end(); ++iinterv1) {
 								for (GIntervals::const_iterator iinterv2 = tgt_intervals[1].begin(); iinterv2 != tgt_intervals[1].end(); ++iinterv2) {
-									int idx = iinterv1->chromid * iu.get_chromkey().get_num_chroms() + iinterv2->chromid;
-									if (!buffered_intervs[idx].opened()) {
+									BufferedIntervals2D &buffered_interv = buffered_intervs[ChromPair(iinterv1->chromid, iinterv2->chromid)];
+									if (!buffered_interv.opened()) {
 										snprintf(filename, sizeof(filename), "%s/_%s-%s", dirname.c_str(), iu.get_chromkey().id2chrom(iinterv1->chromid).c_str(), iu.get_chromkey().id2chrom(iinterv2->chromid).c_str());
-										buffered_intervs[idx].open(filename, "w+", iinterv1->chromid, iinterv2->chromid);
+										buffered_interv.open(filename, "w+", iinterv1->chromid, iinterv2->chromid);
 									}
-									buffered_intervs[idx].write_interval(*iinterv1, *iinterv2, iqtree->v);
+									buffered_interv.write_interval(*iinterv1, *iinterv2, iqtree->v);
 								}
 							}
 							check_interrupt();
@@ -1023,12 +1028,12 @@ SEXP gtrack_liftover(SEXP _track,
 
 							for (GIntervals::const_iterator iinterv1 = tgt_intervals[0].begin(); iinterv1 != tgt_intervals[0].end(); ++iinterv1) {
 								for (GIntervals::const_iterator iinterv2 = tgt_intervals[1].begin(); iinterv2 != tgt_intervals[1].end(); ++iinterv2) {
-									int idx = iinterv1->chromid * iu.get_chromkey().get_num_chroms() + iinterv2->chromid;
-									if (!buffered_intervs[idx].opened()) {
+									BufferedIntervals2D &buffered_interv = buffered_intervs[ChromPair(iinterv1->chromid, iinterv2->chromid)];
+									if (!buffered_interv.opened()) {
 										snprintf(filename, sizeof(filename), "%s/_%s-%s", dirname.c_str(), iu.get_chromkey().id2chrom(iinterv1->chromid).c_str(), iu.get_chromkey().id2chrom(iinterv2->chromid).c_str());
-										buffered_intervs[idx].open(filename, "w+", iinterv1->chromid, iinterv2->chromid);
+										buffered_interv.open(filename, "w+", iinterv1->chromid, iinterv2->chromid);
 									}
-									buffered_intervs[idx].write_interval(*iinterv1, *iinterv2, iqtree->v);
+									buffered_interv.write_interval(*iinterv1, *iinterv2, iqtree->v);
 								}
 							}
 							check_interrupt();
@@ -1039,27 +1044,30 @@ SEXP gtrack_liftover(SEXP _track,
 				}
 			}
 
+			progress.report_last();
+
 			// read the temporary files one by one into memory, build the quad tree and save it in corresponding track
-			for (vector<BufferedIntervals2D>::iterator ibuffered_interv = buffered_intervs.begin(); ibuffered_interv != buffered_intervs.end(); ++ibuffered_interv) {
-				if (ibuffered_interv->opened()) {
-					int chromid1 = ibuffered_interv->chromid1();
-					int chromid2 = ibuffered_interv->chromid2();
+			progress.init(buffered_intervs.size(), 1);
+			for (map<ChromPair, BufferedIntervals2D>::iterator ibuffered_interv = buffered_intervs.begin(); ibuffered_interv != buffered_intervs.end(); ++ibuffered_interv) {
+				if (ibuffered_interv->second.opened()) {
+					int chromid1 = ibuffered_interv->second.chromid1();
+					int chromid2 = ibuffered_interv->second.chromid2();
 					RectsQuadTree qtree;
 
 					qtree.reset(0, 0, iu.get_chromkey().get_chrom_size(chromid1), iu.get_chromkey().get_chrom_size(chromid2));
 
-					ibuffered_interv->flush();
-					ibuffered_interv->seek(0, SEEK_SET);
+					ibuffered_interv->second.flush();
+					ibuffered_interv->second.seek(0, SEEK_SET);
 
 					// Collect the mapped rects, then aggregate overlaps into disjoint
 					// rects before inserting (the quadtree forbids overlapping objects).
 					vector<RectVal2D> rects;
-					while (ibuffered_interv->read_interval()) {
-						const GInterval2D &gi = ibuffered_interv->last_interval();
+					while (ibuffered_interv->second.read_interval()) {
+						const GInterval2D &gi = ibuffered_interv->second.last_interval();
 						RectVal2D rv;
 						rv.x1 = gi.start1(); rv.x2 = gi.end1();
 						rv.y1 = gi.start2(); rv.y2 = gi.end2();
-						rv.v = ibuffered_interv->last_val();
+						rv.v = ibuffered_interv->second.last_val();
 						rects.push_back(rv);
 					}
 					aggregate_2d_rects(rects, agg_cfg, qtree);
@@ -1077,10 +1085,10 @@ SEXP gtrack_liftover(SEXP _track,
 			}
 
 			// remove the buffered intervals files
-			for (vector<BufferedIntervals2D>::iterator ibuffered_interv = buffered_intervs.begin(); ibuffered_interv != buffered_intervs.end(); ++ibuffered_interv) {
-				if (ibuffered_interv->opened()) {
-					string filename = ibuffered_interv->file_name();
-					ibuffered_interv->close();
+			for (map<ChromPair, BufferedIntervals2D>::iterator ibuffered_interv = buffered_intervs.begin(); ibuffered_interv != buffered_intervs.end(); ++ibuffered_interv) {
+				if (ibuffered_interv->second.opened()) {
+					string filename = ibuffered_interv->second.file_name();
+					ibuffered_interv->second.close();
 					unlink(filename.c_str());
 				}
 			}

--- a/src/GenomeCisDecay.cpp
+++ b/src/GenomeCisDecay.cpp
@@ -59,13 +59,35 @@ SEXP C_gcis_decay(SEXP _expr, SEXP _breaks, SEXP _src_intervals, SEXP _domain_in
 		unique_ptr<GIntervalsFetcher2D> initial_scope_guard(initial_scope);
 
 		set<ChromPair> chrompairs_mask;
-		GIntervals2D all_genome_intervs2d;
-		iu.get_all_genome_intervs(all_genome_intervs2d);
 
-		// exclude trans chromosomes from scope
-		for (GIntervals2D::const_iterator iinterval = all_genome_intervs2d.begin(); iinterval != all_genome_intervs2d.end(); ++iinterval) {
-			if (iinterval->chromid1() == iinterval->chromid2()) 
-				chrompairs_mask.insert(ChromPair(iinterval->chromid1(), iinterval->chromid2()));
+		// Exclude trans chrom pairs from the scope. The cis pairs come from the scope itself
+		// rather than from the whole-genome 2D intervals set: above gmulticontig.2d.threshold
+		// contigs that set is a deferred placeholder with no rows, which left this mask empty
+		// and reduced the scope to nothing - an all-zero decay curve, or NULL under
+		// multitasking, for a scope the caller passed explicitly. Masking by the scope's own
+		// cis pairs yields the identical masked copy when the whole-genome set is
+		// materialised, since a mask entry for a pair the scope does not hold selects nothing.
+		GIntervals2D *dense_scope = dynamic_cast<GIntervals2D *>(initial_scope);
+
+		if (dense_scope) {
+			// O(n) over the intervals. GIntervals2D::get_next_chroms() would walk (and
+			// build_chrom_map() would allocate) a dense (max chromid + 1)^2 space instead.
+			for (GIntervals2D::const_iterator iinterval = dense_scope->begin(); iinterval != dense_scope->end(); ++iinterval) {
+				if (iinterval->chromid1() == iinterval->chromid2())
+					chrompairs_mask.insert(ChromPair(iinterval->chromid1(), iinterval->chromid2()));
+			}
+		} else {
+			// Sparse walk over the populated pairs, primed with the (0, 0) check because
+			// get_next_chroms() returns the pair *after* the one it is given.
+			int chromid1 = 0;
+			int chromid2 = 0;
+
+			if (initial_scope->size(0, 0))
+				chrompairs_mask.insert(ChromPair(0, 0));
+			while (initial_scope->get_next_chroms(&chromid1, &chromid2)) {
+				if (chromid1 == chromid2 && initial_scope->size(chromid1, chromid2))
+					chrompairs_mask.insert(ChromPair(chromid1, chromid2));
+			}
 		}
 
 		unique_ptr<GIntervalsFetcher2D> scope(initial_scope->create_masked_copy(chrompairs_mask));

--- a/src/GenomeTrackCreateComputer2dTest.cpp
+++ b/src/GenomeTrackCreateComputer2dTest.cpp
@@ -42,8 +42,6 @@ SEXP gcreate_test_computer2d_track(SEXP _track, SEXP _prob_skip_chrom, SEXP _max
 		string dirname = create_track_dir(_envir, track);
 		IntervUtils iu(_envir);
 		char filename[FILENAME_MAX];
-		GIntervals2D all_genome_intervs2d;
-		iu.get_all_genome_intervs(all_genome_intervs2d);
 
 		Progress_reporter progress;
 		progress.init(iu.get_chromkey().get_num_chroms() * iu.get_chromkey().get_num_chroms(), 1);

--- a/src/rdbinterval.cpp
+++ b/src/rdbinterval.cpp
@@ -620,12 +620,31 @@ int IntervUtils::prepare4multitasking(GIntervalsFetcher1D *scope1d, GIntervalsFe
 				((GIntervals2D *)m_kids_intervals2d.back())->push_back(*iinterv);
 			}
 		} else {
-			set<ChromPair> chrompairs_mask;
-			GIntervals2D all_genome;
-			get_all_genome_intervs(all_genome);
+			// The chrom-pair universe must be taken from the scope itself, not from the
+			// whole-genome 2D intervals set: above gmulticontig.2d.threshold contigs that
+			// set is a deferred placeholder with no rows, so this loop never ran, no kid was
+			// planned, and every 2D caller silently returned NULL for a scope it was given
+			// explicitly. Walking the scope's own populated pairs is also what the
+			// partitioner actually needs, and it drops an O(num_chroms^2) walk.
+			// (Same idiom as GenomeTrackQuantiles.cpp "Phase 7b", including the (0,0) prime:
+			// get_next_chroms() returns the pair *after* the one it is given.)
+			vector<ChromPair> scope_chrompairs;
+			{
+				int chromid1 = 0;
+				int chromid2 = 0;
 
-			for (GIntervals2D::const_iterator iinterv = all_genome.begin(); iinterv != all_genome.end(); ++iinterv) {
-				double chrom_surface = scope2d->surface(iinterv->chromid1(), iinterv->chromid2());
+				if (scope2d->size(0, 0))
+					scope_chrompairs.push_back(ChromPair(0, 0));
+				while (scope2d->get_next_chroms(&chromid1, &chromid2)) {
+					if (scope2d->size(chromid1, chromid2))
+						scope_chrompairs.push_back(ChromPair(chromid1, chromid2));
+				}
+			}
+
+			set<ChromPair> chrompairs_mask;
+
+			for (vector<ChromPair>::const_iterator ipair = scope_chrompairs.begin(); ipair != scope_chrompairs.end(); ++ipair) {
+				double chrom_surface = scope2d->surface(ipair->chromid1, ipair->chromid2);
 
 				if (!chrom_surface) 
 					continue;
@@ -645,7 +664,7 @@ int IntervUtils::prepare4multitasking(GIntervalsFetcher1D *scope1d, GIntervalsFe
 
 				kid_surface += chrom_surface;
 				surface -= chrom_surface;
-				chrompairs_mask.insert(ChromPair(iinterv->chromid1(), iinterv->chromid2()));
+				chrompairs_mask.insert(*ipair);
 			}
 
 			if (!chrompairs_mask.empty())

--- a/tests/testthat/test-multicontig-2d-scope.R
+++ b/tests/testthat/test-multicontig-2d-scope.R
@@ -1,0 +1,157 @@
+# Regression tests for the two defects caused by the deferred whole-genome 2D
+# intervals set (.misha$ALLGENOME[[2]]) that gdb.init/gdb.create store above
+# `gmulticontig.2d.threshold` contigs:
+#
+#   * the 2D multitasking partitioner derived the chrom-pair universe from that
+#     set, so with the placeholder it planned zero kids and every 2D entry point
+#     silently returned NULL - even for a scope the caller passed explicitly;
+#   * gtrack.liftover sized its per-chrom-pair buffer vector from that set and
+#     indexed it with chromid1 * num_chroms + chromid2, i.e. wrote out of bounds
+#     of a zero-length vector.
+#
+# Both are driven here by lowering the threshold on a scratch database, so they
+# need no lab-specific >100-contig database.
+
+flat_seq <- function(len = 2000) paste(rep("A", len), collapse = "")
+
+# A database whose contig count exceeds `gmulticontig.2d.threshold`, so that
+# ALLGENOME[[2]] holds the deferred placeholder rather than the N^2 grid.
+scratch_db <- function(chrom_names, len = 2000) {
+    setup_db(lapply(chrom_names, function(nm) sprintf(">%s\n%s\n", nm, flat_seq(len))),
+        return_db = TRUE
+    )
+}
+
+test_that("2D queries with an explicit 2D scope agree with and without multitasking on a deferred-2D database", {
+    local_db_state()
+    withr::local_options(list(gmulticontig.2d.threshold = 2))
+
+    chroms <- c("chrMT1", "chrMT2", "chrMT3")
+    scratch_db(chroms)
+
+    # The database is above the threshold: the whole-genome 2D set is deferred.
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 0)
+    expect_gt(nrow(.misha$ALLGENOME[[1]]), 2)
+
+    pairs <- expand.grid(chrom1 = chroms, chrom2 = chroms, stringsAsFactors = FALSE)
+    intervs <- data.frame(
+        chrom1 = pairs$chrom1, start1 = 100, end1 = 900,
+        chrom2 = pairs$chrom2, start2 = 100, end2 = 900,
+        stringsAsFactors = FALSE
+    )
+    gtrack.2d.create("mt2d", "2D track over every chrom pair", intervs, seq_len(nrow(intervs)))
+    withr::defer(if (gtrack.exists("mt2d")) gtrack.rm("mt2d", force = TRUE))
+
+    single <- withr::with_options(list(gmultitasking = FALSE), gextract("mt2d", intervals = "mt2d"))
+    multi <- withr::with_options(list(gmultitasking = TRUE), gextract("mt2d", intervals = "mt2d"))
+
+    expect_equal(nrow(single), nrow(intervs))
+    expect_false(is.null(multi)) # returned NULL before the fix
+    expect_equal(nrow(multi), nrow(single))
+    expect_equal(sort(multi$mt2d), sort(single$mt2d))
+
+    summary_single <- withr::with_options(list(gmultitasking = FALSE), gsummary("mt2d", intervals = "mt2d"))
+    summary_multi <- withr::with_options(list(gmultitasking = TRUE), gsummary("mt2d", intervals = "mt2d"))
+    expect_false(is.null(summary_multi))
+    expect_equal(as.numeric(summary_multi), as.numeric(summary_single))
+})
+
+test_that("a 2D scope covering only some chrom pairs is partitioned correctly on a deferred-2D database", {
+    local_db_state()
+    withr::local_options(list(gmulticontig.2d.threshold = 2))
+
+    chroms <- c("chrMS1", "chrMS2", "chrMS3", "chrMS4")
+    scratch_db(chroms)
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 0)
+
+    # Only 3 of the 16 chrom pairs are populated, including a trans pair.
+    intervs <- data.frame(
+        chrom1 = c("chrMS1", "chrMS2", "chrMS4"),
+        start1 = c(100, 100, 100), end1 = c(900, 900, 900),
+        chrom2 = c("chrMS1", "chrMS3", "chrMS4"),
+        start2 = c(100, 100, 100), end2 = c(900, 900, 900),
+        stringsAsFactors = FALSE
+    )
+    gtrack.2d.create("mt2d_sparse", "sparse 2D track", intervs, c(7, 8, 9))
+    withr::defer(if (gtrack.exists("mt2d_sparse")) gtrack.rm("mt2d_sparse", force = TRUE))
+
+    multi <- withr::with_options(list(gmultitasking = TRUE), gextract("mt2d_sparse", intervals = "mt2d_sparse"))
+    expect_false(is.null(multi))
+    expect_equal(nrow(multi), 3)
+    expect_equal(sort(multi$mt2d_sparse), c(7, 8, 9))
+    # the trans pair must survive the partitioning
+    expect_true(any(as.character(multi$chrom1) == "chrMS2" & as.character(multi$chrom2) == "chrMS3"))
+})
+
+# ---------------------------------------------------------------------------
+# gtrack.liftover of a 2D track into a target database above the threshold
+# ---------------------------------------------------------------------------
+
+# Lift a fixed 3-rectangle 2D track from a 2-contig source database into a
+# 3-contig target database, and return the lifted rectangles. `threshold`
+# decides whether the target's whole-genome 2D set is deferred or materialised.
+lift_2d_track <- function(tag, threshold) {
+    withr::local_options(list(gmulticontig.2d.threshold = threshold), .local_envir = parent.frame())
+
+    src_chroms <- paste0("chrS", tag, 1:2)
+    src_db <- setup_db(lapply(src_chroms, function(nm) sprintf(">%s\n%s\n", nm, flat_seq())), return_db = TRUE)
+
+    src_intervs <- data.frame(
+        chrom1 = c(src_chroms[1], src_chroms[1], src_chroms[2]),
+        start1 = c(100, 600, 100), end1 = c(300, 800, 300),
+        chrom2 = c(src_chroms[1], src_chroms[2], src_chroms[2]),
+        start2 = c(100, 600, 100), end2 = c(300, 800, 300),
+        stringsAsFactors = FALSE
+    )
+    src_track <- paste0("src2d_", tag)
+    gtrack.2d.create(src_track, "source 2D track", src_intervs, c(10, 20, 30))
+    src_track_dir <- file.path(src_db, "tracks", paste0(src_track, ".track"))
+
+    tgt_chroms <- paste0("chrT", tag, 1:3)
+    chain <- new_chain_file()
+    write_chain_entry(chain, src_chroms[1], 2000, "+", 0, 2000, tgt_chroms[1], 2000, "+", 0, 2000, 1)
+    write_chain_entry(chain, src_chroms[2], 2000, "+", 0, 2000, tgt_chroms[2], 2000, "+", 0, 2000, 2)
+
+    scratch_db(tgt_chroms)
+
+    lifted <- paste0("lifted2d_", tag)
+    gtrack.liftover(lifted, "lifted 2D track", src_track_dir, chain)
+
+    scope <- gintervals.2d(
+        chroms1 = c(tgt_chroms[1], tgt_chroms[1], tgt_chroms[2]), starts1 = 0, ends1 = 2000,
+        chroms2 = c(tgt_chroms[1], tgt_chroms[2], tgt_chroms[2]), starts2 = 0, ends2 = 2000
+    )
+    res <- gextract(lifted, scope)
+    res <- res[order(as.character(res$chrom1), as.character(res$chrom2), res$start1, res$start2), ]
+    list(res = res, values = res[[lifted]], chroms = tgt_chroms)
+}
+
+test_that("gtrack.liftover of a 2D track into a deferred-2D target database writes the right rectangles", {
+    local_db_state()
+
+    # Before the fix this wrote through buffered_intervs[chromid1 * num_chroms +
+    # chromid2] on a zero-length vector (SIGSEGV in this configuration).
+    out <- lift_2d_track("A", threshold = 2)
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 0)
+
+    expect_equal(nrow(out$res), 3)
+    expect_equal(out$values, c(10, 20, 30))
+    expect_equal(as.character(out$res$chrom1), out$chroms[c(1, 1, 2)])
+    expect_equal(as.character(out$res$chrom2), out$chroms[c(1, 2, 2)])
+    expect_equal(out$res$start1, c(100, 600, 100))
+    expect_equal(out$res$end1, c(300, 800, 300))
+    expect_equal(out$res$start2, c(100, 600, 100))
+    expect_equal(out$res$end2, c(300, 800, 300))
+})
+
+test_that("gtrack.liftover of a 2D track is unchanged when the whole-genome 2D grid is materialised", {
+    local_db_state()
+
+    out <- lift_2d_track("B", threshold = 1000)
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 9) # 3 contigs, materialised grid
+
+    expect_equal(nrow(out$res), 3)
+    expect_equal(out$values, c(10, 20, 30))
+    expect_equal(as.character(out$res$chrom1), out$chroms[c(1, 1, 2)])
+    expect_equal(as.character(out$res$chrom2), out$chroms[c(1, 2, 2)])
+})

--- a/tests/testthat/test-multicontig-2d-scope.R
+++ b/tests/testthat/test-multicontig-2d-scope.R
@@ -155,3 +155,79 @@ test_that("gtrack.liftover of a 2D track is unchanged when the whole-genome 2D g
     expect_equal(as.character(out$res$chrom1), out$chroms[c(1, 1, 2)])
     expect_equal(as.character(out$res$chrom2), out$chroms[c(1, 2, 2)])
 })
+
+# ---------------------------------------------------------------------------
+# gcis_decay masks the trans chrom pairs out of its scope
+# ---------------------------------------------------------------------------
+
+# Build a database of three contigs, each carrying one contact at distance ~300
+# and one at distance ~700, plus one trans contact that the cis mask must drop.
+# `threshold` decides whether the whole-genome 2D set is deferred or materialised.
+setup_cis_decay_db <- function(tag, threshold) {
+    withr::local_options(list(gmulticontig.2d.threshold = threshold), .local_envir = parent.frame())
+
+    chroms <- paste0("chrC", tag, 1:3)
+    scratch_db(chroms)
+
+    cis <- do.call(rbind, lapply(chroms, function(nm) {
+        data.frame(
+            chrom1 = nm, start1 = c(0, 0), end1 = c(100, 100),
+            chrom2 = nm, start2 = c(300, 700), end2 = c(400, 800),
+            stringsAsFactors = FALSE
+        )
+    }))
+    trans <- data.frame(
+        chrom1 = chroms[1], start1 = 0, end1 = 100,
+        chrom2 = chroms[2], start2 = 300, end2 = 400,
+        stringsAsFactors = FALSE
+    )
+    intervs <- rbind(cis, trans)
+    gtrack.2d.create("cis2d", "cis decay test track", intervs, rep(1, nrow(intervs)))
+
+    list(
+        chroms = chroms,
+        anchors = gintervals(chroms, 0, 2000),
+        scope = gintervals.2d(
+            chroms1 = chroms, starts1 = 0, ends1 = 2000,
+            chroms2 = chroms, starts2 = 0, ends2 = 2000
+        )
+    )
+}
+
+cis_decay_counts <- function(db, scope, multitasking) {
+    res <- withr::with_options(
+        list(gmultitasking = multitasking),
+        gcis_decay("cis2d", c(0, 500, 1000), db$anchors, db$anchors, intervals = scope)
+    )
+    as.vector(res)
+}
+
+test_that("gcis_decay is correct on a deferred-2D database, with either scope kind and either multitasking setting", {
+    local_db_state()
+
+    db <- setup_cis_decay_db("A", threshold = 2)
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 0)
+
+    # dense in-memory 2D scope, and the same scope as a 2D track (a non-dense
+    # fetcher, which takes the sparse chrom-pair walk)
+    for (scope in list(db$scope, "cis2d")) {
+        for (multitasking in c(FALSE, TRUE)) {
+            # 3 cis contacts per distance bin; the trans contact must not be counted
+            expect_equal(cis_decay_counts(db, scope, multitasking), c(3, 3, 0, 0))
+        }
+    }
+})
+
+test_that("gcis_decay on a deferred-2D database agrees with a materialised whole-genome 2D grid", {
+    local_db_state()
+
+    materialised <- setup_cis_decay_db("B", threshold = 1000)
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 9)
+    reference <- cis_decay_counts(materialised, materialised$scope, FALSE)
+    expect_equal(reference, c(3, 3, 0, 0))
+
+    deferred <- setup_cis_decay_db("C", threshold = 2)
+    expect_equal(NROW(.misha$ALLGENOME[[2]]), 0)
+    expect_equal(cis_decay_counts(deferred, deferred$scope, FALSE), reference)
+    expect_equal(cis_decay_counts(deferred, "cis2d", TRUE), reference)
+})


### PR DESCRIPTION
Three defects that are present in every released misha, all on databases with more than
`getOption("gmulticontig.2d.threshold", 100)` contigs - which includes hg38 with scaffolds.
All three share one root cause: code that derives a per-chromosome-pair structure from the
*whole-genome* 2D interval list, which above that threshold is a deferred placeholder and
therefore empty.

### 1. `gtrack.liftover` of a 2D track writes out of bounds

`GTrackLiftover.cpp` sized `buffered_intervs` from the whole-genome 2D list but indexed it
at `chromid1 * num_chroms + chromid2`, so above the threshold every access ran off a
zero-length vector - crashing R or corrupting the track being written. Replaced the `N^2`
vector with a sparse `map<ChromPair, BufferedIntervals2D>`.

The reviewer reproduced the crash by reverting only this file (`R is aborting now`), and
verified that below the threshold the new code is output-equivalent to the old: identical
`gextract` rows including a 1-to-4 chain fan-out, identical track file set, identical file
sizes, identical `gsummary`.

### 2. An explicit 2D scope returned `NULL` under multitasking

`rdbinterval.cpp`'s 2D partitioner enumerated chromosome pairs from the whole-genome list,
so with multitasking on it found none and every 2D entry point returned `NULL` - `gextract`,
`gsummary`, `gquantiles`, `gdist`, `gcor`, `gscreen`, `gintervals.mapply`. Now walks the
scope's own pairs via `get_next_chroms`.

### 3. `gcis_decay` returned an all-zero curve

`GenomeCisDecay.cpp` built its cis mask from the same whole-genome list: all-zero serially,
`NULL` under multitasking. Now masks from the scope's own pairs. Verified byte-identical to
master's below-threshold ground truth across a 20-cell matrix of scope shapes, with trans
exclusion preserved; the same matrix on master above the threshold is `0,0,0,0` everywhere.

### Scope

Stages 1-2 of `dev/notes/2026-08-16_deferred-2d-allgenome-design.md` only. No changes under
`R/`, `man/` or `NAMESPACE` - the placeholder itself, the `gmulticontig.2d.*` options and
`gintervals.2d.all()` are untouched and stay for stages 3-5.

### Tests

New `test-multicontig-2d-scope.R` (37 assertions) drives the >100-contig condition with a
lowered threshold rather than depending on hg38. Reverting either fix makes it fail - the
liftover revert aborts R, the partitioner revert produces 7 failures. Ten 2D-related test
files green on the final tree.

### Known follow-ups, not from this diff

- 2D liftover writes 4 uninitialised bytes per record (`RectsQuadTree::ValueType` leaves
  `udata` unset), so its output is not byte-reproducible. Pre-existing; the same master
  build differs from itself run to run.
- The POINTS liftover branch got the same edit but has no test - nothing in the repo creates
  a 2D points track.
